### PR TITLE
Feature/download call details

### DIFF
--- a/lma-ai-stack/.eslintrc.json
+++ b/lma-ai-stack/.eslintrc.json
@@ -14,7 +14,8 @@
         "ecmaVersion": 12
     },
     "rules": {
-        "max-len": ["error", { "code": 120, "ignoreUrls": true}],
+        "max-len": ["error", { "code": 120, "ignoreUrls": true, "ignoreTemplateLiterals":  true}]
+    }],
         "prettier/prettier": [
             "error",
             {

--- a/lma-ai-stack/.eslintrc.json
+++ b/lma-ai-stack/.eslintrc.json
@@ -14,10 +14,11 @@
         "ecmaVersion": 12
     },
     "rules": {
+        "max-len": ["error", { "code": 120, "ignoreUrls": true}],
         "prettier/prettier": [
             "error",
             {
-                "printWidth": 100,
+                "printWidth": 120,
                 "singleQuote": true,
                 "trailingComma": "all"
             }

--- a/lma-ai-stack/.prettierrc
+++ b/lma-ai-stack/.prettierrc
@@ -1,5 +1,5 @@
 {
-    "printWidth": 100,
+    "printWidth": 120,
     "singleQuote": true,
     "trailingComma": "all"
 }

--- a/lma-ai-stack/source/ui/.eslintrc.json
+++ b/lma-ai-stack/source/ui/.eslintrc.json
@@ -24,7 +24,7 @@
     "rules": {
         "no-console": "off",
         "no-alert": "off",
-        "max-len": ["error", { "code": 120, "ignoreUrls": true}],
+        "max-len": ["error", { "code": 120, "ignoreUrls": true, "ignoreTemplateLiterals":  true}],
         "linebreak-style": [
             "error",
             "unix"

--- a/lma-ai-stack/source/ui/.eslintrc.json
+++ b/lma-ai-stack/source/ui/.eslintrc.json
@@ -24,6 +24,7 @@
     "rules": {
         "no-console": "off",
         "no-alert": "off",
+        "max-len": ["error", { "code": 120, "ignoreUrls": true}],
         "linebreak-style": [
             "error",
             "unix"
@@ -40,7 +41,7 @@
         "prettier/prettier": [
             "error",
             {
-                "printWidth": 100,
+                "printWidth": 120,
                 "singleQuote": true,
                 "trailingComma": "all"
             }

--- a/lma-ai-stack/source/ui/.prettierrc
+++ b/lma-ai-stack/source/ui/.prettierrc
@@ -1,5 +1,5 @@
 {
-    "printWidth": 100,
+    "printWidth": 120,
     "singleQuote": true,
     "trailingComma": "all"
 }

--- a/lma-ai-stack/source/ui/package-lock.json
+++ b/lma-ai-stack/source/ui/package-lock.json
@@ -11819,6 +11819,29 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-sfn/node_modules/@smithy/util-config-provider": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",

--- a/lma-ai-stack/source/ui/src/components/call-analytics-layout/CallAnalyticsLayout.jsx
+++ b/lma-ai-stack/source/ui/src/components/call-analytics-layout/CallAnalyticsLayout.jsx
@@ -21,10 +21,7 @@ import Breadcrumbs from './breadcrumbs';
 import ToolsPanel from './tools-panel';
 import SplitPanel from './calls-split-panel';
 
-import {
-  CALL_LIST_SHARDS_PER_DAY,
-  PERIODS_TO_LOAD_STORAGE_KEY,
-} from '../call-list/calls-table-config';
+import { CALL_LIST_SHARDS_PER_DAY, PERIODS_TO_LOAD_STORAGE_KEY } from '../call-list/calls-table-config';
 
 import useAppContext from '../../contexts/app';
 
@@ -44,9 +41,7 @@ const CallAnalyticsLayout = () => {
     // default to 2 hours - half of one (4hr) shard period
     let periods = 0.5;
     try {
-      const periodsFromStorage = Math.abs(
-        JSON.parse(localStorage.getItem(PERIODS_TO_LOAD_STORAGE_KEY)),
-      );
+      const periodsFromStorage = Math.abs(JSON.parse(localStorage.getItem(PERIODS_TO_LOAD_STORAGE_KEY)));
       // prettier-ignore
       if (
         !Number.isSafeInteger(periodsFromStorage)

--- a/lma-ai-stack/source/ui/src/components/call-analytics-layout/navigation.jsx
+++ b/lma-ai-stack/source/ui/src/components/call-analytics-layout/navigation.jsx
@@ -4,12 +4,7 @@ import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 import { SideNavigation } from '@awsui/components-react';
 
-import {
-  CALLS_PATH,
-  STREAM_AUDIO_PATH,
-  VIRTUAL_PARTICIPANT_PATH,
-  DEFAULT_PATH,
-} from '../../routes/constants';
+import { CALLS_PATH, STREAM_AUDIO_PATH, VIRTUAL_PARTICIPANT_PATH, DEFAULT_PATH } from '../../routes/constants';
 
 export const callsNavHeader = { text: 'Meeting Analytics', href: `#${DEFAULT_PATH}` };
 export const callsNavItems = [

--- a/lma-ai-stack/source/ui/src/components/call-analytics-top-navigation/CallAnalyticsTopNavigation.jsx
+++ b/lma-ai-stack/source/ui/src/components/call-analytics-top-navigation/CallAnalyticsTopNavigation.jsx
@@ -65,10 +65,7 @@ const CallAnalyticsTopNavigation = () => {
                   id: 'signout',
                   type: 'button',
                   text: (
-                    <Button
-                      variant="primary"
-                      onClick={() => setIsSignOutModalVisiblesetVisible(true)}
-                    >
+                    <Button variant="primary" onClick={() => setIsSignOutModalVisiblesetVisible(true)}>
                       Sign out
                     </Button>
                   ),
@@ -98,10 +95,7 @@ const CallAnalyticsTopNavigation = () => {
           ]}
         />
       </div>
-      <SignOutModal
-        visible={isSignOutModalVisible}
-        setVisible={setIsSignOutModalVisiblesetVisible}
-      />
+      <SignOutModal visible={isSignOutModalVisible} setVisible={setIsSignOutModalVisiblesetVisible} />
     </>
   );
 };

--- a/lma-ai-stack/source/ui/src/components/call-details/CallDetails.js
+++ b/lma-ai-stack/source/ui/src/components/call-details/CallDetails.js
@@ -73,13 +73,7 @@ const CallDetails = () => {
   }, [calls, callId]);
 
   return (
-    call && (
-      <CallPanel
-        item={call}
-        setToolsOpen={setToolsOpen}
-        callTranscriptPerCallId={callTranscriptPerCallId}
-      />
-    )
+    call && <CallPanel item={call} setToolsOpen={setToolsOpen} callTranscriptPerCallId={callTranscriptPerCallId} />
   );
 };
 

--- a/lma-ai-stack/source/ui/src/components/call-details/breadcrumbs.jsx
+++ b/lma-ai-stack/source/ui/src/components/call-details/breadcrumbs.jsx
@@ -10,10 +10,7 @@ import { callListBreadcrumbItems } from '../call-list/breadcrumbs';
 
 const Breadcrumbs = () => {
   const { callId } = useParams();
-  const callDetailsBreadcrumbItems = [
-    ...callListBreadcrumbItems,
-    { text: callId, href: `#${CALLS_PATH}/${callId}` },
-  ];
+  const callDetailsBreadcrumbItems = [...callListBreadcrumbItems, { text: callId, href: `#${CALLS_PATH}/${callId}` }];
 
   return <BreadcrumbGroup ariaLabel="Breadcrumbs" items={callDetailsBreadcrumbItems} />;
 };

--- a/lma-ai-stack/source/ui/src/components/call-list/CallList.jsx
+++ b/lma-ai-stack/source/ui/src/components/call-list/CallList.jsx
@@ -43,10 +43,7 @@ const CallList = () => {
     periodsToLoad,
   } = useCallsContext();
 
-  const [preferences, setPreferences] = useLocalStorage(
-    'call-list-preferences',
-    DEFAULT_PREFERENCES,
-  );
+  const [preferences, setPreferences] = useLocalStorage('call-list-preferences', DEFAULT_PREFERENCES);
 
   // prettier-ignore
   const {

--- a/lma-ai-stack/source/ui/src/components/call-list/CategoryAlertPill.jsx
+++ b/lma-ai-stack/source/ui/src/components/call-list/CategoryAlertPill.jsx
@@ -29,13 +29,7 @@ export const CategoryAlertPill = (props) => {
     </>
   ));
   return (
-    <Popover
-      dismissButton={false}
-      position="right"
-      size="small"
-      triggerType="custom"
-      content={popup}
-    >
+    <Popover dismissButton={false} position="right" size="small" triggerType="custom" content={popup}>
       <span className="category-pill-alert-icon">{alertCount}</span>
     </Popover>
   );

--- a/lma-ai-stack/source/ui/src/components/call-list/breadcrumbs.jsx
+++ b/lma-ai-stack/source/ui/src/components/call-list/breadcrumbs.jsx
@@ -11,8 +11,6 @@ export const callListBreadcrumbItems = [
   { text: 'Meetings', href: `#${CALLS_PATH}` },
 ];
 
-const Breadcrumbs = () => (
-  <BreadcrumbGroup ariaLabel="Breadcrumbs" items={callListBreadcrumbItems} />
-);
+const Breadcrumbs = () => <BreadcrumbGroup ariaLabel="Breadcrumbs" items={callListBreadcrumbItems} />;
 
 export default Breadcrumbs;

--- a/lma-ai-stack/source/ui/src/components/call-list/calls-split-panel-config.js
+++ b/lma-ai-stack/source/ui/src/components/call-list/calls-split-panel-config.js
@@ -35,13 +35,7 @@ const getPanelContentSingle = ({ items, setToolsOpen, callTranscriptPerCallId })
 
   return {
     header: 'Meeting Details',
-    body: (
-      <CallPanel
-        item={item}
-        setToolsOpen={setToolsOpen}
-        callTranscriptPerCallId={callTranscriptPerCallId}
-      />
-    ),
+    body: <CallPanel item={item} setToolsOpen={setToolsOpen} callTranscriptPerCallId={callTranscriptPerCallId} />,
   };
 };
 
@@ -64,11 +58,7 @@ const getPanelContentMultiple = ({ items, setToolsOpen, callTranscriptPerCallId 
           </Box>
           <Link fontSize="display-l" href={`#${CALLS_PATH}`}>
             <span className="custom-link-font-weight-light">
-              {
-                items.filter(
-                  ({ recordingStatusLabel }) => recordingStatusLabel === IN_PROGRESS_STATUS,
-                ).length
-              }
+              {items.filter(({ recordingStatusLabel }) => recordingStatusLabel === IN_PROGRESS_STATUS).length}
             </span>
           </Link>
         </div>

--- a/lma-ai-stack/source/ui/src/components/call-list/calls-table-config.js
+++ b/lma-ai-stack/source/ui/src/components/call-list/calls-table-config.js
@@ -35,9 +35,7 @@ export const COLUMN_DEFINITIONS_MAIN = [
   {
     id: 'alerts',
     header: '⚠',
-    cell: (item) => (
-      <CategoryAlertPill alertCount={item.alertCount} categories={item.callCategories} />
-    ),
+    cell: (item) => <CategoryAlertPill alertCount={item.alertCount} categories={item.callCategories} />,
     sortingField: 'alertCount',
     width: 85,
   },
@@ -85,9 +83,7 @@ export const COLUMN_DEFINITIONS_MAIN = [
     id: 'recordingStatus',
     header: 'Status',
     cell: (item) => (
-      <StatusIndicator type={item.recordingStatusIcon}>
-        {` ${item.recordingStatusLabel} `}
-      </StatusIndicator>
+      <StatusIndicator type={item.recordingStatusIcon}>{` ${item.recordingStatusLabel} `}</StatusIndicator>
     ),
     sortingField: 'recordingStatusLabel',
     width: 150,
@@ -180,13 +176,7 @@ const VISIBLE_CONTENT_OPTIONS = [
   },
 ];
 
-const VISIBLE_CONTENT = [
-  'agentId',
-  'initiationTimeStamp',
-  'recordingStatus',
-  'summary',
-  'conversationDuration',
-];
+const VISIBLE_CONTENT = ['agentId', 'initiationTimeStamp', 'recordingStatus', 'summary', 'conversationDuration'];
 
 export const DEFAULT_PREFERENCES = {
   pageSize: PAGE_SIZE_OPTIONS[0].value,
@@ -261,11 +251,7 @@ export const CallsCommonHeader = ({ resourceName = 'Meetings', ...props }) => {
       title={resourceName}
       actionButtons={
         <SpaceBetween size="xxs" direction="horizontal">
-          <ButtonDropdown
-            loading={props.loading}
-            onItemClick={onPeriodToLoadChange}
-            items={TIME_PERIOD_DROPDOWN_ITEMS}
-          >
+          <ButtonDropdown loading={props.loading} onItemClick={onPeriodToLoadChange} items={TIME_PERIOD_DROPDOWN_ITEMS}>
             {`Load: ${periodText}`}
           </ButtonDropdown>
           <Button

--- a/lma-ai-stack/source/ui/src/components/call-panel/CallPanel.jsx
+++ b/lma-ai-stack/source/ui/src/components/call-panel/CallPanel.jsx
@@ -154,7 +154,7 @@ const CallAttributes = ({ item, setToolsOpen }) => (
 // eslint-disable-next-line arrow-body-style
 const CallSummary = ({ item }) => {
   const downloadCallSummary = () => {
-    exportToTextFile(getTextFileFormattedSummary(item.callSummaryText), item.callId);
+    exportToTextFile(getTextFileFormattedSummary(item.callSummaryText), `Summary-${item.callId}`);
   };
   return (
     <Container

--- a/lma-ai-stack/source/ui/src/components/call-panel/CallPanel.jsx
+++ b/lma-ai-stack/source/ui/src/components/call-panel/CallPanel.jsx
@@ -163,7 +163,7 @@ const CallSummary = ({ item }) => {
                 <ButtonDropdown
                   items={[
                     { text: 'Download summary', id: 'download', disabled: false, iconName: 'download' },
-                    { text: 'Email summary', id: 'email', disabled: false, iconName: 'envelope' },
+                    { text: 'Email summary (beta)', id: 'email', disabled: false, iconName: 'envelope' },
                   ]}
                   variant="normal"
                   onItemClick={(option) => downloadCallSummary(option)}

--- a/lma-ai-stack/source/ui/src/components/call-panel/CallPanel.jsx
+++ b/lma-ai-stack/source/ui/src/components/call-panel/CallPanel.jsx
@@ -6,10 +6,12 @@ import {
   Badge,
   Box,
   Button,
+  ButtonDropdown,
   ColumnLayout,
   Container,
   Grid,
   Header,
+  Icon,
   Link,
   Popover,
   SpaceBetween,
@@ -134,8 +136,12 @@ const CallAttributes = ({ item, setToolsOpen }) => (
 
 // eslint-disable-next-line arrow-body-style
 const CallSummary = ({ item }) => {
-  const downloadCallSummary = async () => {
-    await exportToTextFile(getTextFileFormattedMeetingDetails(item), `Summary-${item.callId}`);
+  const downloadCallSummary = async (option) => {
+    if (option.detail.id === 'download') {
+      await exportToTextFile(getTextFileFormattedMeetingDetails(item), `Summary-${item.callId}`);
+    } else if (option.detail.id === 'email') {
+      window.open(`mailto:?subject=${item.callId}&body=${getEmailFormattedSummary(item.callSummaryText)}`);
+    }
   };
   return (
     <Container
@@ -154,18 +160,16 @@ const CallSummary = ({ item }) => {
           actions={
             <div>
               {item.callSummaryText && (
-                <div style={{ float: 'right' }}>
-                  <Button
-                    href={`mailto:?subject=${item.callId}&body=${getEmailFormattedSummary(item.callSummaryText)}`}
-                    iconName="envelope"
-                    variant="link"
-                  >
-                    Email Summary
-                  </Button>
-                  <Button onClick={() => downloadCallSummary()} iconName="download" variant="link">
-                    Download Summary
-                  </Button>
-                </div>
+                <ButtonDropdown
+                  items={[
+                    { text: 'Download summary', id: 'download', disabled: false, iconName: 'download' },
+                    { text: 'Email summary', id: 'email', disabled: false, iconName: 'envelope' },
+                  ]}
+                  variant="normal"
+                  onItemClick={(option) => downloadCallSummary(option)}
+                >
+                  <Icon name="download" variant="primary" />
+                </ButtonDropdown>
               )}
             </div>
           }
@@ -748,6 +752,15 @@ const CallTranscriptContainer = ({
     return translateOn;
   };
 
+  const downloadTranscript = (option) => {
+    console.log('option', option);
+    if (option.detail.id === 'text') {
+      downloadTranscriptAsText(callTranscriptPerCallId, item);
+    } else if (option.detail.id === 'excel') {
+      downloadTranscriptAsExcel(callTranscriptPerCallId, item);
+    }
+  };
+
   return (
     <Grid
       gridDefinition={[
@@ -784,28 +797,27 @@ const CallTranscriptContainer = ({
                   <Toggle onChange={({ detail }) => setTranslateOn(detail.checked)} checked={translateOn} />
                   <span>Enable Translation</span>
                   {languageChoices()}
+                  {showDownloadTranscript && (
+                    <SpaceBetween direction="horizontal" size="xs">
+                      <ButtonDropdown
+                        items={[
+                          {
+                            text: 'Download as',
+                            iconName: 'download',
+                            items: [
+                              { text: 'Excel', id: 'excel', disabled: false },
+                              { text: 'Text', id: 'text' },
+                            ],
+                          },
+                        ]}
+                        variant="normal"
+                        onItemClick={(option) => downloadTranscript(option)}
+                      >
+                        <Icon name="download" variant="primary" />
+                      </ButtonDropdown>
+                    </SpaceBetween>
+                  )}
                 </SpaceBetween>
-                {showDownloadTranscript && (
-                  <SpaceBetween direction="horizontal" size="xs">
-                    <span>Download Transcript</span>
-                    <Button
-                      iconName="download"
-                      variant="inline-link"
-                      disabled={false}
-                      onClick={() => downloadTranscriptAsText(callTranscriptPerCallId, item)}
-                    >
-                      Text
-                    </Button>
-                    <Button
-                      iconName="download"
-                      variant="inline-link"
-                      disabled={false}
-                      onClick={() => downloadTranscriptAsExcel(callTranscriptPerCallId, item)}
-                    >
-                      Excel
-                    </Button>
-                  </SpaceBetween>
-                )}
               </SpaceBetween>
             }
           >

--- a/lma-ai-stack/source/ui/src/components/call-panel/sentiment-charts.jsx
+++ b/lma-ai-stack/source/ui/src/components/call-panel/sentiment-charts.jsx
@@ -25,10 +25,7 @@ export const VoiceToneFluctuationChart = ({ item, callTranscriptPerCallId }) => 
       // eslint-disable-next-line implicit-arrow-linebreak
       transcript.segments
         .filter((t) => t.sentimentWeighted)
-        .reduce(
-          (p, c) => [...p, { x: new Date(c.endTime * 1000), y: c.sentimentWeighted }],
-          [{ x: new Date(0), y: 0 }],
-        )
+        .reduce((p, c) => [...p, { x: new Date(c.endTime * 1000), y: c.sentimentWeighted }], [{ x: new Date(0), y: 0 }])
         .sort((a, b) => a.x - b.x),
     ); // eslint-disable-line function-paren-newline
 
@@ -93,10 +90,7 @@ export const SentimentFluctuationChart = ({ item, callTranscriptPerCallId }) => 
       // eslint-disable-next-line implicit-arrow-linebreak
       transcript.segments
         .filter((t) => t.sentimentWeighted)
-        .reduce(
-          (p, c) => [...p, { x: new Date(c.endTime * 1000), y: c.sentimentWeighted }],
-          [{ x: new Date(0), y: 0 }],
-        )
+        .reduce((p, c) => [...p, { x: new Date(c.endTime * 1000), y: c.sentimentWeighted }], [{ x: new Date(0), y: 0 }])
         .sort((a, b) => a.x - b.x),
     ); // eslint-disable-line function-paren-newline
 
@@ -160,10 +154,7 @@ export const SentimentPerQuarterChart = ({ item, callTranscriptPerCallId }) => {
       // eslint-disable-next-line implicit-arrow-linebreak
       sentimentByQuarter
         .filter((s) => s.EndOffsetMillis > 0)
-        .reduce(
-          (p, c) => [...p, { x: new Date(c.EndOffsetMillis), y: c.Score }],
-          [{ x: new Date(0), y: 0 }],
-        ),
+        .reduce((p, c) => [...p, { x: new Date(c.EndOffsetMillis), y: c.Score }], [{ x: new Date(0), y: 0 }]),
     ); // eslint-disable-line function-paren-newline
 
   logger.debug('sentimentByQuarterPerChannel', sentimentByQuarterPerChannel);

--- a/lma-ai-stack/source/ui/src/components/common/download-func.js
+++ b/lma-ai-stack/source/ui/src/components/common/download-func.js
@@ -45,12 +45,12 @@ export const exportToExcel = async (data, nameFile) => {
   }
 };
 
-export const exportToTextFile = async (text) => {
+export const exportToTextFile = async (text, nameFile) => {
   const blob = new Blob([text], { type: 'text/plain' });
   const url = URL.createObjectURL(blob);
   const link = document.createElement('a');
   link.href = url;
-  link.download = 'call-summary.txt';
+  link.download = `${nameFile}.txt`;
   link.click();
   URL.revokeObjectURL(url);
 };

--- a/lma-ai-stack/source/ui/src/components/common/download-func.js
+++ b/lma-ai-stack/source/ui/src/components/common/download-func.js
@@ -44,3 +44,13 @@ export const exportToExcel = async (data, nameFile) => {
     XLSX.writeFile(wb, `${nameFile}.xlsx`);
   }
 };
+
+export const exportToTextFile = async (text) => {
+  const blob = new Blob([text], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'call-summary.txt';
+  link.click();
+  URL.revokeObjectURL(url);
+};

--- a/lma-ai-stack/source/ui/src/components/common/map-call-attributes.js
+++ b/lma-ai-stack/source/ui/src/components/common/map-call-attributes.js
@@ -53,9 +53,7 @@ const mapCallsAttributes = (calls, settings) => {
       recordingUrl,
       pcaUrl,
       totalConversationDurationMillis,
-      conversationDurationTimeStamp: new Date(totalConversationDurationMillis)
-        .toISOString()
-        .substr(11, 8),
+      conversationDurationTimeStamp: new Date(totalConversationDurationMillis).toISOString().substr(11, 8),
       sentiment,
       // change callTimestamp to a sortable date format
       initiationTimeStamp: new Date(callTimestamp).toISOString(),

--- a/lma-ai-stack/source/ui/src/components/common/sentiment.js
+++ b/lma-ai-stack/source/ui/src/components/common/sentiment.js
@@ -15,9 +15,7 @@ export const getSentimentTrendLabel = (sentimentByQuarter) => {
   if (sentimentByQuarter.length <= 1) {
     return 'FLAT';
   }
-  const sentimentByQuarterValues = sentimentByQuarter
-    .filter((s) => s.EndOffsetMillis > 0)
-    .map((s) => s.Score || 0);
+  const sentimentByQuarterValues = sentimentByQuarter.filter((s) => s.EndOffsetMillis > 0).map((s) => s.Score || 0);
 
   const lastQuarterValue = sentimentByQuarterValues.slice(-1);
   const previousQuarters = sentimentByQuarterValues.slice(0, -1);

--- a/lma-ai-stack/source/ui/src/components/common/summary.js
+++ b/lma-ai-stack/source/ui/src/components/common/summary.js
@@ -77,4 +77,22 @@ export const getTextFileFormattedSummary = (callSummaryText) => {
   return summary;
 };
 
+export const getTextFileFormattedMeetingDetails = (meeting) => {
+  let meetingDetails = '';
+  meetingDetails += `Title: ${meeting.callId}\n`;
+
+  // Not reformatting date in this iteration as it may change timezone from expected
+  //  consider adding this in future iterations
+  // const date = new Date(call.initiationTimeStamp);
+  const date = meeting.initiationTimeStamp;
+  meetingDetails += `Date: ${date}\n`;
+
+  meetingDetails += `Length: ${meeting.conversationDurationTimeStamp}\n`;
+
+  const summary = getTextFileFormattedSummary(meeting.callSummaryText);
+  meetingDetails += `\n\n${summary}`;
+
+  return meetingDetails;
+};
+
 export default getTextOnlySummary;

--- a/lma-ai-stack/source/ui/src/components/common/summary.js
+++ b/lma-ai-stack/source/ui/src/components/common/summary.js
@@ -40,4 +40,41 @@ export const getMarkdownSummary = (callSummaryText) => {
   return summary;
 };
 
+export const getEmailFormattedSummary = (callSummaryText) => {
+  if (!callSummaryText) {
+    return 'Not available';
+  }
+  let summary = callSummaryText;
+  try {
+    const jsonSummary = JSON.parse(summary);
+    summary = '';
+    Object.entries(jsonSummary).forEach(([key, value]) => {
+      summary += `${key}%0D%0A%0D%0A${value}%0D%0A%0D%0A`;
+      summary = summary.replace(/\n/g, '%0D%0A');
+      summary = summary.replace(/\*\*/g, '');
+    });
+  } catch (e) {
+    return callSummaryText;
+  }
+  return summary;
+};
+
+export const getTextFileFormattedSummary = (callSummaryText) => {
+  if (!callSummaryText) {
+    return 'Not available';
+  }
+  let summary = callSummaryText;
+  try {
+    const jsonSummary = JSON.parse(summary);
+    summary = '';
+    Object.entries(jsonSummary).forEach(([key, value]) => {
+      summary += `**${key}**\n\n${value}\n\n`;
+      summary = summary.replace(/\*\*/g, '');
+    });
+  } catch (e) {
+    return callSummaryText;
+  }
+  return summary;
+};
+
 export default getTextOnlySummary;

--- a/lma-ai-stack/source/ui/src/components/common/summary.js
+++ b/lma-ai-stack/source/ui/src/components/common/summary.js
@@ -68,7 +68,7 @@ export const getTextFileFormattedSummary = (callSummaryText) => {
     const jsonSummary = JSON.parse(summary);
     summary = '';
     Object.entries(jsonSummary).forEach(([key, value]) => {
-      summary += `**${key}**\n\n${value}\n\n`;
+      summary += `${key}\n\n${value}\n\n`;
       summary = summary.replace(/\*\*/g, '');
     });
   } catch (e) {

--- a/lma-ai-stack/source/ui/src/components/stream-audio-layout/navigation.jsx
+++ b/lma-ai-stack/source/ui/src/components/stream-audio-layout/navigation.jsx
@@ -4,12 +4,7 @@ import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 import { SideNavigation } from '@awsui/components-react';
 
-import {
-  CALLS_PATH,
-  DEFAULT_PATH,
-  STREAM_AUDIO_PATH,
-  VIRTUAL_PARTICIPANT_PATH,
-} from '../../routes/constants';
+import { CALLS_PATH, DEFAULT_PATH, STREAM_AUDIO_PATH, VIRTUAL_PARTICIPANT_PATH } from '../../routes/constants';
 
 export const callsNavHeader = { text: 'Meeting Analytics', href: `#${DEFAULT_PATH}` };
 export const callsNavItems = [

--- a/lma-ai-stack/source/ui/src/components/stream-audio/StreamAudio.jsx
+++ b/lma-ai-stack/source/ui/src/components/stream-audio/StreamAudio.jsx
@@ -18,11 +18,7 @@ import {
 import '@awsui/global-styles/index.css';
 import useWebSocket from 'react-use-websocket';
 
-import {
-  DEFAULT_OTHER_SPEAKER_NAME,
-  DEFAULT_LOCAL_SPEAKER_NAME,
-  SYSTEM,
-} from '../common/constants';
+import { DEFAULT_OTHER_SPEAKER_NAME, DEFAULT_LOCAL_SPEAKER_NAME, SYSTEM } from '../common/constants';
 import useAppContext from '../../contexts/app';
 import useSettingsContext from '../../contexts/settings';
 import { getTimestampStr } from '../common/utilities';
@@ -215,9 +211,7 @@ const StreamAudio = () => {
       sendMessage(JSON.stringify(recordingCallMetaData));
       setStreamingStarted(true);
 
-      displayAudioSource.current = audioContext.current.createMediaStreamSource(
-        displayStream.current,
-      );
+      displayAudioSource.current = audioContext.current.createMediaStreamSource(displayStream.current);
       micAudioSource.current = audioContext.current.createMediaStreamSource(micStream.current);
 
       const monoDisplaySource = convertToMono(displayAudioSource.current);
@@ -298,11 +292,7 @@ const StreamAudio = () => {
         <Form
           actions={
             <SpaceBetween direction="horizontal" size="xs">
-              <Button
-                variant={recording ? 'secondary' : 'primary'}
-                onClick={handleRecording}
-                disabled={false}
-              >
+              <Button variant={recording ? 'secondary' : 'primary'} onClick={handleRecording} disabled={false}>
                 {recording ? 'Stop Streaming' : 'Start Streaming'}
               </Button>
             </SpaceBetween>
@@ -315,12 +305,7 @@ const StreamAudio = () => {
                 actions={
                   <div>
                     {recording && (
-                      <Button
-                        href={`#/calls/${callMetaData.callId}`}
-                        variant="link"
-                        iconName="external"
-                        target="blank"
-                      >
+                      <Button href={`#/calls/${callMetaData.callId}`} variant="link" iconName="external" target="blank">
                         Open in progress meeting
                       </Button>
                     )}
@@ -348,11 +333,7 @@ const StreamAudio = () => {
                 description="Label for stream audio"
                 errorText={callMetaData.fromNumber.length < 1 && DEFAULT_BLANK_FIELD_MSG}
               >
-                <Input
-                  value={callMetaData.fromNumber}
-                  onChange={handlefromNumberChange}
-                  disabled={recording}
-                />
+                <Input value={callMetaData.fromNumber} onChange={handlefromNumberChange} disabled={recording} />
               </FormField>
 
               <FormField
@@ -363,11 +344,7 @@ const StreamAudio = () => {
                 errorText={callMetaData.agentId.length < 1 && DEFAULT_BLANK_FIELD_MSG}
               >
                 <Grid gridDefinition={[{ colspan: 10 }, { colspan: 1 }]}>
-                  <Input
-                    value={callMetaData.agentId}
-                    onChange={handleAgentIdChange}
-                    disabled={recording}
-                  />
+                  <Input value={callMetaData.agentId} onChange={handleAgentIdChange} disabled={recording} />
                   <Button
                     variant={micMuted ? 'secondary' : 'primary'}
                     onClick={toggleMicrophoneEnabled}

--- a/lma-ai-stack/source/ui/src/components/stream-audio/breadcrumbs.jsx
+++ b/lma-ai-stack/source/ui/src/components/stream-audio/breadcrumbs.jsx
@@ -11,8 +11,6 @@ export const callListBreadcrumbItems = [
   { text: 'Stream Audio', href: `#${STREAM_AUDIO_PATH}` },
 ];
 
-const Breadcrumbs = () => (
-  <BreadcrumbGroup ariaLabel="Breadcrumbs" items={callListBreadcrumbItems} />
-);
+const Breadcrumbs = () => <BreadcrumbGroup ariaLabel="Breadcrumbs" items={callListBreadcrumbItems} />;
 
 export default Breadcrumbs;

--- a/lma-ai-stack/source/ui/src/components/virtual-participant-layout/navigation.jsx
+++ b/lma-ai-stack/source/ui/src/components/virtual-participant-layout/navigation.jsx
@@ -4,12 +4,7 @@ import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 import { SideNavigation } from '@awsui/components-react';
 
-import {
-  CALLS_PATH,
-  DEFAULT_PATH,
-  STREAM_AUDIO_PATH,
-  VIRTUAL_PARTICIPANT_PATH,
-} from '../../routes/constants';
+import { CALLS_PATH, DEFAULT_PATH, STREAM_AUDIO_PATH, VIRTUAL_PARTICIPANT_PATH } from '../../routes/constants';
 
 export const callsNavHeader = { text: 'Meeting Analytics', href: `#${DEFAULT_PATH}` };
 export const callsNavItems = [

--- a/lma-ai-stack/source/ui/src/hooks/use-calls-graphql-api.js
+++ b/lma-ai-stack/source/ui/src/hooks/use-calls-graphql-api.js
@@ -45,9 +45,7 @@ const useCallsGraphQlApi = ({ initialPeriodsToLoad = CALL_LIST_SHARDS_PER_DAY * 
       setErrorMessage('failed to get call details - please try again later');
       logger.error('get call promises rejected', getCallRejected);
     }
-    const callValues = getCallResolutions
-      .filter((r) => r.status === 'fulfilled')
-      .map((r) => r.value?.data?.getCall);
+    const callValues = getCallResolutions.filter((r) => r.status === 'fulfilled').map((r) => r.value?.data?.getCall);
 
     return callValues;
   };
@@ -103,12 +101,8 @@ const useCallsGraphQlApi = ({ initialPeriodsToLoad = CALL_LIST_SHARDS_PER_DAY * 
       const currentBase = currentChannelEntry?.base || '';
       const currentSegments = currentChannelEntry?.segments || [];
       logger.debug('setCallTrancriptPerCallId current segments: ', currentSegments);
-      const lastSameSegmentId = currentSegments
-        .filter((s) => s.segmentId === transcriptSegment.segmentId)
-        .pop();
-      const dedupedSegments = currentSegments.filter(
-        (s) => s.segmentId !== transcriptSegment.segmentId,
-      );
+      const lastSameSegmentId = currentSegments.filter((s) => s.segmentId === transcriptSegment.segmentId).pop();
+      const dedupedSegments = currentSegments.filter((s) => s.segmentId !== transcriptSegment.segmentId);
 
       const segments = [
         ...dedupedSegments,
@@ -183,9 +177,7 @@ const useCallsGraphQlApi = ({ initialPeriodsToLoad = CALL_LIST_SHARDS_PER_DAY * 
     }
     logger.debug('setting up onAddTranscriptSegment subscription');
 
-    subscription = API.graphql(
-      graphqlOperation(onAddTranscriptSegment, { callId: liveTranscriptCallId }),
-    ).subscribe({
+    subscription = API.graphql(graphqlOperation(onAddTranscriptSegment, { callId: liveTranscriptCallId })).subscribe({
       next: async ({ provider, value }) => {
         logger.debug('call transcript subscription update', { provider, value });
         const transcriptSegmentValue = value?.data?.onAddTranscriptSegment;
@@ -299,10 +291,7 @@ const useCallsGraphQlApi = ({ initialPeriodsToLoad = CALL_LIST_SHARDS_PER_DAY * 
 
       // reduce array of date/shard pairs into object of shards by date
       // e.g. [ [ '2021-01-01', 3 ], [ '2021-01-01', 4 ] ] -> { '2021-01-01': [ 3, 4 ] }
-      const dateShards = dateShardPairs.reduce(
-        (p, c) => ({ ...p, [c[0]]: [...(p[c[0]] || []), c[1]] }),
-        {},
-      );
+      const dateShards = dateShardPairs.reduce((p, c) => ({ ...p, [c[0]]: [...(p[c[0]] || []), c[1]] }), {});
       logger.debug('call list date shards', dateShards);
 
       // parallelizes listCalls and getCallDetails
@@ -323,9 +312,7 @@ const useCallsGraphQlApi = ({ initialPeriodsToLoad = CALL_LIST_SHARDS_PER_DAY * 
       } else {
         baseDate = new Date(now - periodsToLoad * hoursInShard * 3600 * 1000);
         const residualBaseHour = baseDate.getUTCHours() % hoursInShard;
-        residualHours = [...Array(hoursInShard - residualBaseHour).keys()].map(
-          (h) => baseDate.getUTCHours() + h,
-        );
+        residualHours = [...Array(hoursInShard - residualBaseHour).keys()].map((h) => baseDate.getUTCHours() + h);
       }
       const baseDateString = baseDate.toISOString().split('T')[0];
 
@@ -395,9 +382,7 @@ const useCallsGraphQlApi = ({ initialPeriodsToLoad = CALL_LIST_SHARDS_PER_DAY * 
           .map((t) => mapTranscriptSegmentValue(t))
           .reduce((p, c) => {
             const previousSegments = p[c.channel]?.segments || [];
-            const lastSameSegmentId = previousSegments
-              .filter((s) => s?.segmentId === c?.segmentId)
-              .pop();
+            const lastSameSegmentId = previousSegments.filter((s) => s?.segmentId === c?.segmentId).pop();
             const dedupedSegments = previousSegments.filter((s) => s.segmentId !== c.segmentId);
 
             // prettier-ignore

--- a/lma-ai-stack/source/ui/src/hooks/use-current-session-creds.js
+++ b/lma-ai-stack/source/ui/src/hooks/use-current-session-creds.js
@@ -9,10 +9,7 @@ const DEFAULT_CREDS_REFRESH_INTERVAL_IN_MS = 60 * 15 * 1000;
 
 const logger = new Logger('useCurrentSessionCreds');
 
-const useCurrentSessionCreds = ({
-  authState,
-  credsIntervalInMs = DEFAULT_CREDS_REFRESH_INTERVAL_IN_MS,
-}) => {
+const useCurrentSessionCreds = ({ authState, credsIntervalInMs = DEFAULT_CREDS_REFRESH_INTERVAL_IN_MS }) => {
   const [currentSession, setCurrentSession] = useState();
   const [currentCredentials, setCurrentCredentials] = useState();
   let interval;

--- a/lma-ai-stack/source/ui/src/hooks/use-notifications.js
+++ b/lma-ai-stack/source/ui/src/hooks/use-notifications.js
@@ -29,9 +29,7 @@ const useNotifications = () => {
     const getDissmissedNotificationIdsFromStorage = () => {
       let dismissedInitialNotificationIds = [];
       try {
-        const dismissedStored = JSON.parse(
-          localStorage.getItem(dismissedInitialNotificationsStorageKey) || '[]',
-        );
+        const dismissedStored = JSON.parse(localStorage.getItem(dismissedInitialNotificationsStorageKey) || '[]');
         if (!Array.isArray(dismissedStored)) {
           logger.warn('invalid format of dismisssed notifications from local storage');
         } else {
@@ -67,10 +65,7 @@ const useNotifications = () => {
       onDismiss: () => {
         setNotifications((current) => current.filter((i) => i.id !== n.id));
         const storedIds = getDissmissedNotificationIdsFromStorage();
-        localStorage.setItem(
-          dismissedInitialNotificationsStorageKey,
-          JSON.stringify([...storedIds, n.id]),
-        );
+        localStorage.setItem(dismissedInitialNotificationsStorageKey, JSON.stringify([...storedIds, n.id]));
       },
     }));
 

--- a/lma-ai-stack/source/ui/src/routes/AuthRoutes.jsx
+++ b/lma-ai-stack/source/ui/src/routes/AuthRoutes.jsx
@@ -43,9 +43,7 @@ const AuthRoutes = ({ redirectParam }) => {
           <CallsRoutes />
         </Route>
         <Route path={LOGIN_PATH}>
-          <Redirect
-            to={!redirectParam || redirectParam === LOGIN_PATH ? DEFAULT_PATH : `${redirectParam}`}
-          />
+          <Redirect to={!redirectParam || redirectParam === LOGIN_PATH ? DEFAULT_PATH : `${redirectParam}`} />
         </Route>
         <Route path={LOGOUT_PATH}>
           <AmplifySignOut />

--- a/lma-ai-stack/source/ui/src/routes/UnauthRoutes.jsx
+++ b/lma-ai-stack/source/ui/src/routes/UnauthRoutes.jsx
@@ -4,12 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
-import {
-  AmplifyAuthContainer,
-  AmplifyAuthenticator,
-  AmplifySignIn,
-  AmplifySignUp,
-} from '@aws-amplify/ui-react';
+import { AmplifyAuthContainer, AmplifyAuthenticator, AmplifySignIn, AmplifySignUp } from '@aws-amplify/ui-react';
 
 import { LOGIN_PATH, LOGOUT_PATH, REDIRECT_URL_PARAM } from './constants';
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-samples/amazon-transcribe-live-meeting-assistant/issues/22

*Description of changes:*
- Additional of download buttons for summary and transcript that are visible once the meeting recording is complete.
- Option to download transcript as text or excel
- Option to download summary as text or to open email with summary (requires your browser/machine to have mailto: functionality correctly configured)

![2024-08-16_14-42-05](https://github.com/user-attachments/assets/07915bcd-042c-47a6-a5dc-808ee0cbb21f)

![2024-08-16_14-42-22](https://github.com/user-attachments/assets/4e76192f-78c2-47aa-852f-4f04d7f704c4)

- Additionally linting rules were adjusted to allow for longer line lengths

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
