### PR TITLE
Fix: Remove unused KMS key #72

### DIFF
--- a/lma-ai-stack/deployment/lma-ai-stack.yaml
+++ b/lma-ai-stack/deployment/lma-ai-stack.yaml
@@ -421,9 +421,8 @@ Conditions:
   IsTranscriptSummaryEnabled: !Or
     - !Condition ShouldEnableEndOfCallLambdaHookFunction
     - !Condition ShouldEnableBedrockSummarizer
-  ShouldEnableAppSyncApiCache:
-    !Equals [!Ref EnableAppSyncApiCache, "true"]
-    
+  ShouldEnableAppSyncApiCache: !Equals [!Ref EnableAppSyncApiCache, "true"]
+
 Outputs:
   CognitoLoginUrl:
     Value: !Sub https://${LMAUserPoolDomain}.auth.${AWS::Region}.amazoncognito.com
@@ -578,33 +577,6 @@ Resources:
         Enabled: true
       StreamSpecification:
         StreamViewType: NEW_IMAGE
-
-  # Add permissions to the default key to allow S3 access
-  SQSManagedKey:
-    Type: AWS::KMS::Key
-    Properties:
-      EnableKeyRotation: true
-      KeyPolicy:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                - "s3.amazonaws.com"
-            Action:
-              - "kms:GenerateDataKey*"
-              - "kms:Decrypt"
-            Resource: "*"
-          - Effect: Allow
-            Principal:
-              AWS: !Join
-                - ""
-                - - "arn:aws:iam::"
-                  - !Ref "AWS::AccountId"
-                  - ":root"
-            Action:
-              - "kms:*"
-            Resource: "*"
 
   ##########################################################################
   # ParameterStore


### PR DESCRIPTION
*Issue #, if available:*
 #72 

*Description of changes:*

remove AWS::KMS::Key resource `SQSManagedKey` from AISTACK template

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
