### PR TITLE
fix meeting url - remove &

### DIFF
--- a/lma-browser-extension-stack/src/components/screens/Capture.tsx
+++ b/lma-browser-extension-stack/src/components/screens/Capture.tsx
@@ -56,7 +56,7 @@ function Capture() {
 
   const startListening = useCallback(() => {
     // eslint-disable-next-line no-useless-escape
-    setTopic(topic.replace(/[\/?#%\+]/g, '|'));
+    setTopic(topic.replace(/[\/?#%\+&]/g, '|'));
 
     if (validateForm() === false) {
       return;


### PR DESCRIPTION
*Issue #, if available:*
#9 Open in LMA" button does not open the meeting details page in LMA 

*Description of changes:*
Replaced & with | and tested the changes. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
