### PR TITLE
Fix #6 - Multi languageID segment overwrite issue

### DIFF
--- a/lma-websocket-stack/source/app/src/lca.ts
+++ b/lma-websocket-stack/source/app/src/lca.ts
@@ -127,7 +127,7 @@ export const writeTranscriptionSegment = async function (transcribeMessageJson: 
                 EventType: 'ADD_TRANSCRIPT_SEGMENT',
                 CallId: callMetadata.callId,
                 Channel: (result.ChannelId === 'ch_0' ? 'CALLER' : 'AGENT'),
-                SegmentId: result.ResultId || '',
+                SegmentId: `${result.ChannelId}-${result.StartTime}`,
                 StartTime: result.StartTime || 0,
                 EndTime: result.EndTime || 0,
                 Transcript: transcript || '',


### PR DESCRIPTION
*Issue #, if available:*

#6 

*Description of changes:*

Per service engineering team, `resultId` doesn't uniquely identify an audio segment when using multi-language identification. Modified LMA code to a use concatenation of `channelId` and segment `startTime` as segmentId, instead of `resultId` - works in all cases - with our without maguageId.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
