### PR TITLE
Feature/unauth role fix

### DIFF
--- a/lma-ai-stack/deployment/lma-ai-stack.yaml
+++ b/lma-ai-stack/deployment/lma-ai-stack.yaml
@@ -1198,6 +1198,7 @@ Resources:
     Properties:
       IdentityPoolId: !Ref AgentAssistBotIdentityPool
       Roles:
+        authenticated: !GetAtt AgentAssistBotAuthRole.Arn
         unauthenticated: !GetAtt AgentAssistBotUnauthRole.Arn
 
   AgentAssistBotUnauthRole:
@@ -1216,8 +1217,25 @@ Resources:
                 "cognito-identity.amazonaws.com:aud": !Ref AgentAssistBotIdentityPool
               "ForAnyValue:StringLike":
                 "cognito-identity.amazonaws.com:amr": unauthenticated
+
+  AgentAssistBotAuthRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: cognito-identity.amazonaws.com
+            Action:
+              - sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                "cognito-identity.amazonaws.com:aud": !Ref AgentAssistBotIdentityPool
+              "ForAnyValue:StringLike":
+                "cognito-identity.amazonaws.com:amr": authenticated
       Policies:
-        - PolicyName: AgentAssistBotUnauthPolicy
+        - PolicyName: AgentAssistBotAuthPolicy
           PolicyDocument:
             Version: 2012-10-17
             Statement:

--- a/lma-ai-stack/deployment/lma-ai-stack.yaml
+++ b/lma-ai-stack/deployment/lma-ai-stack.yaml
@@ -1192,6 +1192,9 @@ Resources:
     Properties:
       IdentityPoolName: !Sub "${AWS::StackName}-AgentAssistBot-IdentityPool"
       AllowUnauthenticatedIdentities: true
+      CognitoIdentityProviders:
+        - ClientId: !Ref UserPoolClient
+          ProviderName: !GetAtt UserPool.ProviderName
 
   AgentAssistBotIdentityPoolSetRole:
     Type: AWS::Cognito::IdentityPoolRoleAttachment

--- a/lma-ai-stack/source/ui/public/lex-web-ui-loader-config-template.json
+++ b/lma-ai-stack/source/ui/public/lex-web-ui-loader-config-template.json
@@ -2,9 +2,9 @@
   "region": "${REACT_APP_AWS_REGION}",
   "cognito": {
     "poolId": "${REACT_APP_LEX_IDENTITY_POOL_ID}",
-    "appUserPoolClientId": "notused",
-    "appUserPoolName": "notused",
-    "appDomainName": "notused",
+    "appUserPoolClientId": "${REACT_APP_LEX_IDENTITY_POOL_CLIENT_ID}",
+    "appUserPoolName": "${REACT_APP_LEX_USER_POOL_NAME}",
+    "appDomainName": "${REACT_APP_LEX_DOMAIN_NAME}",
     "aws_cognito_region": "${REACT_APP_AWS_REGION}",
     "region": "${REACT_APP_AWS_REGION}"
   },

--- a/lma-ai-stack/source/ui/src/hooks/use-user-auth-state.js
+++ b/lma-ai-stack/source/ui/src/hooks/use-user-auth-state.js
@@ -16,6 +16,14 @@ const useUserAuthState = (awsconfig) => {
       logger.debug('auth state change authData:', authData);
       setAuthState(nextAuthState);
       setUser(authData);
+      if (authData) {
+        // prettier-ignore
+        localStorage.setItem(`${authData.pool.clientId}idtokenjwt`, authData.signInUserSession.idToken.jwtToken);
+        // prettier-ignore
+        localStorage.setItem(`${authData.pool.clientId}accesstokenjwt`, authData.signInUserSession.accessToken.jwtToken);
+        // prettier-ignore
+        localStorage.setItem(`${authData.pool.clientId}refreshtoken`, authData.signInUserSession.refreshToken.jwtToken);
+      }
     });
   }, [awsconfig]);
 

--- a/lma-main.yaml
+++ b/lma-main.yaml
@@ -1011,6 +1011,9 @@ Resources:
         EndOfCallTranscriptSummary: !Ref EndOfCallTranscriptSummary
         EndOfCallLambdaHookFunctionArn: !Ref EndOfCallLambdaHookFunctionArn
         LexMeetingAssistIdentityPoolId: !GetAtt AISTACK.Outputs.LexAgentAssistIdentityPoolId
+        LexMeetingAssistUserPoolClientId: !GetAtt AISTACK.Outputs.CognitoClientId
+        LexMeetingAssistUserPoolId: !GetAtt AISTACK.Outputs.UserPoolId
+        LexMeetingAssistDomainName: !GetAtt AISTACK.Outputs.CognitoLoginUrl
         CloudFrontDomainName: !GetAtt AISTACK.Outputs.CloudFrontDomainName
         FetchTranscriptFunctionArn: !GetAtt AISTACK.Outputs.FetchTranscriptArn
         TranscriptSummaryFunctionArn: !GetAtt AISTACK.Outputs.TranscriptSummaryFunctionArn

--- a/lma-meetingassist-setup-stack/src/setup_function.py
+++ b/lma-meetingassist-setup-stack/src/setup_function.py
@@ -45,20 +45,20 @@ def addBotToAistack(props, oldprops):
     )
     print("Updated AsyncAgentAssistOrchestratorFunction Environment variable to add Lex bot.")
 
-    print("Updating updating Cognito Unauthenticated Role for Agent Assist...")
-    agentAssistBotUnauthRole = getStackResource(
-        props["AISTACK"], "AgentAssistBotUnauthRole")
+    print("Updating updating Cognito Authenticated Role for Agent Assist...")
+    agentAssistBotAuthRole = getStackResource(
+        props["AISTACK"], "AgentAssistBotAuthRole")
     newArn = f'arn:{aws_partition}:lex:{AWS_REGION}:{aws_account_id}:bot-alias/{props["LexMeetingAssistBotId"]}/{props["LexMeetingAssistAliasId"]}'
     newPolicy = {'Version': '2012-10-17', 'Statement': [{'Action': [
         'lex:RecognizeText', 'lex:RecognizeUtterance', 'lex:DeleteSession', 'lex:PutSession'], 'Resource': newArn, 'Effect': 'Allow'}]}
     print('New Policy:')
     print(newPolicy)
     iam.put_role_policy(
-        RoleName=agentAssistBotUnauthRole,
-        PolicyName='AgentAssistBotUnauthPolicy',
+        RoleName=agentAssistBotAuthRole,
+        PolicyName='AgentAssistBotAthPolicy',
         PolicyDocument=json.dumps(newPolicy)
     )
-    print("Done updating Cognito Unauthenticated Role for Agent Assist")
+    print("Done updating Cognito Authenticated Role for Agent Assist")
 
     # update config file and invalidate CF
     print("Updating lex-web-ui-loader-config.json...")
@@ -76,6 +76,12 @@ def addBotToAistack(props, oldprops):
     contents = contents.replace('${REACT_APP_AWS_REGION}', AWS_REGION)
     contents = contents.replace(
         '${REACT_APP_LEX_IDENTITY_POOL_ID}', props["LexMeetingAssistIdentityPoolId"])
+    contents = contents.replace(
+        '${REACT_APP_LEX_IDENTITY_POOL_CLIENT_ID}', props["LexMeetingAssistUserPoolClientId"])
+    contents = contents.replace(
+        '${REACT_APP_LEX_USER_POOL_NAME}', props["LexMeetingAssistUserPoolId"])
+    contents = contents.replace(
+        '${REACT_APP_LEX_DOMAIN_NAME}', props["LexMeetingAssistDomainName"])
     contents = contents.replace(
         '${CLOUDFRONT_DOMAIN}', props["CloudFrontDomainName"])
     print("New LexWebUI Config: ", json.dumps(contents))

--- a/lma-meetingassist-setup-stack/template.yaml
+++ b/lma-meetingassist-setup-stack/template.yaml
@@ -103,6 +103,18 @@ Parameters:
     Type: String
     Description: The LMA Meeting Assist Identity Pool ID
 
+  LexMeetingAssistUserPoolClientId:
+    Type: String
+    Description: The LMA Meeting Assist User Pool Client ID
+
+  LexMeetingAssistUserPoolId:
+    Type: String
+    Description: The LMA Meeting Assist User Pool ID
+
+  LexMeetingAssistDomainName:
+    Type: String
+    Description: The LMA Meeting Assist Domain Url
+
   CloudFrontDomainName:
     Type: String
     Description: The domain name of the LMA CloudFront distribution
@@ -619,6 +631,9 @@ Resources:
       LexMeetingAssistAliasId: !Ref LexMeetingAssistAliasId
       LexMeetingAssistLocaleId: !Ref LexMeetingAssistLocaleId
       LexMeetingAssistIdentityPoolId: !Ref LexMeetingAssistIdentityPoolId
+      LexMeetingAssistUserPoolClientId: !Ref LexMeetingAssistUserPoolClientId
+      LexMeetingAssistUserPoolId: !Ref LexMeetingAssistUserPoolId
+      LexMeetingAssistDomainName: !Ref LexMeetingAssistDomainName
       QnaMeetingAssistDemoJson: !Ref QnaMeetingAssistDemoJson
       QNASummarizeCallFunction: !Ref QNASummarizeCallFunction
       QNAMeetingAssistLambdaHookFunction: !If


### PR DESCRIPTION
PR to resolve the issue with unauthenticated role being used to talk to the assistant bot.

- The unauth role still exists and is active but has no permissions. The Lex Web UI expects the authenticated role to exist when it establishes initial contact with Cognito, but as long as an authenticated user exists it will not make any calls to Lex with the unauthenticated user. The user exists with a role that has no permission policies granted.
- Because the Web UI & LMA use different version of Cognito auth libraries, the expected local storage tokens are named differently and the easiest solution was just to push what the Web UI expected as a local storage item with the auth data.
- Everything else is just about hooking up the user pool to the Web UI since it previously did not have one. It is sharing the user pool with the larger LMA application.