### PR TITLE
Fix: Virtual participant stack

### DIFF
--- a/lma-virtual-participant-stack/backend/requirements.txt
+++ b/lma-virtual-participant-stack/backend/requirements.txt
@@ -3,4 +3,3 @@ boto3
 pytest-playwright 
 requests
 sounddevice
-wave


### PR DESCRIPTION
Issue: When deploying LMA, the VirtualParticipantStack fails to create due to BuildCustomResourceFunction resource.
Fix: Remove wave package from requirements.txt file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
