### PR TITLE
sam build --use-image and python 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Publish script fails to detect make failure in lca-ai-stack during build - Issue #111
 - When publishing, AISTACK `make` fails to find bash with new version of gnu make (4.3) - Issue #110
 - Muliple dependabot PRs
-
+- Upgrade all python Lambda functions to python3.12 (latest)
+- Publish script hangs in lma-ui-stack in sam build when using arm64 container image, on new EC2 and Cloud9 instances #124
 
 ## [0.2.1] - 2024-08-29
 

--- a/lma-ai-stack/Makefile
+++ b/lma-ai-stack/Makefile
@@ -295,6 +295,7 @@ $(PACKAGE_RELEASE_OUT_FILE): $(PACKAGE_RELEASE_REPLACE_OUT_FILE) | $(OUT_DIR)
 	@echo '[INFO] sam building template file for release $(RELEASE_VERSION)'
 	sam build \
 		--use-container \
+		--build-image public.ecr.aws/sam/build-python3.12:latest-x86_64 \
 		--parallel \
 		--cached \
 		--template-file '$(PACKAGE_RELEASE_REPLACE_OUT_FILE)' \

--- a/lma-ai-stack/deployment/lma-ai-stack.yaml
+++ b/lma-ai-stack/deployment/lma-ai-stack.yaml
@@ -746,7 +746,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Role: !GetAtt LambdaCodeBuildStartBuildExecutionRole.Arn
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 60
       MemorySize: 128
       Handler: lambda_start_codebuild.handler
@@ -791,7 +791,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Role: !GetAtt LambdaFetchTranscriptExecutionRole.Arn
-      Runtime: python3.11
+      Runtime: python3.12
       Environment:
         Variables:
           LCA_CALL_EVENTS_TABLE: !Ref EventSourcingTable
@@ -849,7 +849,7 @@ Resources:
     Condition: ShouldEnableBedrockSummarizer
     Properties:
       Role: !GetAtt BedrockSummaryLambdaExecutionRole.Arn
-      Runtime: python3.11
+      Runtime: python3.12
       Environment:
         Variables:
           BEDROCK_MODEL_ID: !Ref BedrockModelId
@@ -932,7 +932,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Role: !GetAtt AsyncAgentAssistOrchestratorExecutionRole.Arn
-      Runtime: python3.11
+      Runtime: python3.12
       Environment:
         Variables:
           CALL_DATA_STREAM_NAME: !Ref CallDataStream
@@ -1012,7 +1012,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Role: !GetAtt AsyncTranscriptSummaryOrchestratorExecutionRole.Arn
-      Runtime: python3.11
+      Runtime: python3.12
       Environment:
         Variables:
           TRANSCRIPT_SUMMARY_FUNCTION_ARN:
@@ -1201,7 +1201,7 @@ Resources:
               Action:
                 - lambda:InvokeFunction
               Resource: !GetAtt AsyncAgentAssistOrchestrator.Arn
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 900
       Environment:
         Variables:
@@ -1255,14 +1255,14 @@ Resources:
   TranscriptEnrichmentPythonLayer:
     Type: AWS::Serverless::LayerVersion
     Metadata:
-      BuildMethod: python3.11
+      BuildMethod: python3.12
     Properties:
       Description: !Sub "Transcript Enrichment Python Layer for stack: ${AWS::StackName}"
       ContentUri: ../source/lambda_layers/transcript_enrichment_layer
       CompatibleArchitectures:
         - arm64
       CompatibleRuntimes:
-        - python3.11
+        - python3.12
       RetentionPolicy: Delete
 
   ##########################################################################
@@ -1687,7 +1687,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Handler: "index.lambda_handler"
-      Runtime: python3.11
+      Runtime: python3.12
       MemorySize: 128
       Timeout: 60
       Role: !GetAtt BucketDeleteLambdaRole.Arn

--- a/lma-ai-stack/ml-stacks/bedrock-preview-boto3-stack.yaml
+++ b/lma-ai-stack/ml-stacks/bedrock-preview-boto3-stack.yaml
@@ -45,7 +45,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Role: !GetAtt 'BedrockBoto3ZipFunctionRole.Arn'
       Timeout: 60
       MemorySize: 512
@@ -163,7 +163,7 @@ Resources:
         S3Bucket: !GetAtt BedrockBoto3Zip.Bucket
         S3Key: !GetAtt BedrockBoto3Zip.Key
       CompatibleRuntimes:
-      - python3.11
+      - python3.12
 
 Outputs:
 

--- a/lma-ai-stack/source/lambda_functions/async_agent_assist_orchestrator/lambda_function.py
+++ b/lma-ai-stack/source/lambda_functions/async_agent_assist_orchestrator/lambda_function.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.11
+#!/usr/bin/env python3.12
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/lma-ai-stack/source/lambda_functions/async_transcript_summary_orchestrator/lambda_function.py
+++ b/lma-ai-stack/source/lambda_functions/async_transcript_summary_orchestrator/lambda_function.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.11
+#!/usr/bin/env python3.12
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/lma-ai-stack/source/lambda_functions/call_event_processor/lambda_function.py
+++ b/lma-ai-stack/source/lambda_functions/call_event_processor/lambda_function.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.11
+#!/usr/bin/env python3.12
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """ Transcription Passthrough Lambda Function
@@ -44,7 +44,8 @@ else:
     SSMClient = object
 
 APPSYNC_GRAPHQL_URL = environ["APPSYNC_GRAPHQL_URL"]
-APPSYNC_CLIENT = AppsyncAioGqlClient(url=APPSYNC_GRAPHQL_URL, fetch_schema_from_transport=True)
+APPSYNC_CLIENT = AppsyncAioGqlClient(
+    url=APPSYNC_GRAPHQL_URL, fetch_schema_from_transport=True)
 
 BOTO3_SESSION: Boto3Session = boto3.Session()
 CLIENT_CONFIG = BotoCoreConfig(
@@ -56,32 +57,40 @@ STATE_DYNAMODB_RESOURCE: DynamoDBServiceResource = BOTO3_SESSION.resource(
     "dynamodb",
     config=CLIENT_CONFIG,
 )
-STATE_DYNAMODB_TABLE: DynamoDbTable = STATE_DYNAMODB_RESOURCE.Table(STATE_DYNAMODB_TABLE_NAME)
+STATE_DYNAMODB_TABLE: DynamoDbTable = STATE_DYNAMODB_RESOURCE.Table(
+    STATE_DYNAMODB_TABLE_NAME)
 
-IS_LEX_AGENT_ASSIST_ENABLED = getenv("IS_LEX_AGENT_ASSIST_ENABLED", "true").lower() == "true"
+IS_LEX_AGENT_ASSIST_ENABLED = getenv(
+    "IS_LEX_AGENT_ASSIST_ENABLED", "true").lower() == "true"
 
-IS_LAMBDA_AGENT_ASSIST_ENABLED = getenv("IS_LAMBDA_AGENT_ASSIST_ENABLED", "true").lower() == "true"
+IS_LAMBDA_AGENT_ASSIST_ENABLED = getenv(
+    "IS_LAMBDA_AGENT_ASSIST_ENABLED", "true").lower() == "true"
 
-IS_SENTIMENT_ANALYSIS_ENABLED = getenv("IS_SENTIMENT_ANALYSIS_ENABLED", "true").lower() == "true"
+IS_SENTIMENT_ANALYSIS_ENABLED = getenv(
+    "IS_SENTIMENT_ANALYSIS_ENABLED", "true").lower() == "true"
 if IS_SENTIMENT_ANALYSIS_ENABLED:
-    COMPREHEND_CLIENT: ComprehendClient = BOTO3_SESSION.client("comprehend", config=CLIENT_CONFIG)
+    COMPREHEND_CLIENT: ComprehendClient = BOTO3_SESSION.client(
+        "comprehend", config=CLIENT_CONFIG)
 else:
     COMPREHEND_CLIENT = None
 COMPREHEND_LANGUAGE_CODE = getenv("COMPREHEND_LANGUAGE_CODE", "en")
 
-SNS_CLIENT:SNSClient = BOTO3_SESSION.client("sns", config=CLIENT_CONFIG)
-SSM_CLIENT:SSMClient = BOTO3_SESSION.client("ssm", config=CLIENT_CONFIG)
+SNS_CLIENT: SNSClient = BOTO3_SESSION.client("sns", config=CLIENT_CONFIG)
+SSM_CLIENT: SSMClient = BOTO3_SESSION.client("ssm", config=CLIENT_CONFIG)
 
 LOGGER = Logger(location="%(filename)s:%(lineno)d - %(funcName)s()")
 
 EVENT_LOOP = asyncio.get_event_loop()
 
-setting_response = SSM_CLIENT.get_parameter(Name=getenv("PARAMETER_STORE_NAME"))
+setting_response = SSM_CLIENT.get_parameter(
+    Name=getenv("PARAMETER_STORE_NAME"))
 SETTINGS = json.loads(setting_response["Parameter"]["Value"])
 if "CategoryAlertRegex" in SETTINGS:
     SETTINGS['AlertRegEx'] = re.compile(SETTINGS["CategoryAlertRegex"])
 if "AssistantWakePhraseRegEx" in SETTINGS:
-    SETTINGS['AssistantWakePhraseRegEx'] = re.compile(SETTINGS["AssistantWakePhraseRegEx"])
+    SETTINGS['AssistantWakePhraseRegEx'] = re.compile(
+        SETTINGS["AssistantWakePhraseRegEx"])
+
 
 async def process_event(event) -> Dict[str, List]:
     """Processes a Batch of Transcript Records"""
@@ -104,14 +113,17 @@ async def process_event(event) -> Dict[str, List]:
 
     return processor.results
 
+
 @LOGGER.inject_lambda_context
 def handler(event, context: LambdaContext):
     # pylint: disable=unused-argument
     """Lambda handler"""
     LOGGER.debug("lambda event", extra={"event": event})
 
-    event_processor_results = EVENT_LOOP.run_until_complete(process_event(event=event))
-    LOGGER.debug("event processor results", extra=dict(event_results=event_processor_results))
+    event_processor_results = EVENT_LOOP.run_until_complete(
+        process_event(event=event))
+    LOGGER.debug("event processor results", extra=dict(
+        event_results=event_processor_results))
 
     for error in event_processor_results.get("errors", []):
         LOGGER.error("event processor error: %s", error)
@@ -121,4 +133,4 @@ def handler(event, context: LambdaContext):
             except Exception:  # pylint: disable=broad-except
                 LOGGER.exception("event processor exception")
 
-    return 
+    return

--- a/lma-ai-stack/source/lambda_layers/transcript_enrichment_layer/requirements.txt
+++ b/lma-ai-stack/source/lambda_layers/transcript_enrichment_layer/requirements.txt
@@ -1,6 +1,6 @@
 # keep in sync with local dev dependencies in requirements-dev.txt
 boto3~=1.22.12
-gql[botocore,aiohttp,requests]~=3.2.0
+gql[botocore,aiohttp,requests]~=3.5.0
 aws-lambda-powertools~=1.25.10
 phonenumbers~=8.12.51
 pyjwt

--- a/lma-bedrockkb-stack/template.yaml
+++ b/lma-bedrockkb-stack/template.yaml
@@ -190,7 +190,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 30
       InlineCode: |
         import cfnresponse
@@ -213,7 +213,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 30
       InlineCode: |
         import cfnresponse
@@ -289,7 +289,7 @@ Resources:
     Type: AWS::Lambda::LayerVersion
     Properties:
       CompatibleRuntimes:
-        - python3.11
+        - python3.12
       Content: ./opensearchpy_layer
       Description: opensearchpy layer including requests, requests-aws4auth, and boto3-1.34.82
       LicenseInfo: Apache-2.0
@@ -376,7 +376,7 @@ Resources:
         Fn::GetAtt:
           - OSSSetupLambdaFunctionRole
           - Arn
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 840
       Code: ./src/oss_setup
       Layers:
@@ -621,7 +621,7 @@ Resources:
     Properties:
       Handler: handler.lambda_handler
       Role: !GetAtt "WebCrawlerKBDataSourceFunctionRole.Arn"
-      Runtime: python3.11
+      Runtime: python3.12
       Layers:
         - !Ref OpenSearchPyLayer
       Timeout: 600

--- a/lma-browser-extension-stack/template.yaml
+++ b/lma-browser-extension-stack/template.yaml
@@ -217,7 +217,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt LambdaExecutionRole.Arn
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 300
       MemorySize: 128
       Handler: index.handler

--- a/lma-cognito-stack/deployment/lma-cognito-stack.yaml
+++ b/lma-cognito-stack/deployment/lma-cognito-stack.yaml
@@ -187,7 +187,7 @@ Resources:
     Properties:
       Description: Returns the lowercase version of a string
       MemorySize: 256
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.lambda_handler
       Role: !GetAtt GetDomainLambdaRole.Arn
       Timeout: 30

--- a/lma-llm-template-setup-stack/deployment/llm-template-setup.yaml
+++ b/lma-llm-template-setup-stack/deployment/llm-template-setup.yaml
@@ -71,7 +71,7 @@ Resources:
       Code: ../source/lambda_functions
       Handler: llm_prompt_upload.lambda_handler
       Role: !GetAtt LLMPromptUploadRole.Arn
-      Runtime: python3.11
+      Runtime: python3.12
       MemorySize: 128
       Timeout: 60
       Environment:

--- a/lma-main.yaml
+++ b/lma-main.yaml
@@ -813,7 +813,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.11
+      Runtime: python3.12
       InlineCode: |
         import cfnresponse
         import time
@@ -885,7 +885,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Role: !GetAtt ValidateParametersFunctionRole.Arn
       Timeout: 60
       InlineCode: |
@@ -1044,7 +1044,7 @@ Resources:
     Properties:
       Role: !GetAtt UpdateLMASettingsFunctionRole.Arn
       Handler: index.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 900
       Code:
         ZipFile: |
@@ -1160,7 +1160,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.11
+      Runtime: python3.12
       InlineCode: |
         import cfnresponse
         import json

--- a/lma-meetingassist-setup-stack/template.yaml
+++ b/lma-meetingassist-setup-stack/template.yaml
@@ -181,7 +181,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 30
       InlineCode: |
         import cfnresponse
@@ -248,7 +248,7 @@ Resources:
       FunctionName: !Sub "QNA-SummarizeCall-${LMAStackName}"
       Role: !GetAtt LambdaHookSummarizeCallRole.Arn
       Handler: qna_summarize_call_function.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 900
       Environment:
         Variables:
@@ -282,7 +282,7 @@ Resources:
     Properties:
       Content: ./boto3_layer
       CompatibleRuntimes:
-        - python3.11
+        - python3.12
 
   QNABedrockKnowledgeBaseFunctionRole:
     Condition: ShouldConfigureBedrockKB
@@ -344,7 +344,7 @@ Resources:
       FunctionName: !Sub "QNA-${LMAStackName}-BedrockKB-LambdaHook"
       Role: !GetAtt QNABedrockKnowledgeBaseFunctionRole.Arn
       Handler: qna_bedrockkb_lambdahook_function.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Layers:
         - !Ref Boto3Layer
       Timeout: 900
@@ -425,7 +425,7 @@ Resources:
       FunctionName: !Sub "QNA-${LMAStackName}-BedrockLLM-LambdaHook"
       Role: !GetAtt QNABedrockLLMFunctionRole.Arn
       Handler: qna_bedrockllm_lambdahook_function.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Layers:
         - !Ref Boto3Layer
       Timeout: 900
@@ -549,7 +549,7 @@ Resources:
     Properties:
       Role: !GetAtt SetupFunctionRole.Arn
       Handler: setup_function.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 900
       Code: ./src
       LoggingConfig:


### PR DESCRIPTION
*Issue #, if available:*
#124 

Build hangs appear to be a recent docker reliability issue running an arm64 container from sam build, on an x86 machine.
The fix is to use an x86 docker image in sam build, using the --build-image arg - it appears that it works to use an x86 container to build the arm64 lambda function and lambda layer artifacts.
Fix is in the lma-ai-stack Makefile:

sam build
--use-container
--build-image public.ecr.aws/sam/build-python3.12:latest-x86_64
--parallel
--cached
--template-file 'out/template-replaced-bobs-artifacts-us-east-1-lma-python312_0.9.2_lca-ai-stack-0.9.2.yaml'

Also updates all Lambda functions to use python3.12
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
