### PR TITLE
Adding support for Claude Sonnet 3.7

### DIFF
--- a/lma-ai-stack/deployment/lma-ai-stack.yaml
+++ b/lma-ai-stack/deployment/lma-ai-stack.yaml
@@ -184,6 +184,7 @@ Parameters:
       - "anthropic.claude-3-sonnet-20240229-v1:0"
       - "anthropic.claude-3-5-sonnet-20240620-v1:0"
       - "anthropic.claude-3-5-sonnet-20241022-v2:0"
+      - "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
 
     Description: >
       If EndOfCallTranscriptSummary is BEDROCK, then choose a model ID from the list
@@ -953,9 +954,11 @@ Resources:
               - Effect: Allow
                 Action:
                   - "bedrock:InvokeModel"
+                  - "bedrock:GetInferenceProfile"
                 Resource:
                   - !Sub "arn:${AWS::Partition}:bedrock:*::foundation-model/*"
                   - !Sub "arn:${AWS::Partition}:bedrock:*:${AWS::AccountId}:custom-model/*"
+                  - !Sub "arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/*"
         - PolicyName: !Sub ${AWS::StackName}-S3
           PolicyDocument:
             Version: 2012-10-17
@@ -1406,7 +1409,10 @@ Resources:
               - Effect: Allow
                 Action:
                   - "bedrock:InvokeModel"
-                Resource: !Sub "arn:aws:bedrock:${AWS::Region}::foundation-model/${BedrockModelId}"
+                  - "bedrock:GetInferenceProfile"
+                Resource:
+                  - !Sub "arn:aws:bedrock:${AWS::Region}::foundation-model/${BedrockModelId}"
+                  - !Sub "arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/*"
 
   AppSyncLambdaRole:
     Type: AWS::IAM::Role

--- a/lma-main.yaml
+++ b/lma-main.yaml
@@ -46,6 +46,7 @@ Parameters:
       - "anthropic.claude-3-sonnet-20240229-v1:0"
       - "anthropic.claude-3-5-sonnet-20240620-v1:0"
       - "anthropic.claude-3-5-sonnet-20241022-v2:0"
+      - "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
     Description: >-
       Select a Bedrock LLM model from the list."
 
@@ -359,6 +360,7 @@ Parameters:
       - "anthropic.claude-3-sonnet-20240229-v1:0"
       - "anthropic.claude-3-5-sonnet-20240620-v1:0"
       - "anthropic.claude-3-5-sonnet-20241022-v2:0"
+      - "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
     Description: >
       If EndOfCallTranscriptSummary is BEDROCK, then choose a model ID from the list
       of supported models.  Defaults to 'anthropic.claude-3-haiku-20240307-v1:0'
@@ -970,7 +972,10 @@ Resources:
               - Effect: Allow
                 Action:
                   - "bedrock:InvokeModel"
-                Resource: !Sub "arn:aws:bedrock:${AWS::Region}::foundation-model/*"
+                  - "bedrock:GetInferenceProfile"
+                Resource:
+                  - !Sub "arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/*"
+                  - !Sub "arn:aws:bedrock:${AWS::Region}::foundation-model/*"
           PolicyName: BedrockPolicy
 
   ValidateParametersFunction:


### PR DESCRIPTION
Adding support for Claude Sonnet 3.7 + cross-region inference. 

*Issue #, if available:*
Claude 3.7 Sonnet was not available as an option for meeting summarization. IAM role created for ValidateParametersFunctionRole did not have GetInferenceProfile permissions. 

*Description of changes:*
Updated .yaml templates to add options to configs and updated the ValidateParametersFunctionRole IAM definition to enable the use of inference profiles.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
