### PR TITLE
replace url unsafe characters with | to avoid problem opening meetings

### DIFF
--- a/lma-ai-stack/source/ui/src/components/virtual-participant-layout/MeetingForm.jsx
+++ b/lma-ai-stack/source/ui/src/components/virtual-participant-layout/MeetingForm.jsx
@@ -81,7 +81,10 @@ const MeetingForm = () => {
       <Form variant="embedded">
         <SpaceBetween direction="vertical" size="l">
           <FormField label="Meeting Name">
-            <Input onChange={({ detail }) => setMeetingName(detail.value)} value={meetingName} />
+            <Input
+              onChange={({ detail }) => setMeetingName(detail.value.replace(/[/?#%+&]/g, '|'))}
+              value={meetingName}
+            />
           </FormField>
           <FormField label="Meeting Platform">
             <Select


### PR DESCRIPTION
*Issue #, if available:*
#142 

*Description of changes:*
replace url unsafe characters with | to avoid problem opening meetings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
