### PR TITLE
Fix/active speaker assignment not for mic channel

### DIFF
--- a/lma-websocket-stack/README.md
+++ b/lma-websocket-stack/README.md
@@ -3,6 +3,14 @@
 ## Introduction
 Websocket server ingests audio from the web client (web and microphone audio stream), transcribes the audio real time, and writes the transcription events to KDS. 
 
+## Local build check
+
+Test locally for syntax or lint errors that will cause CodeBuild failures during deployment if not fixed. Run these commands from the root directory of the repo:
+```
+cd lca-websocket-stack/source/app/
+npm run setup
+npm run buildcheck
+```
 
 ## Cloudformation Deployment
 

--- a/lma-websocket-stack/README.md
+++ b/lma-websocket-stack/README.md
@@ -7,7 +7,7 @@ Websocket server ingests audio from the web client (web and microphone audio str
 
 Test locally for syntax or lint errors that will cause CodeBuild failures during deployment if not fixed. Run these commands from the root directory of the repo:
 ```
-cd lca-websocket-stack/source/app/
+cd lma-websocket-stack/source/app/
 npm run setup
 npm run buildcheck
 ```


### PR DESCRIPTION
*Issue #, if available:*

#33

*Description of changes:*

We already know speaker name for the microphone channel (ch_1) - represented in callMetaData.agentId. 
We should only use SPEAKER_CHANGE to track who is speaking on the incoming meeting channel (ch_0)
If the speaker is the same as the agentId, then we ignore the event.

Also fixes issue with callMetadata from every event leaking to the transcription loop, buy cleaning up use of socketData structure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
