### PR TITLE
Fix/unmutemic

### DIFF
--- a/lma-browser-extension-stack/public/content_scripts/providers/chime.js
+++ b/lma-browser-extension-stack/public/content_scripts/providers/chime.js
@@ -118,7 +118,7 @@ window.onload = function () {
       } else */
       if (mutation.type === "characterData") {
         // this is a changed record
-        if (!mutation.target.data.includes("Mute") && !mutation.target.data.includes("Only they may unmute themselves.")) {
+        if (!mutation.target.data.includes("Mute") && !mutation.target.data.includes("Unmute my microphone") && !mutation.target.data.includes("Only they may unmute themselves.")) {
           const activeSpeaker = mutation.target.data;
           if (activeSpeaker !== 'No one') {
             chrome.runtime.sendMessage({action: "ActiveSpeakerChange", active_speaker: activeSpeaker});

--- a/lma-browser-extension-stack/public/content_scripts/providers/chime.js
+++ b/lma-browser-extension-stack/public/content_scripts/providers/chime.js
@@ -118,7 +118,7 @@ window.onload = function () {
       } else */
       if (mutation.type === "characterData") {
         // this is a changed record
-        if (!mutation.target.data.includes("Mute") && !mutation.target.data.includes("Unmute my microphone") && !mutation.target.data.includes("Only they may unmute themselves.")) {
+        if (!mutation.target.data.includes("Mute") && !mutation.target.data.includes("Unmute my microphone") && !mutation.target.data.includes("Only they may")) {
           const activeSpeaker = mutation.target.data;
           if (activeSpeaker !== 'No one') {
             chrome.runtime.sendMessage({action: "ActiveSpeakerChange", active_speaker: activeSpeaker});

--- a/lma-browser-extension-stack/public/content_scripts/providers/chime.js
+++ b/lma-browser-extension-stack/public/content_scripts/providers/chime.js
@@ -119,7 +119,7 @@ window.onload = function () {
       if (mutation.type === "characterData") {
         // this is a changed record
         // The following will ignore text that includes the word 'Mute', 'Unmute my microphone', 
-        // and 'Only they may'(to cover both 'Only they may mute themselves' and 'Only they may unmute themselves', which appear as text within the active speaker.
+        // and 'Only they may' which covers both 'Only they may mute themselves' and 'Only they may unmute themselves', which appear as text within the active speaker.
         if (!mutation.target.data.includes("Mute") && !mutation.target.data.includes("Unmute my microphone") && !mutation.target.data.includes("Only they may")) {
           const activeSpeaker = mutation.target.data;
           if (activeSpeaker !== 'No one') {

--- a/lma-browser-extension-stack/public/content_scripts/providers/chime.js
+++ b/lma-browser-extension-stack/public/content_scripts/providers/chime.js
@@ -118,6 +118,8 @@ window.onload = function () {
       } else */
       if (mutation.type === "characterData") {
         // this is a changed record
+        // The following will ignore text that includes the word 'Mute', 'Unmute my microphone', 
+        // and 'Only they may'(to cover both 'Only they may mute themselves' and 'Only they may unmute themselves', which appear as text within the active speaker.
         if (!mutation.target.data.includes("Mute") && !mutation.target.data.includes("Unmute my microphone") && !mutation.target.data.includes("Only they may")) {
           const activeSpeaker = mutation.target.data;
           if (activeSpeaker !== 'No one') {


### PR DESCRIPTION
*Issue #, if available:*  #2

*Description of changes:*

The mutation observer for the active speaker listens for text changes from a particular dom element, including its children. When mute/unmute changes, there are child elements that get added to the active speaker div (I think as tooltips/popovers or something?). This PR ignores certain phrases that appear in those child elements.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
