### PR TITLE
Fix to getCall query resolver logic

### DIFF
--- a/lma-ai-stack/source/appsync/getCall.response.vtl
+++ b/lma-ai-stack/source/appsync/getCall.response.vtl
@@ -2,17 +2,10 @@
   $util.error($ctx.error.message, $ctx.error.type)
 #end
 
-#if($context.result.items.size() > 0 && !$context.identity.groups.contains("Admin"))
-  #set($ownerFilter = [])
-  #foreach($item in $context.result.items)
-    #if("$item.owner" == "$context.identity.username")
-      $util.qr($ownerFilter.add($item))
-    #end
-  #end
-  {
-    "items": $ownerFilter,
-    "nextToken": "$context.result.nextToken"
-  }
+#if(!$context.identity.groups.contains("Admin")
+    && $context.result.Owner != $context.identity.username
+    && !$context.result.SharedWith.contains($context.identity.username))
+      $util.error("User $context.identity.username is not authorized", "AuthorizationError")
 #else
   $utils.toJson($context.result)
 #end


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixed a bug in getCall resolver that was incorrectly looking at a non-existent field used to filter calls based on ownership essentially letting any user to get the call details by placing the callId into the LMA url. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
