### PR TITLE
Fix Non admin users are unable to see meetings started with Virtual Participant

### DIFF
--- a/lma-ai-stack/source/ui/src/components/virtual-participant-layout/MeetingForm.jsx
+++ b/lma-ai-stack/source/ui/src/components/virtual-participant-layout/MeetingForm.jsx
@@ -48,6 +48,9 @@ const MeetingForm = () => {
           meetingName,
           meetingTime: meetingDateTimeFormatted,
           userName,
+          accesstoken: user.signInUserSession.accesstoken,
+          idtoken: user.signInUserSession.idToken.jwtToken,
+          refreshtoken: user.signInUserSession.refreshToken.token,
         },
       }),
     };

--- a/lma-ai-stack/source/ui/src/components/virtual-participant-layout/MeetingForm.jsx
+++ b/lma-ai-stack/source/ui/src/components/virtual-participant-layout/MeetingForm.jsx
@@ -48,9 +48,9 @@ const MeetingForm = () => {
           meetingName,
           meetingTime: meetingDateTimeFormatted,
           userName,
-          accesstoken: user.signInUserSession.accesstoken,
-          idtoken: user.signInUserSession.idToken.jwtToken,
-          refreshtoken: user.signInUserSession.refreshToken.token,
+          accessToken: user.signInUserSession.accessToken.jwtToken,
+          idToken: user.signInUserSession.idToken.jwtToken,
+          rereshToken: user.signInUserSession.refreshToken.token,
         },
       }),
     };

--- a/lma-virtual-participant-stack/backend/src/chime.py
+++ b/lma-virtual-participant-stack/backend/src/chime.py
@@ -16,7 +16,7 @@ async def meeting(page):
     try:
         name_text_element = await page.wait_for_selector('#name')
     except TimeoutError:
-        print("Your scribe was unable to join the meeting.")
+        print("LMA Virtual Participant was unable to join the meeting.")
         return
     else:
         await name_text_element.type(details.lma_identity)
@@ -40,7 +40,7 @@ async def meeting(page):
             timeout=details.waiting_timeout
         )
     except TimeoutError:
-        print("Your scribe was not admitted into the meeting.")
+        print("LMA Virtual Participant was not admitted into the meeting.")
         return
     else:
         await chat_panel_element.click()
@@ -64,7 +64,7 @@ async def meeting(page):
 
     async def attendee_change(number: int):
         if number <= 1:
-            print("Your scribe got lonely and left.")
+            print("LMA Virtual Participant got lonely and left.")
             details.start = False
             await page.goto("about:blank")
 
@@ -116,7 +116,7 @@ async def meeting(page):
             sender = prev_sender
         prev_sender = sender
         if text == details.end_command:
-            print("Your scribe has been removed from the meeting.")
+            print("LMA Virtual Participant has been removed from the meeting.")
             await send_messages(details.exit_messages)
             details.start = False
             await page.goto("about:blank")

--- a/lma-virtual-participant-stack/backend/src/kds.py
+++ b/lma-virtual-participant-stack/backend/src/kds.py
@@ -10,6 +10,9 @@ KINESIS_STREAM_NAME = os.getenv("KINESIS_STREAM_NAME")
 MEETING_NAME = details.meeting_name
 LMA_MEETING_NAME = MEETING_NAME + '-' + \
     datetime.datetime.now().strftime('%Y-%m-%d-%H:%M:%S.%f')[:-3]
+USER_ACCESS_TOKEN = os.getenv("USER_ACCESS_TOKEN")
+USER_ID_TOKEN = os.getenv("USER_ID_TOKEN")
+USER_REFRESH_TOKEN = os.getenv("USER_REFRESH_TOKEN")
 
 KINESIS = boto3.client('kinesis', region_name=REGION)
 
@@ -97,7 +100,10 @@ def send_add_transcript_segment(speaker_name, result):
                 'Sentiment': None,
                 'TranscriptEvent': None,
                 'UtteranceEvent': None,
-                'Speaker': segment['Speaker']
+                'Speaker': segment['Speaker'],
+                'AccessToken': USER_ACCESS_TOKEN,
+                'IdToken': USER_ID_TOKEN,
+                'RefreshToken': USER_REFRESH_TOKEN,
             }
             # Write the messages to the Kinesis Data Stream
             response = KINESIS.put_record(
@@ -120,7 +126,10 @@ def send_start_meeting():
             'CustomerPhoneNumber': 'Customer Phone',
             'SystemPhoneNumber': 'System Phone',
             'AgentId': 'test-agent',
-            'CreatedAt': get_aws_date_now()
+            'CreatedAt': get_aws_date_now(),
+            'AccessToken': USER_ACCESS_TOKEN,
+            'IdToken': USER_ID_TOKEN,
+            'RefreshToken': USER_REFRESH_TOKEN,
         }
         print(
             f"Sending start meeting event to Kinesis. Event: {start_call_event}")
@@ -144,7 +153,10 @@ def send_end_meeting():
             'CallId': LMA_MEETING_NAME,
             'CustomerPhoneNumber': 'Customer Phone',
             'SystemPhoneNumber': 'System Phone',
-            'CreatedAt': get_aws_date_now()
+            'CreatedAt': get_aws_date_now(),
+            'AccessToken': USER_ACCESS_TOKEN,
+            'IdToken': USER_ID_TOKEN,
+            'RefreshToken': USER_REFRESH_TOKEN,
         }
         print(
             f"Sending end meeting event to Kinesis. Event: {start_call_event}")

--- a/lma-virtual-participant-stack/backend/src/kds.py
+++ b/lma-virtual-participant-stack/backend/src/kds.py
@@ -10,6 +10,7 @@ KINESIS_STREAM_NAME = os.getenv("KINESIS_STREAM_NAME")
 MEETING_NAME = details.meeting_name
 LMA_MEETING_NAME = MEETING_NAME + '-' + \
     datetime.datetime.now().strftime('%Y-%m-%d-%H:%M:%S.%f')[:-3]
+USER_NAME = details.lma_identity
 USER_ACCESS_TOKEN = os.getenv("USER_ACCESS_TOKEN")
 USER_ID_TOKEN = os.getenv("USER_ID_TOKEN")
 USER_REFRESH_TOKEN = os.getenv("USER_REFRESH_TOKEN")
@@ -125,7 +126,7 @@ def send_start_meeting():
             'CallId': LMA_MEETING_NAME,
             'CustomerPhoneNumber': 'Customer Phone',
             'SystemPhoneNumber': 'System Phone',
-            'AgentId': 'test-agent',
+            'AgentId': USER_NAME,
             'CreatedAt': get_aws_date_now(),
             'AccessToken': USER_ACCESS_TOKEN,
             'IdToken': USER_ID_TOKEN,

--- a/lma-virtual-participant-stack/backend/src/zoom.py
+++ b/lma-virtual-participant-stack/backend/src/zoom.py
@@ -14,7 +14,7 @@ async def meeting(page):
     try:
         password_text_element = await page.wait_for_selector('#input-for-pwd')
     except TimeoutError:
-        print("Your scribe was unable to join the meeting.")
+        print("LMA Virtual Participant was unable to join the meeting.")
         return
     else:
         await password_text_element.type(details.meeting_password)
@@ -31,7 +31,7 @@ async def meeting(page):
             timeout=details.waiting_timeout
         )
     except TimeoutError:
-        print("Your scribe was not admitted into the meeting.")
+        print("LMA Virtual Participant was not admitted into the meeting.")
         return
     else:
         await audio_button_element.click()
@@ -56,7 +56,7 @@ async def meeting(page):
 
     async def attendee_change(number: int):
         if number <= 1:
-            print("Your scribe got lonely and left.")
+            print("LMA Virtual Participant got lonely and left.")
             details.start = False
             await page.goto("about:blank")
 
@@ -107,7 +107,7 @@ async def meeting(page):
     async def message_change(message):
         print('New Message:', message)
         if details.end_command in message:
-            print("Your scribe has been removed from the meeting.")
+            print("LMA Virtual Participant has been removed from the meeting.")
             details.start = False
             await send_messages(details.exit_messages)
             await page.goto("about:blank")

--- a/lma-virtual-participant-stack/template.yaml
+++ b/lma-virtual-participant-stack/template.yaml
@@ -890,15 +890,15 @@ Resources:
                           },
                           {
                             "Name": "USER_ACCESS_TOKEN",
-                            "Value.$": "$.data.accesstoken"
+                            "Value.$": "$.data.accessToken"
                           },
                           {
                             "Name": "USER_ID_TOKEN",
-                            "Value.$": "$.data.idtoken"
+                            "Value.$": "$.data.idToken"
                           },
                           {
                             "Name": "USER_REFRESH_TOKEN",
-                            "Value.$": "$.data.refreshtoken"
+                            "Value.$": "$.data.rereshToken"
                           }
                         ]
                       }

--- a/lma-virtual-participant-stack/template.yaml
+++ b/lma-virtual-participant-stack/template.yaml
@@ -887,6 +887,18 @@ Resources:
                           {
                             "Name": "LMA_USER",
                             "Value.$": "$.data.userName"
+                          },
+                          {
+                            "Name": "USER_ACCESS_TOKEN",
+                            "Value.$": "$.data.accesstoken"
+                          },
+                          {
+                            "Name": "USER_ID_TOKEN",
+                            "Value.$": "$.data.idtoken"
+                          },
+                          {
+                            "Name": "USER_REFRESH_TOKEN",
+                            "Value.$": "$.data.refreshtoken"
                           }
                         ]
                       }


### PR DESCRIPTION
*Issue #, if available:*
#98 

*Description of changes:*

User tokens are now passed from the Virtual Participant (Preview) UI when starting the fargate task, and included now in the KDS messages from that task, so that they are used in the UBAC attributes and AppSync filters downstream.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
