### PR TITLE
Fix/qnabot v5.5.2

### DIFF
--- a/patches/qnabot/Makefile
+++ b/patches/qnabot/Makefile
@@ -1,13 +1,13 @@
 TEMPLATES=$(shell for l in $$(ls ./templates | egrep -v "util|lib|README.md|jest.config.js|package.json|package-lock.json|node_modules|coverage|__tests__|.pytest_cache|.venv-test|pytest.ini|requirements.txt|requirements-test.txt");do echo templates/$$l;done)
 
-All: ml_model assets templates lambda website make_directories
+All: assets templates lambda website make_directories
 
 build: All
 
 make_directories:
 	mkdir -p build/lambda build/documents build/templates/test  build/templates/dev
 
-.PHONY: ml_model lambda templates upload website test bootstrap assets config.aws-solutions.json
+.PHONY: lambda templates upload website test bootstrap assets config.aws-solutions.json
 .PHONY: $(TEMPLATES)
 
 config.json:

--- a/patches/qnabot/Makefile
+++ b/patches/qnabot/Makefile
@@ -1,11 +1,11 @@
-TEMPLATES=$(shell for l in $$(ls ./templates | egrep -v "__tests__|util|lib|dev|README.md|jest.config.js|package.json|package-lock.json");do echo templates/$$l;done)
+TEMPLATES=$(shell for l in $$(ls ./templates | egrep -v "util|lib|README.md|jest.config.js|package.json|package-lock.json|node_modules|coverage|__tests__|.pytest_cache|.venv-test|pytest.ini|requirements.txt|requirements-test.txt");do echo templates/$$l;done)
 
 All: ml_model assets templates lambda website make_directories
 
 build: All
 
 make_directories:
-	mkdir -p build/ml_model build/lambda build/documents build/templates/test  build/templates/dev
+	mkdir -p build/lambda build/documents build/templates/test  build/templates/dev
 
 .PHONY: ml_model lambda templates upload website test bootstrap assets config.aws-solutions.json
 .PHONY: $(TEMPLATES)
@@ -15,9 +15,6 @@ config.json:
 
 config.aws-solutions.json:
 	node bin/config.js buildType=AWSSolutions > config.json
-
-ml_model:  make_directories
-	make -C ./ml_model
 
 lambda:  make_directories
 	make -C ./lambda
@@ -39,7 +36,7 @@ assets: make_directories
 samples:docs/blog-samples.json make_directories
 	cp docs/blog-samples.json build/documents
 
-upload: ml_model templates lambda website make_directories assets
+upload: templates lambda website make_directories assets
 	./bin/upload.sh
 
 test: make_directories

--- a/publish.sh
+++ b/publish.sh
@@ -233,7 +233,8 @@ cat > config.json <<_EOF
   "profile": "${AWS_PROFILE:-default}",
   "region": "${REGION}",
   "buildType": "Custom",
-  "skipCheckTemplate":true
+  "skipCheckTemplate":true,
+  "noStackOutput": true
 }
 _EOF
 npm install


### PR DESCRIPTION
*Issue #, if available:*
#24 

*Description of changes:*
Updated QnABot submodule to tagged QnAbot version 5.5.2 which is reported to fix #24:
> "TestAllStepLambda" continues to run even when not in use. The "TestAll-2024-05-07-14-02-813.csv" file is continuously put into the S3 bucket "lma-qnabot-cudpdtligjfk-testallbucket-*", and S3 versioning keeps growing.

See [QnAbot Issue 718](https://github.com/aws-solutions/qnabot-on-aws/issues/718#issuecomment-2091464088) fixed in [QnABot v5.5.2](https://github.com/aws-solutions/qnabot-on-aws/blob/main/CHANGELOG.md#552---2024-05-08)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

