### PR TITLE
(1) Add BEDROCK_LLM option, and make knowledge base optional.  (2) Fix Stack name too long issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix for #1 - "Stream Audio" tab stops working after a stack update when AssistantWakePhraseRegEx is modified. PR #11
 ### Changed
 - Downsize web socket server ecs-fargate task for improved cost efficiency. PR #12
+### Added
+- New MeetingAssistService option to allow Bedrock (without KB) to be used for 'OK Assistant' and 'Ask Assistant' responses.
+ 
 
 
 ## [0.1.1] - 2024-04-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.1.2] - TBD
+### Added
+- New MeetingAssistService option to allow Bedrock LLM (without knowledge bases) to be used for 'OK Assistant' and 'Ask Assistant' responses.
 ### Fixed
 - Added `&` to the previous defense against Meeting Names / IDs with special characters that are not URL safe, by replacing with pipe character `|` in the browser extension when starting the streaming. PR #10
 - Fix for #1 - "Stream Audio" tab stops working after a stack update when AssistantWakePhraseRegEx is modified. PR #11
+- Fix for #13 - Longer CloudFormation stack names cause errors in length of Lambda function names.
 ### Changed
 - Downsize web socket server ecs-fargate task for improved cost efficiency. PR #12
-### Added
-- New MeetingAssistService option to allow Bedrock (without KB) to be used for 'OK Assistant' and 'Ask Assistant' responses.
+
  
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `&` to the previous defense against Meeting Names / IDs with special characters that are not URL safe, by replacing with pipe character `|` in the browser extension when starting the streaming. PR #10
 - Fix for #1 - "Stream Audio" tab stops working after a stack update when AssistantWakePhraseRegEx is modified. PR #11
 - Fix for #13 - Longer CloudFormation stack names cause errors in length of Lambda function names.
+- Fix for #3 - Add a CloudFormation rule to require `BedrockKnowledgeBaseId` parameter to be provided when BEDROCK_KNOWLEDGE_BASE is chosen as the meeting assistant service.  
 ### Changed
 - Downsize web socket server ecs-fargate task for improved cost efficiency. PR #12
 
  
-
-
 ## [0.1.1] - 2024-04-19
 ### Fixed
 - Added defense against Meeting Names / IDs with special characters `/?#%+` that are not URL safe, by replacing with pipe character `|` in the browser extension when starting the streaming.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following are some of the things LMA can do:
    <p align="left"><img src="./images/readme-transcription.png" alt="Transcription" /></p>
 - **Live translation** - It uses Amazon Translate to optionally show each segment of the conversation translated into your language of choice, from a selection of 75 languages.
   <p align="left"><img src="./images/readme-translation.png" alt="Translation" width=400/></p>
-- **Context aware meeting assistant** - It uses Knowledge Bases for Amazon Bedrock to provide answers from your trusted sources, using the live transcript as context for fact-checking and follow-up questions. To activate the assistant, just say “*Okay, Assistant*,” choose the **ASK ASSISTANT!** button, or enter your own question in the UI.
+- **Context aware meeting assistant** - It uses Knowledge Bases for Amazon Bedrock to provide answers from your trusted sources, or a Bedrock LLM if you don't have or need a knowledge base, using the live transcript as context for fact-checking and follow-up questions. To activate the assistant, just say “*Okay, Assistant*,” choose the **ASK ASSISTANT!** button, or enter your own question in the UI.
   <p align="left"><img src="./images/readme-OK-Assistant.png" alt="OK Q" width=400/></p>
 - **On demand summaries of the meeting** - With the click of a button on the UI, you can generate a summary, which is useful when someone joins late and needs to get caught up. The summaries are generated from the transcript by Amazon Bedrock. LMA also provides options for identifying the current meeting topic, and for generating a list of action items with owners and due dates. You can also create your own custom prompts and corresponding options.
   <p align="left"><img src="./images/readme-action-items.png" alt="Action Items" /></p>
@@ -49,9 +49,9 @@ You are responsible for complying with legal, corporate, and ethical restriction
 
 You need to have an AWS account and an [AWS Identity and Access Management](https://aws.amazon.com/iam/) (IAM) role and user with permissions to create and manage the necessary resources and components for this application. If you don’t have an AWS account, see [How do I create and activate a new Amazon Web Services account?](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/)
 
-You also need to have an existing, working, Knowledge Base of Amazon Bedrock. If you haven’t set one up yet, see [Create a knowledge base](https://docs.aws.amazon.com/bedrock/latest/userguide/knowledge-base-create.html). Populate your knowledge base with content to power LMA’s context aware meeting assistant. 
+If you want LMA to use your own trusted documents, then you also need to have an existing, working, Knowledge Base of Amazon Bedrock. If you haven’t set one up yet, see [Create a knowledge base](https://docs.aws.amazon.com/bedrock/latest/userguide/knowledge-base-create.html). Populate your knowledge base with content to power LMA’s context aware meeting assistant.  Otherwise, you can use LMA without a knowledge base, and take live meeting advice directly from the selected Bedrock LLM model.  
 
-Finally, LMA uses Amazon Bedrock LLM models for its meeting summarization features. Before proceeding, if you have not previously done so, you must [request access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html) to the following Amazon Bedrock models:
+Finally, LMA uses Amazon Bedrock LLM models for its live meeting assistant and meeting summarization features. Before proceeding, if you have not previously done so, you must [request access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html) to the following Amazon Bedrock models:
 - Titan Embeddings G1 – Text
 - Anthropic:  All Claude models
 
@@ -76,8 +76,8 @@ Complete the following steps to launch the CloudFormation stack:
 1. For **Stack name**, use the default value, `LMA`.
 1. For **Admin Email Address**, use a valid email address—your temporary password is emailed to this address during the deployment.
 1. For **Authorized Account Email Domain**, use the domain name part of your corporate email address to allow users with email addresses in the same domain to create their own new UI accounts, or leave blank to prevent users from directly creating their own accounts. You can enter multiple domains as a comma separated list.
-1. For **MeetingAssistService** choose BEDROCK_KNOWLEDGE_BASE (currently the only available option!)  
-1. For **Meeting Assist Bedrock Knowledge Base Id (existing)**, enter your existing Knowledge base ID (for example, JSXXXXX3D8). You can copy it from the Amazon Bedrock Knowledge bases console.
+1. For **MeetingAssistService** choose BEDROCK_KNOWLEDGE_BASE (preferred) or BEDROCK_LLM (if you do not need a knowledge base)  
+1. For **Meeting Assist Bedrock Knowledge Base Id (existing)**, leave it blank if you selected BEDROCK_LLM in the previous step, otherwise enter your existing Knowledge base ID (for example, JSXXXXX3D8). You can copy it from the Amazon Bedrock Knowledge bases console.
     <p align="left"><img src="./images/readme-knowledgebase-id.png" alt="KB ID" width=350/></p>
 1. For **all other parameters**, use the default values. If you want to customize the settings later, for example to add your own lambda functions, to use  custom vocabularies and language models to improve accuracy, enable PII redaction, and more, you can update the stack for these parameters.
 1. Check the acknowledgement boxes, and choose Create stack.
@@ -175,7 +175,7 @@ We show you how to use both options in the following sections.
    <img src="./images/readme-browser-extension-listening.png" alt="Browser Extension Listening" width="500"/>
  
 1. Choose **Open in LMA** to see your live transcript in a new tab.  
-1. Choose your preferred transcript language, and interact with the meeting assistant using the wake phrase *"OK Assistant!"* or the **Meeting Assist Bot** pane on the right. The **ASK ASSISTANT** button is fun to try – it asks the meeting assistant service (Bedrock knowledge base) to suggest a ‘good response’ based on the transcript of the recent interactions in the meeting. Your mileage may vary, so experiment!
+1. Choose your preferred transcript language, and interact with the meeting assistant using the wake phrase *"OK Assistant!"* or the **Meeting Assist Bot** pane on the right. The **ASK ASSISTANT** button is fun to try – it asks the meeting assistant service (Bedrock knowledge base or Bedrock LLM) to suggest a ‘good response’ based on the transcript of the recent interactions in the meeting. Your mileage may vary, so experiment!
 
    <img src="./images/readme-lma-meeting-detail.png" alt="Meeting Detail page" width="500"/>
 
@@ -251,9 +251,10 @@ For QnABot on AWS for Meeting Assist, refer to the [Meeting Assist README](./lma
 
 ## Cost assessment
 
-LMA provides a websocket server using Fargate (2vCPU) and VPC networking resources costing about $0.10/hr (~$72/mth) - see [Fargate pricing](https://aws.amazon.com/fargate/pricing/).
+LMA provides a websocket server using Fargate (0.25vCPU) and VPC networking resources costing about $0.014/hr (~$10/mth) - see [Fargate pricing](https://aws.amazon.com/fargate/pricing/).
 
-Meeting Assist is enabled using QnABot and Knowledge bases for Amazon Bedrock. You create your own Knowledge base which you use for LMA and potentially other use cases – see [Amazon Bedrock pricing](https://aws.amazon.com/bedrock/pricing/) for more. Additional AWS services used by the QnABot solution cost about $0.77/hour – see [QnABot on AWS solution costs](https://docs.aws.amazon.com/solutions/latest/qnabot-on-aws/cost.html). 
+Meeting Assist is enabled using QnABot and Knowledge bases for Amazon Bedrock. You create your own Knowledge base which you use for LMA and potentially other use cases – see [Amazon Bedrock pricing](https://aws.amazon.com/bedrock/pricing/) for more, or you can choose, when you deploy, to use a Bedrock LLM without a knowledge base.
+Additional AWS services used by the QnABot solution as configured (with Opensearch node count default of '1') cost about $0.14/hour ($100/mth) – see [QnABot on AWS solution costs](https://docs.aws.amazon.com/solutions/latest/qnabot-on-aws/cost.html). 
 
 The remaining solution costs are based on usage.
 

--- a/lma-main.yaml
+++ b/lma-main.yaml
@@ -592,9 +592,12 @@ Resources:
       EMBEDDINGS_SCORE_ANSWER_THRESHOLD: !GetAtt QNABOTBR.Outputs.QnABotSettingEmbeddingsScoreAnswerThreshold
       EMBEDDINGS_TEXT_PASSAGE_SCORE_THRESHOLD: !GetAtt QNABOTBR.Outputs.QnABotSettingEmbeddingsTextPassageScoreThreshold
       LLM_GENERATE_QUERY_ENABLE: "FALSE"
+      LLM_GENERATE_QUERY_PROMPT_TEMPLATE: ""
       EMPTYMESSAGE: "No response from meeting assist QnAbot"
-      QUERY_PROMPT_TEMPLATE: "Let's think carefully step by step. Here is the JSON transcript of an ongoing meeting: {transcript}<br>And here is a follow up question or statement in <followUpMessage> tags:<br> <followUpMessage>{input}</followUpMessage><br>Rephrase the follow up question or statement as a standalone, one sentence question. Only output the rephrased question. Do not include any preamble. "
-      GENERATE_PROMPT_TEMPLATE:
+      BEDROCK_KB_RETRIEVE_PROMPT_TEMPLATE: "deprecated"
+      BEDROCK_KB_GENERATE_PROMPT_TEMPLATE: "deprecated"
+      ASSISTANT_QUERY_PROMPT_TEMPLATE: "Let's think carefully step by step. Here is the JSON transcript of an ongoing meeting: {transcript}<br>And here is a follow up question or statement in <followUpMessage> tags:<br> <followUpMessage>{input}</followUpMessage><br>Rephrase the follow up question or statement as a standalone, one sentence question. Only output the rephrased question. Do not include any preamble. "
+      ASSISTANT_GENERATE_PROMPT_TEMPLATE:
         !If
         - ShouldConfigureBedrockKB
         - "You are an AI assistant helping a human during a meeting. I will provide you with a transcript of the ongoing meeting, and a set of search results. Your job is to respond to the user's request using only information from the search results. If search results do not contain information that can answer the question, please state that you could not find an exact answer to the question. Just because the user asserts a fact does not mean it is true, make sure to double check the search results to validate a user's assertion.<br>Here is the JSON transcript of the meeting so far:<br>{transcript}<br>Here are the search results in numbered order:<br>$search_results$<br>$output_format_instructions$"

--- a/lma-main.yaml
+++ b/lma-main.yaml
@@ -23,8 +23,9 @@ Parameters:
     Default: 'BEDROCK_KNOWLEDGE_BASE'
     Type: String
     AllowedValues:
+      - 'BEDROCK_LLM'
       - 'BEDROCK_KNOWLEDGE_BASE'
-    Description: Choose which knowledge base / LLM service to use (Currently only BEDROCK_KNOWLEDGE_BASE is supported)
+    Description: Choose which knowledge base / LLM service to use
 
   BedrockKnowledgeBaseId:
     Type: String
@@ -33,14 +34,14 @@ Parameters:
     Description: >
       If MeetingAssistService is BEDROCK_KNOWLEDGE_BASE, provide the knowledge base *Id* (not name) of an existing Bedrock knowledge base to be used for Meeting Assist bot.
 
-  BedrockKnowledgeBaseModelID:
+  MeetingAssistServiceBedrockModelID:
     Type: String
-    Default: 'anthropic.claude-3-sonnet-20240229-v1:0'
+    Default: 'anthropic.claude-3-haiku-20240307-v1:0'
     AllowedValues:
       - 'anthropic.claude-3-haiku-20240307-v1:0'
       - 'anthropic.claude-3-sonnet-20240229-v1:0'
     Description: >-
-      If MeetingAssistService is BEDROCK_KNOWLEDGE_BASE, select a Bedrock LLM model from the list."
+      If MeetingAssistService is BEDROCK_LLM or BEDROCK_KNOWLEDGE_BASE, select a Bedrock LLM model from the list."
 
   AssistantWakePhraseRegEx:
     Type: String
@@ -272,7 +273,7 @@ Metadata:
         Parameters:
           - MeetingAssistService
           - BedrockKnowledgeBaseId
-          - BedrockKnowledgeBaseModelID
+          - MeetingAssistServiceBedrockModelID
           - AssistantWakePhraseRegEx
           - MeetingAssistQnABotOpenSearchNodeCount
       - Label:
@@ -330,6 +331,8 @@ Metadata:
         default: Authorized Account Email Domain(s)
       BedrockKnowledgeBaseId:
         default: Meeting Assist Bedrock Knowledge Base Id (existing)
+      MeetingAssistServiceBedrockModelID:
+        default: Meeting Assist Service Bedrock Model ID
       AssistantWakePhraseRegEx:
         default: Meeting Assist Wake Phrase Regular Expression
       MeetingAssistQnABotOpenSearchNodeCount:
@@ -422,6 +425,21 @@ Mappings:
     zh-CN:
       Value: zh_CH
 
+Rules:
+  # check required parameters
+  BedrockKnowledgeBaseId:
+    RuleCondition:
+      !Equals [
+        !Ref MeetingAssistService,
+        'BEDROCK_KNOWLEDGE_BASE',
+      ]
+    Assertions:
+      - Assert: !Not [!Equals [!Ref BedrockKnowledgeBaseId, '']]
+        AssertDescription: BedrockKnowledgeBaseId is required when MeetingAssistService is 'BEDROCK_KNOWLEDGE_BASE'
+
+Conditions:
+  ShouldConfigureBedrockKB: !Equals [!Ref MeetingAssistService, 'BEDROCK_KNOWLEDGE_BASE']
+
 Resources:
   # Custom resource to enforce max length of StackName - prevent downstream failures
   StacknameCheckFunction:
@@ -492,7 +510,7 @@ Resources:
           - id: W92
             reason: Customer can choose reserved concurrency based on their requirement.
 
-  QNABOTPLUGINBEDROCK:
+  QNABOTBR:
     Type: AWS::CloudFormation::Stack
     DependsOn: IsStacknameLengthOK
     Properties:
@@ -524,10 +542,10 @@ Resources:
         BootstrapPrefix: <ARTIFACT_PREFIX_TOKEN>/aws-qnabot
         InstallLexResponseBots: 'false'
         EmbeddingsApi: 'LAMBDA'
-        EmbeddingsLambdaArn: !GetAtt QNABOTPLUGINBEDROCK.Outputs.EmbeddingsLambdaArn
-        EmbeddingsLambdaDimensions: !GetAtt QNABOTPLUGINBEDROCK.Outputs.EmbeddingsLambdaDimensions
+        EmbeddingsLambdaArn: !GetAtt QNABOTBR.Outputs.EmbeddingsLambdaArn
+        EmbeddingsLambdaDimensions: !GetAtt QNABOTBR.Outputs.EmbeddingsLambdaDimensions
         LLMApi: 'LAMBDA'
-        LLMLambdaArn: !GetAtt QNABOTPLUGINBEDROCK.Outputs.LLMLambdaArn
+        LLMLambdaArn: !GetAtt QNABOTBR.Outputs.LLMLambdaArn
 
   LLMTEMPLATESTACK:
     Type: AWS::CloudFormation::Stack
@@ -570,13 +588,17 @@ Resources:
     Type: Custom::ToJSON
     Properties:
       ServiceToken: !GetAtt ToJSONFunction.Arn
-      EMBEDDINGS_SCORE_THRESHOLD: !GetAtt QNABOTPLUGINBEDROCK.Outputs.QnABotSettingEmbeddingsScoreThreshold
-      EMBEDDINGS_SCORE_ANSWER_THRESHOLD: !GetAtt QNABOTPLUGINBEDROCK.Outputs.QnABotSettingEmbeddingsScoreAnswerThreshold
-      EMBEDDINGS_TEXT_PASSAGE_SCORE_THRESHOLD: !GetAtt QNABOTPLUGINBEDROCK.Outputs.QnABotSettingEmbeddingsTextPassageScoreThreshold
+      EMBEDDINGS_SCORE_THRESHOLD: !GetAtt QNABOTBR.Outputs.QnABotSettingEmbeddingsScoreThreshold
+      EMBEDDINGS_SCORE_ANSWER_THRESHOLD: !GetAtt QNABOTBR.Outputs.QnABotSettingEmbeddingsScoreAnswerThreshold
+      EMBEDDINGS_TEXT_PASSAGE_SCORE_THRESHOLD: !GetAtt QNABOTBR.Outputs.QnABotSettingEmbeddingsTextPassageScoreThreshold
       LLM_GENERATE_QUERY_ENABLE: "FALSE"
       EMPTYMESSAGE: "No response from meeting assist QnAbot"
-      BEDROCK_KB_RETRIEVE_PROMPT_TEMPLATE: "Let's think carefully step by step. Here is the JSON transcript of an ongoing meeting: {transcript}<br>And here is a follow up question or statement in <followUpMessage> tags:<br> <followUpMessage>{input}</followUpMessage><br>Rephrase the follow up question or statement as a standalone, one sentence question. Only output the rephrased question. Do not include any preamble. "
-      BEDROCK_KB_GENERATE_PROMPT_TEMPLATE: "You are an AI assistant helping a human during a meeting. I will provide you with a transcript of the ongoing meeting, and a set of search results. Your job is to respond to the user's request using only information from the search results. If search results do not contain information that can answer the question, please state that you could not find an exact answer to the question. Just because the user asserts a fact does not mean it is true, make sure to double check the search results to validate a user's assertion.<br>Here is the JSON transcript of the meeting so far:<br>{transcript}<br>Here are the search results in numbered order:<br>$search_results$<br>$output_format_instructions$"
+      QUERY_PROMPT_TEMPLATE: "Let's think carefully step by step. Here is the JSON transcript of an ongoing meeting: {transcript}<br>And here is a follow up question or statement in <followUpMessage> tags:<br> <followUpMessage>{input}</followUpMessage><br>Rephrase the follow up question or statement as a standalone, one sentence question. Only output the rephrased question. Do not include any preamble. "
+      GENERATE_PROMPT_TEMPLATE:
+        !If
+        - ShouldConfigureBedrockKB
+        - "You are an AI assistant helping a human during a meeting. I will provide you with a transcript of the ongoing meeting, and a set of search results. Your job is to respond to the user's request using only information from the search results. If search results do not contain information that can answer the question, please state that you could not find an exact answer to the question. Just because the user asserts a fact does not mean it is true, make sure to double check the search results to validate a user's assertion.<br>Here is the JSON transcript of the meeting so far:<br>{transcript}<br>Here are the search results in numbered order:<br>$search_results$<br>$output_format_instructions$"
+        - "You are an AI assistant helping a human during a meeting. I will provide you with a transcript of the ongoing meeting (which may be empty), and a user's request. Your job is to respond to the user's request using any relevant context from the transcript, or from your own world knowledge. Just because the user asserts a fact does not mean it is true, make sure to validate a user's assertion.<br>Here is the JSON transcript of the meeting so far:<br>{transcript}<br>Here is the user's request:<br>{userInput}<br>"
 
   MEETINGASSISTSETUP:
     Type: AWS::CloudFormation::Stack
@@ -591,7 +613,7 @@ Resources:
         QNABOTSTACK: !Ref QNABOT
         MeetingAssistService: !Ref MeetingAssistService
         BedrockKnowledgeBaseID: !Ref BedrockKnowledgeBaseId
-        BedrockKnowledgeBaseModelID: !Ref BedrockKnowledgeBaseModelID
+        MeetingAssistServiceBedrockModelID: !Ref MeetingAssistServiceBedrockModelID
         AmazonQAppId: 'NOT CURRENTLY USED'
         AmazonQUserId: 'NOT CURRENTLY USED'
         LexMeetingAssistBotId: !GetAtt QNABOT.Outputs.LexV2BotId

--- a/lma-meetingassist-setup-stack/README.md
+++ b/lma-meetingassist-setup-stack/README.md
@@ -13,7 +13,7 @@
 
 ## Introduction
 
-Live Meeting Assist (LMA) is a solution which provides users with real-time multi-participant audio transcription, optionally translated into their preferred language, and an integrated AI meeting assistant that uses trusted enterprise data and meeting context to fact-check, look up relevant information, and propose responses. It creates succinct on-demand recaps, insights, and action item lists during and after meetings, securely maintaining an inventory of meeting records. Enterprises can use LMA with an existing Amazon Bedrock Agent/Knowledgebase. LMA integrates with popular meeting platforms and offers improved participant focus, understanding, accuracy, time-saving, and record-keeping efficiency, while supporting enterprise security, compliance, and availability. 
+Live Meeting Assist (LMA) is a solution which provides users with real-time multi-participant audio transcription, optionally translated into their preferred language, and an integrated AI meeting assistant that uses trusted enterprise data and meeting context to fact-check, look up relevant information, and propose responses. It creates succinct on-demand recaps, insights, and action item lists during and after meetings, securely maintaining an inventory of meeting records. Enterprises can use LMA with an existing Amazon Bedrock Agent/Knowledgebase, or with a bedrock LLM without a knowledge base. LMA integrates with popular meeting platforms and offers improved participant focus, understanding, accuracy, time-saving, and record-keeping efficiency, while supporting enterprise security, compliance, and availability. 
 
 Before continuing, please read the blog post [Live Meeting Assistant (LMA)](https://amazon.com/live-meeting-assistant), deploy LMA, and follow the tutorial to experience the Meeting Assist demo. This is prerequisite context for the rest of this document.
 
@@ -78,7 +78,7 @@ The **SUMMARIZE** and **TOPIC** buttons work the same way as **ACTIONS**. They a
 
 The **ASK ASSISTANT!** button works similarly, but it uses a different Lambda Hook function than the Summarize, Topic, and Actions items. 
 
-In QnAbot Designer, select the `AA.AskAssistant` item to see its definition. Note that it has a different **Lambda Hook** function. Here we use the 'BedrockKB-LambdaHook' function that was also deployed with LMA - this function interacts with Knowledge bases for Bedrock.
+In QnAbot Designer, select the `AA.AskAssistant` item to see its definition. Note that it has a different **Lambda Hook** function. Here we use the 'BedrockKB-LambdaHook' function that was also deployed with LMA - this function interacts with Knowledge bases for Bedrock. If you elected not to integrate a knowledge base by selecting `BEDROCK_LLM` as the Meeting Assist Service when you deployed LMA, then you will see 'BedrockLLM-LambdaHook' function here instead.
 
 The Lambda Hook function retrieves the meeting transcript, and truncates it if needed to represent the last N turns, where N is the value of the QnABot Setting `LLM_CHAT_HISTORY_MAX_MESSAGES` (default is 20, but you can change it in QnABot designer Settings page). The transcript is used to provide context for the prompt.
 
@@ -122,7 +122,7 @@ Select `CustomNoMatches` item in Designer:
 
   <img src="../images/meetingassist-qnabot-designer-no_hits_qid.png" alt="Bot No_hits" style="display: block; margin-left: 0; margin-right: auto;"/> 
 
-This item, too, has a Lambda Hook function. It also uses the 'BedrockKB-LambdaHook' function, but note that here, unlike in the previous 'AA.AskAssistant' item, there is no value for "Prompt" in the Lambda Hook Argument JSON value.  Rather than using a predefined value for Prompt, the prompt is the actual question that you typed or spoke.  Your question is used in the context of the meeting transcription, so it can refer to recent statements and topics being discussed. 
+This item, too, has a Lambda Hook function. It also uses either the 'BedrockKB-LambdaHook' or the 'BedrockLLM-LambdaHook' function, but note that here, unlike in the previous 'AA.AskAssistant' item, there is no value for "Prompt" in the Lambda Hook Argument JSON value.  Rather than using a predefined value for Prompt, the prompt is the actual question that you typed or spoke.  Your question is used in the context of the meeting transcription, so it can refer to recent statements and topics being discussed. 
 
 ## Start Message
 
@@ -149,8 +149,8 @@ Create new items in QnABot designer to add capabilities to LMA.
 
 Give you new item an `Item ID`. Use this ID in any button values (`QID::<Item ID>`) as you've seen in the examples above, when you want a button press to explicitly match the item.
 
-Add one or more **Questions/Utterances** to your item to enable semantic search for free form questions. When an LMA user says `OK Assistant, Why is the sky blue?` or types `Why is the sky blue?` in the bot, QnAbot first tries to find a 'good answer' from the set of items, before invoking the no_hits fallback when it asks Knowledge base (see [Freeform questions](#freeform-questions)). By configuring one or more questions that are a "good match" (eg `Why is the sky blue`) then QnAbot will match the question to your item instead of the no_hits item, and your item will determine the response that is given by the meeting assistant.
+Add one or more **Questions/Utterances** to your item to enable semantic search for free form questions. When an LMA user says `OK Assistant, Why is the sky blue?` or types `Why is the sky blue?` in the bot, QnAbot first tries to find a 'good answer' from the set of items, before invoking the no_hits fallback when it asks Knowledge base or the LLM (see [Freeform questions](#freeform-questions)). By configuring one or more questions that are a "good match" (eg `Why is the sky blue`) then QnAbot will match the question to your item instead of the no_hits item, and your item will determine the response that is given by the meeting assistant.
 
 You can configure a static response by entering plain text in the **Answer** field, or (better) choose **Advanced** and enter rich text in the form of Markdown or HTML in the **Alternate Answers / Markdown Answer** field. Your static answer can optionally use Handlebars to enable conditions and substitutions - see [Handlerbars README](https://github.com/aws-solutions/qnabot-on-aws/blob/main/docs/handlebars/README.md). 
 
-Or you can configure a Lambda Hook for completely dynamic answers based on any logic you choose. Use one of the Lambda Hook functions discussed above (`SummarizeCall` or `BedrockKB-LambdaHook`) with your own Argument values. Or use a new Lambda Hook function that you create yourself, to do whatever you want it to do, for example, query your databases, retrieve information or perform actions using API, integrate with other LLMs - you provide the function, and LMA will run it and return its response to the LMA user. 
+Or you can configure a Lambda Hook for completely dynamic answers based on any logic you choose. Use one of the Lambda Hook functions discussed above (`SummarizeCall`, `BedrockKB-LambdaHook`, or `BedrockLLM-LambdaHook`) with your own Argument values. Or use a new Lambda Hook function that you create yourself, to do whatever you want it to do, for example, query your databases, retrieve information or perform actions using API, integrate with other LLMs - you provide the function, and LMA will run it and return its response to the LMA user. 

--- a/lma-meetingassist-setup-stack/src/qna_bedrockkb_lambdahook_function.py
+++ b/lma-meetingassist-setup-stack/src/qna_bedrockkb_lambdahook_function.py
@@ -267,12 +267,12 @@ def handler(event, context):
         print("no callId in request or session attributes")
 
     retrievePromptTemplate = event["req"]["_settings"].get(
-        "QUERY_PROMPT_TEMPLATE")
+        "ASSISTANT_QUERY_PROMPT_TEMPLATE")
     query = generateRetrieveQuery(
         retrievePromptTemplate, transcript, userInput)
 
     generatePromptTemplate = event["req"]["_settings"].get(
-        "GENERATE_PROMPT_TEMPLATE")
+        "ASSISTANT_GENERATE_PROMPT_TEMPLATE")
     kb_response = get_kb_response(
         generatePromptTemplate, transcript, query)
 

--- a/lma-meetingassist-setup-stack/src/qna_bedrockllm_lambdahook_function.py
+++ b/lma-meetingassist-setup-stack/src/qna_bedrockllm_lambdahook_function.py
@@ -203,12 +203,12 @@ def handler(event, context):
         print("no callId in request or session attributes")
 
     queryPromptTemplate = event["req"]["_settings"].get(
-        "QUERY_PROMPT_TEMPLATE")
+        "ASSISTANT_QUERY_PROMPT_TEMPLATE")
     query = generateRetrieveQuery(
         queryPromptTemplate, transcript, userInput)
 
     generatePromptTemplate = event["req"]["_settings"].get(
-        "GENERATE_PROMPT_TEMPLATE")
+        "ASSISTANT_GENERATE_PROMPT_TEMPLATE")
     br_response = get_br_response(
         generatePromptTemplate, transcript, query)
     event = format_response(event, br_response, query)

--- a/lma-meetingassist-setup-stack/template.yaml
+++ b/lma-meetingassist-setup-stack/template.yaml
@@ -38,8 +38,9 @@ Parameters:
     Default: 'BEDROCK_KNOWLEDGE_BASE'
     Type: String
     AllowedValues:
+      - 'BEDROCK_LLM'
       - 'BEDROCK_KNOWLEDGE_BASE'
-    Description: Choose which knowledge base / LLM service to use (Currently only BEDROCK_KNOWLEDGE_BASE is supported)
+    Description: Choose which knowledge base / LLM service to use
 
   BedrockKnowledgeBaseID:
     Type: String
@@ -48,14 +49,14 @@ Parameters:
     Description: >
       If MeetingAssistService is BEDROCK_KNOWLEDGE_BASE, provide the *id* (not name) of an existing Bedrock Knowledge Base to be used for Meeting Assist bot.
 
-  BedrockKnowledgeBaseModelID:
+  MeetingAssistServiceBedrockModelID:
     Type: String
     Default: 'anthropic.claude-3-sonnet-20240229-v1:0'
-    AllowedValues: 
+    AllowedValues:
       - 'anthropic.claude-3-haiku-20240307-v1:0'
       - 'anthropic.claude-3-sonnet-20240229-v1:0'
     Description: >-
-      If MeetingAssistService is BEDROCK_KNOWLEDGE_BASE, select a Bedrock LLM model from the list."
+      If MeetingAssistService is BEDROCK_LLM or BEDROCK_KNOWLEDGE_BASE, select a Bedrock LLM model from the list."
 
   AmazonQAppId:
     Type: String
@@ -162,6 +163,7 @@ Parameters:
 Conditions:
   ShouldConfigureQnabot: !Not [!Equals [!Ref QNABOTSTACK, '']]
   HasSummaryLambdaFunction: !Not [!Equals [!Ref TranscriptSummaryFunctionArn, '']]
+  ShouldConfigureBedrockLLM: !Equals [!Ref MeetingAssistService, 'BEDROCK_LLM']
   ShouldConfigureBedrockKB: !Equals [!Ref MeetingAssistService, 'BEDROCK_KNOWLEDGE_BASE']
   ShouldConfigureQBusiness: !Equals [!Ref MeetingAssistService, 'Q_BUSINESS']
 
@@ -338,7 +340,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - "bedrock:InvokeModel"
-                Resource: !Sub "arn:aws:bedrock:${AWS::Region}::foundation-model/${BedrockKnowledgeBaseModelID}"
+                Resource: !Sub "arn:aws:bedrock:${AWS::Region}::foundation-model/${MeetingAssistServiceBedrockModelID}"
           PolicyName: BedrockPolicy
         - PolicyDocument:
             Version: 2012-10-17
@@ -372,7 +374,70 @@ Resources:
         Variables:
           FETCH_TRANSCRIPT_FUNCTION_ARN: !Ref FetchTranscriptFunctionArn
           KB_ID: !Ref BedrockKnowledgeBaseID
-          MODEL_ID: !Ref BedrockKnowledgeBaseModelID
+          MODEL_ID: !Ref MeetingAssistServiceBedrockModelID
+      Code: ./src
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W89
+            reason: Customer can use VPC if desired
+          - id: W92
+            reason: Customer can choose reserved concurrency based on their requirement.
+
+  QNABedrockLLMFunctionRole:
+    Condition: ShouldConfigureBedrockLLM
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "bedrock:InvokeModel"
+                Resource: !Sub "arn:aws:bedrock:${AWS::Region}::foundation-model/${MeetingAssistServiceBedrockModelID}"
+          PolicyName: BedrockPolicy
+        - PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "s3:GetObject"
+                Resource: "arn:aws:s3:::*-importbucket-*/*"
+          PolicyName: S3ImportBucketPolicy
+        - PolicyName: InlinePolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Action: lambda:InvokeFunction
+                Effect: Allow
+                Resource: !Ref FetchTranscriptFunctionArn
+
+  QNABedrockLLMFunction:
+    Condition: ShouldConfigureBedrockLLM
+    Type: "AWS::Lambda::Function"
+    Properties:
+      # FunctionName must start with 'QNA-' to match QnABot fulfillment role permissions
+      FunctionName: !Sub "QNA-${LMAStackName}-BedrockLLM-LambdaHook"
+      Role: !GetAtt QNABedrockLLMFunctionRole.Arn
+      Handler: qna_bedrockllm_lambdahook_function.handler
+      Runtime: python3.11
+      Layers: 
+        - !Ref Boto3Layer
+      Timeout: 900
+      Environment:
+        Variables:
+          FETCH_TRANSCRIPT_FUNCTION_ARN: !Ref FetchTranscriptFunctionArn
+          MODEL_ID: !Ref MeetingAssistServiceBedrockModelID
       Code: ./src
     Metadata:
       cfn_nag:
@@ -501,7 +566,10 @@ Resources:
       QNAMeetingAssistLambdaHookFunction: !If
       - ShouldConfigureQBusiness
       - !Ref QNAQBusinessFunction
-      - !Ref QNABedrockKnowledgeBaseFunction
+      - !If
+        - ShouldConfigureBedrockKB
+        - !Ref QNABedrockKnowledgeBaseFunction
+        - !Ref QNABedrockLLMFunction
       QnaBotSettings: !Ref QnaBotSettings
       # Changes to Params below force MeetingAssist Setup to execute.
       TranscribeLanguageCode: !Ref TranscribeLanguageCode


### PR DESCRIPTION
*Issue #, if available:*

#13 
#3 

*Description of changes:*

(1) Add BEDROCK_LLM option, and make knowledge base optional. Add template rule to check for valid KB_ID with BEDROCK_KNOWLEDGE_BASE is selected.

![image](https://github.com/aws-samples/amazon-transcribe-live-meeting-assistant/assets/10953374/ca54908f-b598-4f05-9c98-4ef3c43c827c)

(2) Fix Stack name too long issue


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
