### PR TITLE
downsize ecs-fargate task

### DIFF
--- a/lma-websocket-stack/deployment/lca-websocket.yaml
+++ b/lma-websocket-stack/deployment/lca-websocket.yaml
@@ -1200,10 +1200,10 @@ Resources:
           PortMappings:
             - ContainerPort: 8080
               Protocol: tcp
-      Cpu: 2048
+      Cpu: 256
       ExecutionRoleArn: !GetAtt TranscriberWebsocketTaskDefExecutionRole.Arn
       Family: !Sub ${AWS::StackName}TranscriberWebsocketTaskDef
-      Memory: 4096
+      Memory: 1024
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - FARGATE


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Downsized Websocket fargate-ecs-task from (2vCPU, 4GB) to (0.25vCPU, 1GB) based on CPU and Memory utilization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
