### PR TITLE
Fix: Use env for virtual-participant language

### DIFF
--- a/lma-main.yaml
+++ b/lma-main.yaml
@@ -208,6 +208,8 @@ Parameters:
       per language - e.g. 'en-US, en-AU' is not allowed.
       Allowed values are: en-US, es-US, en-GB, fr-CA, fr-FR, en-AU, it-IT, de-DE,
       pt-BR, ja-JP, ko-KR, zh-CN, hi-IN, th-TH
+      NOTE: The identify-language feature has not yet been applied to the virtual participant. 
+      If selected, the virtual participant will use the value of TranscribePreferredLanguage (if set) or 'en-US' (by default).
 
   TranscribePreferredLanguage:
     Type: String

--- a/lma-virtual-participant-stack/backend/src/details.py
+++ b/lma-virtual-participant-stack/backend/src/details.py
@@ -12,6 +12,7 @@ email_receiver = os.getenv('EMAIL_RECEIVER', '')
 lma_user = os.getenv('LMA_USER', 'unknown user')
 
 transcribe_language_code = os.getenv('TRANSCRIBE_LANGUAGE_CODE', 'en-US')
+transcribe_preferred_language = os.getenv('TRANSCRIBE_PREFERRED_LANGUAGE', 'en-US')
 
 intro_message = os.environ['INTRO_MESSAGE'].replace('{LMA_USER}', lma_user)
 start_recording_message = os.environ['START_RECORDING_MESSAGE'].replace(

--- a/lma-virtual-participant-stack/backend/src/details.py
+++ b/lma-virtual-participant-stack/backend/src/details.py
@@ -11,6 +11,8 @@ email_receiver = os.getenv('EMAIL_RECEIVER', '')
 
 lma_user = os.getenv('LMA_USER', 'unknown user')
 
+trunscribe_language_code = os.getenv('TRANSCRIBE_LANGUAGE_CODE', 'en-US')
+
 intro_message = os.environ['INTRO_MESSAGE'].replace('{LMA_USER}', lma_user)
 start_recording_message = os.environ['START_RECORDING_MESSAGE'].replace(
     '{LMA_USER}', lma_user)

--- a/lma-virtual-participant-stack/backend/src/details.py
+++ b/lma-virtual-participant-stack/backend/src/details.py
@@ -11,7 +11,7 @@ email_receiver = os.getenv('EMAIL_RECEIVER', '')
 
 lma_user = os.getenv('LMA_USER', 'unknown user')
 
-trunscribe_language_code = os.getenv('TRANSCRIBE_LANGUAGE_CODE', 'en-US')
+transcribe_language_code = os.getenv('TRANSCRIBE_LANGUAGE_CODE', 'en-US')
 
 intro_message = os.environ['INTRO_MESSAGE'].replace('{LMA_USER}', lma_user)
 start_recording_message = os.environ['START_RECORDING_MESSAGE'].replace(

--- a/lma-virtual-participant-stack/backend/src/scribe.py
+++ b/lma-virtual-participant-stack/backend/src/scribe.py
@@ -43,8 +43,18 @@ async def write_audio(stream):
 async def transcribe():
     print("Transcribe starting")
     kds.send_start_meeting()
+    
+    if details.transcribe_language_code in ["identify-language", "identify-multiple-languages"]:
+        print("WARNING: Language identification option has been selected.")
+        if details.transcribe_preferred_language == "None":
+            language_code = "en-US"
+        else:
+            language_code = details.transcribe_preferred_language
+    else:
+        language_code = details.transcribe_language_code
+            
     stream = await TranscribeStreamingClient(region="us-east-1").start_stream_transcription(
-        language_code=details.transcribe_language_code,
+        language_code=language_code,
         media_sample_rate_hz=16000,
         media_encoding="pcm",
     )

--- a/lma-virtual-participant-stack/backend/src/scribe.py
+++ b/lma-virtual-participant-stack/backend/src/scribe.py
@@ -44,7 +44,7 @@ async def transcribe():
     print("Transcribe starting")
     kds.send_start_meeting()
     stream = await TranscribeStreamingClient(region="us-east-1").start_stream_transcription(
-        language_code="en-US",
+        language_code=details.trunscribe_language_code,
         media_sample_rate_hz=16000,
         media_encoding="pcm",
     )

--- a/lma-virtual-participant-stack/backend/src/scribe.py
+++ b/lma-virtual-participant-stack/backend/src/scribe.py
@@ -44,7 +44,7 @@ async def transcribe():
     print("Transcribe starting")
     kds.send_start_meeting()
     stream = await TranscribeStreamingClient(region="us-east-1").start_stream_transcription(
-        language_code=details.trunscribe_language_code,
+        language_code=details.transcribe_language_code,
         media_sample_rate_hz=16000,
         media_encoding="pcm",
     )


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/amazon-transcribe-live-meeting-assistant/issues/117

*Description of changes:*
We have modified the virtual-participant functionality to retrieve the language code for speech recognition from the ECS environment variable "TRANSCRIBE_LANGUAGE_CODE."

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
