### PR TITLE
Add support for Bedrock Guardrails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .aws-sam
 samconfig.toml
 .checksum
+.commit-hash

--- a/lma-main.yaml
+++ b/lma-main.yaml
@@ -46,6 +46,22 @@ Parameters:
     Description: >-
       Select a Bedrock LLM model from the list."
 
+  BedrockGuardrailId:
+    Type: String
+    Default: ""
+    AllowedPattern: "^(|[a-z0-9]+)$"
+    Description: >
+      If MeetingAssistService is 'BEDROCK_LLM' or 'BEDROCK_KNOWLEDGE_BASE', optionally provide the *Id* (not name) of an *existing* 
+      Bedrock Guardrail to be used for Meeting Assist bot.
+
+  BedrockGuardrailVersion:
+    Type: String
+    Default: "DRAFT"
+    AllowedPattern: "^(|(([1-9][0-9]{0,7})|(DRAFT)))$"
+    Description: >
+      If MeetingAssistService is 'BEDROCK_LLM' or 'BEDROCK_KNOWLEDGE_BASE', and you provided a Bedrock Guardrail Id above, provide the 
+      corresponding Guardrail version here.
+
   BedrockKnowledgeBaseId:
     Type: String
     Default: ""
@@ -534,6 +550,11 @@ Metadata:
           - AssistantWakePhraseRegEx
           - MeetingAssistQnABotOpenSearchNodeCount
       - Label:
+          default: Meeting Assist Bedrock Guardrails Integration
+        Parameters:
+          - BedrockGuardrailId
+          - BedrockGuardrailVersion
+      - Label:
           default: Meeting Assist Bedrock Knowledge Base Integration
         Parameters:
           - BedrockKnowledgeBaseId
@@ -629,6 +650,10 @@ Metadata:
         default: Meeting Assist Wake Phrase Regular Expression
       MeetingAssistQnABotOpenSearchNodeCount:
         default: Meeting Assist QnABot OpenSearch Node Count
+      BedrockGuardrailId:
+        default: Bedrock Guardrail Id (optional)
+      BedrockGuardrailVersion:
+        default: Bedrock Guardrail Version (optional)
       BedrockKnowledgeBaseId:
         default: Bedrock Knowledge Base Id (existing)
       BedrockKnowledgeBaseS3BucketName:
@@ -1302,6 +1327,8 @@ Resources:
       EMPTYMESSAGE: "No response from meeting assist QnAbot"
       BEDROCK_KB_RETRIEVE_PROMPT_TEMPLATE: "deprecated"
       BEDROCK_KB_GENERATE_PROMPT_TEMPLATE: "deprecated"
+      ASSISTANT_BEDROCK_GUARDRAIL_ID: !Ref BedrockGuardrailId
+      ASSISTANT_BEDROCK_GUARDRAIL_VERSION: !Ref BedrockGuardrailVersion
       ASSISTANT_QUERY_PROMPT_TEMPLATE:
         "Let's think carefully step by step. Here is
         the JSON transcript of an ongoing meeting: {transcript}<br>And here is a follow

--- a/lma-meetingassist-setup-stack/src/qna_bedrockkb_lambdahook_function.py
+++ b/lma-meetingassist-setup-stack/src/qna_bedrockkb_lambdahook_function.py
@@ -61,8 +61,9 @@ def get_call_transcript(callId, userInput, maxMessages):
     return transcript
 
 
-def get_kb_response(generatePromptTemplate, transcript, query):
-    # if the query has already been labeled "small talk", we can skip
+def get_kb_response(transcript, query, settings):
+
+    # if the query has been labeled "small talk", we can skip
     # ensure the reponse matches the default ASSISTANT_NO_HITS_REGEX value ("Sorry,")
     if query == "small talk":
         resp = {
@@ -70,7 +71,8 @@ def get_kb_response(generatePromptTemplate, transcript, query):
         }
         print("Small talk response: ", json.dumps(resp))
     else:
-        promptTemplate = generatePromptTemplate
+        # create generate prompt
+        promptTemplate = settings.get("ASSISTANT_GENERATE_PROMPT_TEMPLATE")
         promptTemplate = promptTemplate.format(transcript=json.dumps(
             transcript))
         input = {
@@ -90,6 +92,14 @@ def get_kb_response(generatePromptTemplate, transcript, query):
                 'type': 'KNOWLEDGE_BASE'
             }
         }
+        # optional guardrails config
+        guardrailIdentifier = settings.get(
+            "ASSISTANT_BEDROCK_GUARDRAIL_ID", "")
+        if guardrailIdentifier:
+            input["retrieveAndGenerateConfiguration"]["knowledgeBaseConfiguration"]["generationConfiguration"]["guardrailConfiguration"] = {
+                "guardrailId": guardrailIdentifier,
+                "guardrailVersion": settings.get("ASSISTANT_BEDROCK_GUARDRAIL_VERSION", "DRAFT")
+            }
         print("Amazon Bedrock KB Request: ", input)
         try:
             resp = KB_CLIENT.retrieve_and_generate(**input)
@@ -139,12 +149,24 @@ def get_generate_text(modelId, response):
     return generated_text
 
 
-def get_bedrock_response(prompt):
+def get_bedrock_response(prompt, settings):
     modelId = MODEL_ID
     body = get_request_body(modelId, prompt)
-    print("Bedrock request - ModelId", modelId, "-  Body: ", body)
-    response = BEDROCK_CLIENT.invoke_model(body=json.dumps(
-        body), modelId=modelId, accept='application/json', contentType='application/json')
+    args = dict(
+        body=json.dumps(body),
+        modelId=modelId,
+        accept='application/json',
+        contentType='application/json'
+    )
+    # optional guardrails config
+    guardrailIdentifier = settings.get(
+        "ASSISTANT_BEDROCK_GUARDRAIL_ID", "")
+    if guardrailIdentifier:
+        args["guardrailIdentifier"] = guardrailIdentifier
+        args["guardrailVersion"] = settings.get(
+            "ASSISTANT_BEDROCK_GUARDRAIL_VERSION", "DRAFT")
+    print("Bedrock request args - ", args)
+    response = BEDROCK_CLIENT.invoke_model(**args)
     generated_text = get_generate_text(modelId, response)
     print("Bedrock response: ", generated_text)
     return generated_text
@@ -290,18 +312,19 @@ def format_response(event, kb_response, query):
     return event
 
 
-def generateRetrieveQuery(retrievePromptTemplate, transcript, userInput):
+def generateRetrieveQuery(retrievePromptTemplate, transcript, userInput, settings):
     print("Use Bedrock to generate a relevant search query based on the transcript and input")
     promptTemplate = retrievePromptTemplate or "Let's think carefully step by step. Here is the JSON transcript of an ongoing meeting: {transcript}<br>And here is a follow up question or statement in <followUpMessage> tags:<br> <followUpMessage>{input}</followUpMessage><br>Rephrase the follow up question or statement as a standalone, one sentence question. If the caller is just engaging in small talk or saying thanks, respond with \"small talk\". Only output the rephrased question. Do not include any preamble."
     prompt = promptTemplate.format(
         transcript=json.dumps(transcript), input=userInput)
     prompt = prompt.replace("<br>", "\n")
-    query = get_bedrock_response(prompt)
+    query = get_bedrock_response(prompt, settings)
     return query
 
 
 def handler(event, context):
     print("Received event: %s" % json.dumps(event))
+    settings = event["req"]["_settings"]
     args = get_args_from_lambdahook_args(event)
     # Any prompt value defined in the lambdahook args is used as UserInput, e.g used by
     # 'easy button' QIDs like 'Ask Assistant' where user didn't type a question, and we
@@ -319,21 +342,19 @@ def handler(event, context):
     callId = event["req"]["session"].get("callId") or event["req"]["_event"].get(
         "requestAttributes", {}).get("callId")
     if callId:
-        maxMessages = int(event["req"]["_settings"].get(
+        maxMessages = int(settings.get(
             "LLM_CHAT_HISTORY_MAX_MESSAGES", 20))
         transcript = get_call_transcript(callId, userInput, maxMessages)
     else:
         print("no callId in request or session attributes")
 
-    retrievePromptTemplate = event["req"]["_settings"].get(
+    # create retrieve query
+    retrievePromptTemplate = settings.get(
         "ASSISTANT_QUERY_PROMPT_TEMPLATE")
     query = generateRetrieveQuery(
-        retrievePromptTemplate, transcript, userInput)
+        retrievePromptTemplate, transcript, userInput, settings)
 
-    generatePromptTemplate = event["req"]["_settings"].get(
-        "ASSISTANT_GENERATE_PROMPT_TEMPLATE")
-    kb_response = get_kb_response(
-        generatePromptTemplate, transcript, query)
+    kb_response = get_kb_response(transcript, query, settings)
 
     event = format_response(event, kb_response, query)
     print("Returning response: %s" % json.dumps(event))

--- a/lma-meetingassist-setup-stack/src/qna_bedrockkb_lambdahook_function.py
+++ b/lma-meetingassist-setup-stack/src/qna_bedrockkb_lambdahook_function.py
@@ -98,7 +98,7 @@ def get_kb_response(transcript, query, settings):
         if guardrailIdentifier:
             input["retrieveAndGenerateConfiguration"]["knowledgeBaseConfiguration"]["generationConfiguration"]["guardrailConfiguration"] = {
                 "guardrailId": guardrailIdentifier,
-                "guardrailVersion": settings.get("ASSISTANT_BEDROCK_GUARDRAIL_VERSION", "DRAFT")
+                "guardrailVersion": str(settings.get("ASSISTANT_BEDROCK_GUARDRAIL_VERSION", "DRAFT"))
             }
         print("Amazon Bedrock KB Request: ", input)
         try:
@@ -163,8 +163,8 @@ def get_bedrock_response(prompt, settings):
         "ASSISTANT_BEDROCK_GUARDRAIL_ID", "")
     if guardrailIdentifier:
         args["guardrailIdentifier"] = guardrailIdentifier
-        args["guardrailVersion"] = settings.get(
-            "ASSISTANT_BEDROCK_GUARDRAIL_VERSION", "DRAFT")
+        args["guardrailVersion"] = str(settings.get(
+            "ASSISTANT_BEDROCK_GUARDRAIL_VERSION", "DRAFT"))
     print("Bedrock request args - ", args)
     response = BEDROCK_CLIENT.invoke_model(**args)
     generated_text = get_generate_text(modelId, response)

--- a/lma-meetingassist-setup-stack/src/qna_bedrockllm_lambdahook_function.py
+++ b/lma-meetingassist-setup-stack/src/qna_bedrockllm_lambdahook_function.py
@@ -117,8 +117,8 @@ def get_bedrock_response(prompt, settings):
         "ASSISTANT_BEDROCK_GUARDRAIL_ID", "")
     if guardrailIdentifier:
         args["guardrailIdentifier"] = guardrailIdentifier
-        args["guardrailVersion"] = settings.get(
-            "ASSISTANT_BEDROCK_GUARDRAIL_VERSION", "DRAFT")
+        args["guardrailVersion"] = str(settings.get(
+            "ASSISTANT_BEDROCK_GUARDRAIL_VERSION", "DRAFT"))
     print("Bedrock request args - ", args)
     response = BEDROCK_CLIENT.invoke_model(**args)
     generated_text = get_generate_text(modelId, response)

--- a/lma-meetingassist-setup-stack/template.yaml
+++ b/lma-meetingassist-setup-stack/template.yaml
@@ -310,6 +310,10 @@ Resources:
                 Action:
                   - "bedrock:InvokeModel"
                 Resource: !Sub "arn:aws:bedrock:${AWS::Region}::foundation-model/${MeetingAssistServiceBedrockModelID}"
+              - Effect: Allow
+                Action:
+                  - "bedrock:ApplyGuardrail"
+                Resource: '*'
           PolicyName: BedrockPolicy
         - PolicyDocument:
             Version: 2012-10-17
@@ -392,6 +396,10 @@ Resources:
                 Action:
                   - "bedrock:InvokeModel"
                 Resource: !Sub "arn:aws:bedrock:${AWS::Region}::foundation-model/${MeetingAssistServiceBedrockModelID}"
+              - Effect: Allow
+                Action:
+                  - "bedrock:ApplyGuardrail"
+                Resource: '*'
           PolicyName: BedrockPolicy
         - PolicyDocument:
             Version: 2012-10-17
@@ -742,6 +750,10 @@ Resources:
                 Action:
                   - "bedrock:InvokeModel"
                 Resource: !Sub "arn:aws:bedrock:${AWS::Region}::foundation-model/${MeetingAssistServiceBedrockModelID}"
+              - Effect: Allow
+                Action:
+                  - "bedrock:ApplyGuardrail"
+                Resource: '*'
           PolicyName: BedrockInvoke
         - PolicyDocument:
             Version: 2012-10-17

--- a/patches/qnabot/website_js_lib_store_api_actions_settings.js
+++ b/patches/qnabot/website_js_lib_store_api_actions_settings.js
@@ -495,6 +495,14 @@ const settingsMap = {
                         type: 'textarea',
                         hint: 'LLM prompt template for generating an answer to the query, using the transcript and either KB search results and/or LLM knowledge. Not used when the Meeting Assistant service is Q_BUSINESS.',
                     },
+                    {
+                        id: 'ASSISTANT_BEDROCK_GUARDRAIL_ID',
+                        hint: 'Id (not name) of an existing Bedrock Guardrail to be used for Meeting Assist bot. Not used when the Meeting Assistant service is Q_BUSINESS.',
+                    },
+                    {
+                        id: 'ASSISTANT_BEDROCK_GUARDRAIL_VERSION',
+                        hint: 'Version of the above Bedrock Guardrail to be used for Meeting Assist bot. Not used when the Meeting Assistant service is Q_BUSINESS.',
+                    },
                 ],
             },
         },

--- a/publish.sh
+++ b/publish.sh
@@ -116,7 +116,7 @@ local HASH=$(
 echo $HASH
 }
 
-
+# Function to check if any source files in the directory have been changed
 haschanged() {
   local dir=$1
   local checksum_file="${dir}/.checksum"
@@ -136,7 +136,6 @@ haschanged() {
       return 1  # False, the directory has not changed
   fi
 }
-
 update_checksum() {
   local dir=$1
   local checksum_file="${dir}/.checksum"
@@ -148,6 +147,36 @@ update_checksum() {
   echo "$current_checksum" > "$checksum_file"
 }
 
+# Function to check if the submodule commit hash has changed
+hassubmodulechanged() {
+    local dir=$1
+    local hash_file="${dir}/.commit-hash"
+    # Get the current commit hash of the submodule
+    cd "$dir" || exit 1
+    current_hash=$(git rev-parse HEAD)
+    cd - > /dev/null || exit 1
+    # Check if the hash file exists and read the previous hash
+    if [ -f "$hash_file" ]; then
+        previous_hash=$(cat "$hash_file")
+    else
+        previous_hash=""
+    fi
+    if [ "$current_hash" != "$previous_hash" ]; then
+        return 0  # True, the submodule has changed
+    else
+        return 1  # False, the submodule has not changed
+    fi
+}
+update_submodule_hash() {
+    local dir=$1
+    local hash_file="${dir}/.commit-hash"
+    # Get the current commit hash of the submodule
+    cd "$dir" || exit 1
+    current_hash=$(git rev-parse HEAD)
+    cd - > /dev/null || exit 1
+    # Save the current hash
+    echo "$current_hash" > "$hash_file"
+}
 
 dir=lma-browser-extension-stack
 cd $dir
@@ -281,7 +310,6 @@ dir=lma-llm-template-setup-stack
 if haschanged $dir; then
 echo "PACKAGING $dir/deployment"
 pushd $dir/deployment
-
 # by hashing the contents of the source folder, we can force the custom resource lambda to re-run
 # when the code or prompt template contents change.
 echo "Computing hash of src folder contents"
@@ -309,7 +337,7 @@ echo "SKIPPING $dir (unchanged)"
 fi
 
 dir=submodule-aws-qnabot
-echo "PACKAGING $dir"
+echo "UPDATING $dir"
 git submodule init
 echo "Removing any QnAbot changes from previous builds"
 pushd $dir && git checkout . && popd
@@ -326,10 +354,8 @@ if sed --version 2>/dev/null | grep -q GNU; then # GNU sed
 else # BSD like sed
   sed -i '' 's/"version": *"\([0-9]*\.[0-9]*\.[0-9]*\)"/"version": "\1-lma"/' $dir/source/package.json
 fi
-if haschanged $dir; then
-pushd $dir/source
-mkdir -p build/templates/dev
-cat > config.json <<_EOF
+echo "Creating config.json"
+cat > $dir/source/config.json <<_EOF
 {
   "profile": "${AWS_PROFILE:-default}",
   "region": "${REGION}",
@@ -338,6 +364,14 @@ cat > config.json <<_EOF
   "noStackOutput": true
 }
 _EOF
+
+# only re-build QnABot if patch files or submodule version has changed
+if haschanged ./patches/qnabot || hassubmodulechanged $dir; then
+
+echo "PACKAGING $dir"
+
+pushd $dir/source
+mkdir -p build/templates/dev
 npm install
 npm run build || exit 1
 # Rename OpenbsearchDomain resource in template to force resource replacement during upgrade/downgrade
@@ -346,7 +380,8 @@ npm run build || exit 1
 cat ./build/templates/master.json | sed -e "s%OpensearchDomain%LMAQnaBotOpensearchDomain%g" > ./build/templates/qnabot-main.json
 aws s3 sync ./build/ s3://${BUCKET}/${PREFIX_AND_VERSION}/aws-qnabot/ --delete 
 popd
-update_checksum $dir
+update_checksum ./patches/qnabot
+update_submodule_hash $dir
 else
 echo "SKIPPING $dir (unchanged)"
 fi


### PR DESCRIPTION
*Issue #, if available:*
#51 

*Description of changes:*

Add optional support to apply a specified Bedrock Guardrail to Meeting Assistant queries when Meeting Assistant Service is BEDROCK_LLM or BEDROCK_KNOWLEDGE_BASE

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
