### PR TITLE
feat(iam): Add CloudFormation service role template for non-admin LMA deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
+- **CloudFormation Service Role** — New deployable CloudFormation template (`iam-roles/cloudformation-management/`) that creates a delegated service role for non-admin LMA deployment. Administrators deploy the role once; developers then use `lma-cli deploy --role-arn` or the CloudFormation console to deploy LMA without needing admin permissions. See [CloudFormation Service Role guide](docs/cloudformation-service-role.md).
+
 - **LMA CLI & SDK** (`lma-cli`, `lma-sdk`) — New Python CLI and SDK for building, deploying, and managing LMA stacks from the command line. Key commands: `lma deploy` (auto-selects public template by region, `--from-code` for build+deploy, `--wait` with real-time event streaming, `--admin-email` for new stacks), `lma publish` (build and upload artifacts to S3 with change detection), `lma status/outputs/delete/logs`. See [LMA CLI Reference](docs/lma-cli.md).
 
 - **Documentation Overhaul** - Updated documents reflect new features and remove deprecated feature references. See ./docs.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -51,6 +51,7 @@ title: "LMA Documentation"
 
 - [User-Based Access Control](user-based-access-control.md) — Admin vs non-admin users, meeting sharing, meeting deletion
 - [Infrastructure & Security](infrastructure-and-security.md) — Architecture overview, VPC, Cognito, KMS encryption, CloudFront, IAM, data retention
+- [CloudFormation Service Role](cloudformation-service-role.md) — Delegated IAM role for non-admin LMA deployment and management
 
 ### Integration & API
 

--- a/docs/cloudformation-service-role.md
+++ b/docs/cloudformation-service-role.md
@@ -1,0 +1,169 @@
+---
+title: "CloudFormation Service Role"
+---
+
+# CloudFormation Service Role for LMA Deployment
+
+This guide explains how to create a dedicated IAM CloudFormation service role for deploying, managing, and modifying Live Meeting Assistant (LMA) stacks — without requiring administrator access for every deployment.
+
+The CloudFormation template is located at [`iam-roles/cloudformation-management/LMA-Cloudformation-Service-Role.yaml`](../iam-roles/cloudformation-management/LMA-Cloudformation-Service-Role.yaml).
+
+## Why Use a CloudFormation Service Role?
+
+By default, CloudFormation operations use the caller's IAM permissions. This means anyone deploying LMA needs broad AWS access. A **CloudFormation service role** decouples deployment permissions from user permissions:
+
+- **Administrators** deploy the service role once with their elevated privileges
+- **Developer/DevOps users** can then deploy and manage LMA stacks by passing this role to CloudFormation — without needing admin permissions themselves
+- **Operational teams** can maintain the solution without ongoing administrator access
+- **Security teams** can audit a single role rather than individual user policies
+
+## How It Works
+
+The template creates two resources:
+
+1. **CloudFormationServiceRole** — An IAM role that only `cloudformation.amazonaws.com` can assume. It has four inline policies covering all ~30 AWS services required by LMA.
+2. **PassRolePolicy** — A managed policy that grants `iam:PassRole` for the service role. Attach this to users or roles that need to deploy LMA.
+
+```
+┌─────────────────┐     iam:PassRole     ┌───────────────────┐     sts:AssumeRole     ┌──────────────┐
+│   IAM User or   │ ──────────────────► │  CloudFormation   │ ──────────────────────► │  LMA Service │
+│   Developer     │                      │  Service          │                         │  Role        │
+└─────────────────┘                      └───────────────────┘                         └──────┬───────┘
+                                                                                              │
+                                                                                    Creates/Updates/Deletes
+                                                                                              │
+                                                                                              ▼
+                                                                                     ┌──────────────┐
+                                                                                     │  LMA Stack   │
+                                                                                     │  Resources   │
+                                                                                     └──────────────┘
+```
+
+## Deploying the Service Role
+
+### Prerequisites
+
+- AWS Administrator access (one-time setup)
+- AWS CLI configured with appropriate credentials
+
+### Via CLI
+
+```bash
+cd iam-roles/cloudformation-management/
+
+aws cloudformation deploy \
+  --template-file LMA-Cloudformation-Service-Role.yaml \
+  --stack-name LMA-CFServiceRole \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --region <your-region>
+```
+
+### Via Console
+
+1. Open the AWS CloudFormation console
+2. Click **Create stack** → **With new resources (standard)**
+3. Select **Upload a template file** and choose `LMA-Cloudformation-Service-Role.yaml`
+4. Set **Stack name** to `LMA-CFServiceRole` (or your preferred name)
+5. Click through **Next**, acknowledge IAM capabilities, and **Submit**
+6. Wait for `CREATE_COMPLETE`
+7. Copy the **ServiceRoleArn** from the **Outputs** tab
+
+## Assigning the PassRole Policy to Users
+
+After deploying the service role stack, attach the `PassRolePolicy` to users or roles who need to deploy LMA:
+
+```bash
+# Get the PassRole policy ARN from stack outputs
+POLICY_ARN=$(aws cloudformation describe-stacks \
+  --stack-name LMA-CFServiceRole \
+  --query 'Stacks[0].Outputs[?OutputKey==`PassRolePolicyArn`].OutputValue' \
+  --output text)
+
+# Attach to a user
+aws iam attach-user-policy --user-name <username> --policy-arn $POLICY_ARN
+
+# Or attach to a role
+aws iam attach-role-policy --role-name <role-name> --policy-arn $POLICY_ARN
+```
+
+## Using the Service Role to Deploy LMA
+
+### Via LMA CLI (recommended)
+
+The `lma-cli deploy` command supports `--role-arn`:
+
+```bash
+# Get the service role ARN
+ROLE_ARN=$(aws cloudformation describe-stacks \
+  --stack-name LMA-CFServiceRole \
+  --query 'Stacks[0].Outputs[?OutputKey==`ServiceRoleArn`].OutputValue' \
+  --output text)
+
+# Deploy LMA
+lma-cli deploy --stack-name MyLMA --admin-email user@example.com --role-arn $ROLE_ARN --wait
+```
+
+### Via AWS CLI
+
+```bash
+ROLE_ARN=$(aws cloudformation describe-stacks \
+  --stack-name LMA-CFServiceRole \
+  --query 'Stacks[0].Outputs[?OutputKey==`ServiceRoleArn`].OutputValue' \
+  --output text)
+
+aws cloudformation create-stack \
+  --stack-name LMA \
+  --template-url <lma-template-url> \
+  --role-arn $ROLE_ARN \
+  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
+  --parameters ...
+```
+
+### Via Console
+
+1. Navigate to the CloudFormation console
+2. Click **Create stack** → choose the LMA template
+3. In the **Configure stack options** step, under **Permissions**, select the service role
+4. Complete the deployment as normal
+
+## AWS Service Permissions
+
+The role provides access to the following AWS services required by LMA:
+
+| Category | Services |
+|----------|----------|
+| **Core Infrastructure** | CloudFormation, IAM, Serverless Application Repository |
+| **Compute & Serverless** | Lambda, Step Functions, CodeBuild, ECS, ECR |
+| **AI/ML Services** | Bedrock, Bedrock AgentCore, Transcribe, Translate, Comprehend |
+| **Storage & Data** | S3, S3 Vectors, DynamoDB, Kinesis, OpenSearch Serverless |
+| **API & Application** | AppSync, CloudFront, Elastic Load Balancing |
+| **Security & Identity** | Cognito, KMS, Secrets Manager, SSO/Identity Center |
+| **Messaging & Events** | SNS, SES, EventBridge, EventBridge Scheduler |
+| **Monitoring** | CloudWatch Logs, X-Ray |
+| **Networking** | EC2/VPC, Auto Scaling |
+| **Optional** | Lex, Q Business, AWS Marketplace |
+
+### Security Details
+
+- **Trust policy** restricts role assumption to `cloudformation.amazonaws.com` only
+- **PassRole** is constrained by `iam:PassedToService` condition to specific AWS services (Lambda, ECS, CodeBuild, AppSync, Step Functions, Bedrock, etc.)
+- **Service-linked role creation** is limited to the ECS service
+- All CloudFormation operations using this role are logged in **CloudTrail**
+- Organizations may further restrict permissions based on their specific compliance requirements
+
+## Troubleshooting
+
+| Issue | Resolution |
+|-------|------------|
+| **Access Denied when deploying LMA** | Verify the user has the `PassRolePolicy` attached |
+| **Stack creation fails with capability error** | Include `CAPABILITY_NAMED_IAM` when deploying the service role template |
+| **Missing permissions during LMA deployment** | This role covers all known LMA services. If new services are added, update the template and redeploy |
+| **Role name conflicts** | The role name includes the stack name — use a unique stack name |
+
+## Cleanup
+
+```bash
+aws cloudformation delete-stack --stack-name LMA-CFServiceRole
+```
+
+This removes both the service role and the PassRole policy.

--- a/iam-roles/cloudformation-management/LMA-Cloudformation-Service-Role.yaml
+++ b/iam-roles/cloudformation-management/LMA-Cloudformation-Service-Role.yaml
@@ -1,0 +1,345 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  This template creates a CloudFormation Service Role for the Live Meeting Assistant (LMA) solution.
+  This role grants permissions to create, update, and delete LMA CloudFormation
+  stacks and their resources. It follows the principle of least privilege
+  by allowing only the necessary actions for stack management. This template also
+  creates a user permission policy that allows users to pass the CloudFormation
+  service role to CloudFormation. The iam:PassRole policy must be attached to
+  the user or role that will be using the CloudFormation Service Role in order
+  to successfully pass the role.
+Resources:
+  CloudFormationServiceRole:
+    Type: AWS::IAM::Role
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W11
+            reason: "Broad permissions required for non-admin users to deploy LMA stacks via delegated CloudFormation service role"
+          - id: W28
+            reason: "Explicit role name required for consistent cross-stack references in delegated deployment model"
+          - id: F38
+            reason: "Resource wildcard needed with broad permissions required for non-admin users to deploy LMA stacks via delegated CloudFormation service role"
+          - id: W76
+            reason: "Suppressing W76: SPCM for IAM policy document is higher than 25"
+          - id: F3
+            reason: "Suppressing F3: wildcard action on named services required for CloudFormation service role, to allow CRUD on stack resources"
+          - id: AwsSolutions-IAM5
+            reason: "Broad permissions required for non-admin users to deploy LMA stacks via delegated CloudFormation service role"
+      cdk_nag:
+        rules_to_suppress:
+          - id: AwsSolutions-IAM5
+            reason: "CloudFormation service role requires broad permissions to deploy and manage the full LMA application stack. Assumable only by cloudformation.amazonaws.com. All operations logged in CloudTrail."
+          - id: AwsSolutions-IAM4
+            reason: "AWS managed policies not used. All policies are inline and custom-scoped."
+    # checkov:skip=CKV_AWS_110: "CloudFormation service role requires IAM permissions to create Lambda execution roles and service-linked roles during stack deployment. Trust policy restricts to cloudformation.amazonaws.com service principal."
+    # checkov:skip=CKV_AWS_109: "CloudFormation service role requires IAM policy management permissions to attach policies to created roles during infrastructure deployment. Constrained by trust policy."
+    # checkov:skip=CKV_AWS_108: "CloudFormation service role requires S3/KMS permissions to create and configure encrypted data buckets for the LMA solution. All buckets use customer-managed KMS encryption."
+    # checkov:skip=CKV_AWS_111: "CloudFormation service role requires write permissions across AWS services to deploy complete LMA infrastructure. Trust policy limits to CloudFormation service. Use in conjunction with CloudTrail auditing."
+    # checkov:skip=CKV_AWS_107: "CloudFormation service role may need to create/configure secrets for service integrations. Actual secret values are provided via parameters, not embedded in templates."
+    Properties:
+      RoleName: !Sub '${AWS::StackName}-CFServiceRole'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: !Sub 'cloudformation.${AWS::URLSuffix}'
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: CloudFormationPermissions
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudFormationFullAccess
+                Effect: Allow
+                Action:
+                  - cloudformation:*
+                Resource: '*'
+              - Sid: CloudFormationTransform
+                Effect: Allow
+                Action:
+                  - serverlessrepo:CreateCloudFormationChangeSet
+                  - serverlessrepo:GetApplication
+                Resource: '*'
+              - Sid: IAMRolesAndPolicies
+                Effect: Allow
+                Action:
+                  - iam:CreateRole
+                  - iam:DeleteRole
+                  - iam:GetRole
+                  - iam:UpdateRole
+                  - iam:AttachRolePolicy
+                  - iam:DetachRolePolicy
+                  - iam:PutRolePolicy
+                  - iam:DeleteRolePolicy
+                  - iam:GetRolePolicy
+                  - iam:ListRolePolicies
+                  - iam:ListAttachedRolePolicies
+                  - iam:TagRole
+                  - iam:UntagRole
+                  - iam:CreatePolicy
+                  - iam:DeletePolicy
+                  - iam:GetPolicy
+                  - iam:GetPolicyVersion
+                  - iam:ListPolicyVersions
+                  - iam:CreatePolicyVersion
+                  - iam:DeletePolicyVersion
+                  - iam:CreateInstanceProfile
+                  - iam:DeleteInstanceProfile
+                  - iam:AddRoleToInstanceProfile
+                  - iam:RemoveRoleFromInstanceProfile
+                  - iam:GetInstanceProfile
+                Resource: '*'
+              - Sid: IAMCreateServiceLinkedRole
+                Effect: Allow
+                Action: iam:CreateServiceLinkedRole
+                Resource: !Sub 'arn:${AWS::Partition}:iam::*:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS'
+                Condition:
+                  StringEquals:
+                    iam:AWSServiceName: ecs.amazonaws.com
+              - Sid: IAMPassRole
+                Effect: Allow
+                Action: iam:PassRole
+                Resource: '*'
+                Condition:
+                  StringEquals:
+                    iam:PassedToService:
+                      - cloudformation.amazonaws.com
+                      - lambda.amazonaws.com
+                      - ecs-tasks.amazonaws.com
+                      - ec2.amazonaws.com
+                      - codebuild.amazonaws.com
+                      - appsync.amazonaws.com
+                      - states.amazonaws.com
+                      - bedrock.amazonaws.com
+                      - bedrock-agentcore.amazonaws.com
+                      - scheduler.amazonaws.com
+                      - logs.amazonaws.com
+                      - vpc-flow-logs.amazonaws.com
+        - PolicyName: LMAInfraAndDataPermissions
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: LambdaManagement
+                Effect: Allow
+                Action:
+                  - lambda:*
+                Resource: '*'
+              - Sid: DynamoDB
+                Effect: Allow
+                Action:
+                  - dynamodb:*
+                Resource: '*'
+              - Sid: S3Management
+                Effect: Allow
+                Action:
+                  - s3:*
+                Resource: '*'
+              - Sid: S3Vectors
+                Effect: Allow
+                Action:
+                  - s3vectors:*
+                Resource: '*'
+              - Sid: KinesisDataStreams
+                Effect: Allow
+                Action:
+                  - kinesis:*
+                Resource: '*'
+              - Sid: KMS
+                Effect: Allow
+                Action:
+                  - kms:*
+                Resource: '*'
+              - Sid: SecretsManager
+                Effect: Allow
+                Action:
+                  - secretsmanager:*
+                Resource: '*'
+              - Sid: SNS
+                Effect: Allow
+                Action:
+                  - sns:*
+                Resource: '*'
+              - Sid: SES
+                Effect: Allow
+                Action:
+                  - ses:SendEmail
+                  - ses:SendRawEmail
+                Resource: '*'
+              - Sid: SSMParameterStore
+                Effect: Allow
+                Action:
+                  - ssm:*
+                Resource: '*'
+              - Sid: EventBridge
+                Effect: Allow
+                Action:
+                  - events:*
+                Resource: '*'
+              - Sid: EventBridgeScheduler
+                Effect: Allow
+                Action:
+                  - scheduler:*
+                Resource: '*'
+              - Sid: StepFunctions
+                Effect: Allow
+                Action:
+                  - states:*
+                Resource: '*'
+              - Sid: CodeBuild
+                Effect: Allow
+                Action:
+                  - codebuild:*
+                Resource: '*'
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:*
+                Resource: '*'
+        - PolicyName: LMAFrontendComputePermissions
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppSync
+                Effect: Allow
+                Action:
+                  - appsync:*
+                Resource: '*'
+              - Sid: CognitoUserPoolAndIdentity
+                Effect: Allow
+                Action:
+                  - cognito-idp:*
+                  - cognito-identity:*
+                Resource: '*'
+              - Sid: CloudFront
+                Effect: Allow
+                Action:
+                  - cloudfront:*
+                Resource: '*'
+              - Sid: BedrockModelsAndKnowledgeBases
+                Effect: Allow
+                Action:
+                  - bedrock:*
+                Resource: '*'
+              - Sid: BedrockAgentCore
+                Effect: Allow
+                Action:
+                  - bedrock-agentcore:*
+                Resource: '*'
+              - Sid: AWSMarketplace
+                Effect: Allow
+                Action:
+                  - aws-marketplace:Subscribe
+                  - aws-marketplace:Unsubscribe
+                  - aws-marketplace:ViewSubscriptions
+                Resource: '*'
+              - Sid: Transcribe
+                Effect: Allow
+                Action:
+                  - transcribe:*
+                Resource: '*'
+              - Sid: TranslateAndComprehend
+                Effect: Allow
+                Action:
+                  - translate:TranslateText
+                  - comprehend:DetectSentiment
+                  - comprehend:DetectDominantLanguage
+                Resource: '*'
+              - Sid: ECSAndFargate
+                Effect: Allow
+                Action:
+                  - ecs:*
+                Resource: '*'
+              - Sid: ECR
+                Effect: Allow
+                Action:
+                  - ecr:*
+                Resource: '*'
+              - Sid: EC2AndVPC
+                Effect: Allow
+                Action:
+                  - ec2:*
+                Resource: '*'
+              - Sid: ElasticLoadBalancing
+                Effect: Allow
+                Action:
+                  - elasticloadbalancing:*
+                Resource: '*'
+              - Sid: AutoScaling
+                Effect: Allow
+                Action:
+                  - autoscaling:*
+                Resource: '*'
+              - Sid: XRay
+                Effect: Allow
+                Action:
+                  - xray:PutTraceSegments
+                  - xray:PutTelemetryRecords
+                  - xray:GetSamplingRules
+                  - xray:GetSamplingTargets
+                Resource: '*'
+        - PolicyName: LMAOptionalServicesPermissions
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: OpenSearchServerless
+                Effect: Allow
+                Action:
+                  - aoss:*
+                Resource: '*'
+              - Sid: LexBot
+                Effect: Allow
+                Action:
+                  - lex:*
+                Resource: '*'
+              - Sid: QBusiness
+                Effect: Allow
+                Action:
+                  - qbusiness:GetApplication
+                  - qbusiness:ChatSync
+                  - qbusiness:Chat
+                  - qbusiness:ListMessages
+                  - qbusiness:ListConversations
+                Resource: '*'
+              - Sid: SSOIdentityCenter
+                Effect: Allow
+                Action:
+                  - sso:CreateApplication
+                  - sso:DeleteApplication
+                  - sso:DescribeApplication
+                  - sso:PutApplicationGrant
+                  - sso:PutApplicationAuthenticationMethod
+                  - sso:PutApplicationAccessScope
+                  - sso-oauth:CreateTokenWithIAM
+                Resource: '*'
+
+  PassRolePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+            reason: "Explicit policy name required for consistent cross-stack references in delegated deployment model"
+    Properties:
+      ManagedPolicyName: !Sub '${AWS::StackName}-PassRolePolicy'
+      Description: Policy to allow passing the LMA CloudFormation service role
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - iam:PassRole
+            Resource: !GetAtt CloudFormationServiceRole.Arn
+
+Outputs:
+  ServiceRoleArn:
+    Description: ARN of the CloudFormation service role
+    Value: !GetAtt CloudFormationServiceRole.Arn
+    Export:
+      Name: !Sub '${AWS::StackName}-ServiceRoleArn'
+  PassRolePolicyArn:
+    Description: ARN of the PassRole policy for admins to assign to users
+    Value: !Ref PassRolePolicy
+    Export:
+      Name: !Sub '${AWS::StackName}-PassRolePolicyArn'

--- a/iam-roles/cloudformation-management/LMA-Cloudformation-Service-Role.yaml
+++ b/iam-roles/cloudformation-management/LMA-Cloudformation-Service-Role.yaml
@@ -100,23 +100,9 @@ Resources:
                     iam:AWSServiceName: ecs.amazonaws.com
               - Sid: IAMPassRole
                 Effect: Allow
-                Action: iam:PassRole
+                Action:
+                  - iam:PassRole
                 Resource: '*'
-                Condition:
-                  StringEquals:
-                    iam:PassedToService:
-                      - cloudformation.amazonaws.com
-                      - lambda.amazonaws.com
-                      - ecs-tasks.amazonaws.com
-                      - ec2.amazonaws.com
-                      - codebuild.amazonaws.com
-                      - appsync.amazonaws.com
-                      - states.amazonaws.com
-                      - bedrock.amazonaws.com
-                      - bedrock-agentcore.amazonaws.com
-                      - scheduler.amazonaws.com
-                      - logs.amazonaws.com
-                      - vpc-flow-logs.amazonaws.com
         - PolicyName: LMAInfraAndDataPermissions
           PolicyDocument:
             Version: '2012-10-17'

--- a/iam-roles/cloudformation-management/LMA-Cloudformation-Service-Role.yaml
+++ b/iam-roles/cloudformation-management/LMA-Cloudformation-Service-Role.yaml
@@ -1,0 +1,331 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  This template creates a CloudFormation Service Role for the Live Meeting Assistant (LMA) solution.
+  This role grants permissions to create, update, and delete LMA CloudFormation
+  stacks and their resources. It follows the principle of least privilege
+  by allowing only the necessary actions for stack management. This template also
+  creates a user permission policy that allows users to pass the CloudFormation
+  service role to CloudFormation. The iam:PassRole policy must be attached to
+  the user or role that will be using the CloudFormation Service Role in order
+  to successfully pass the role.
+Resources:
+  CloudFormationServiceRole:
+    Type: AWS::IAM::Role
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W11
+            reason: "Broad permissions required for non-admin users to deploy LMA stacks via delegated CloudFormation service role"
+          - id: W28
+            reason: "Explicit role name required for consistent cross-stack references in delegated deployment model"
+          - id: F38
+            reason: "Resource wildcard needed with broad permissions required for non-admin users to deploy LMA stacks via delegated CloudFormation service role"
+          - id: W76
+            reason: "Suppressing W76: SPCM for IAM policy document is higher than 25"
+          - id: F3
+            reason: "Suppressing F3: wildcard action on named services required for CloudFormation service role, to allow CRUD on stack resources"
+          - id: AwsSolutions-IAM5
+            reason: "Broad permissions required for non-admin users to deploy LMA stacks via delegated CloudFormation service role"
+      cdk_nag:
+        rules_to_suppress:
+          - id: AwsSolutions-IAM5
+            reason: "CloudFormation service role requires broad permissions to deploy and manage the full LMA application stack. Assumable only by cloudformation.amazonaws.com. All operations logged in CloudTrail."
+          - id: AwsSolutions-IAM4
+            reason: "AWS managed policies not used. All policies are inline and custom-scoped."
+    # checkov:skip=CKV_AWS_110: "CloudFormation service role requires IAM permissions to create Lambda execution roles and service-linked roles during stack deployment. Trust policy restricts to cloudformation.amazonaws.com service principal."
+    # checkov:skip=CKV_AWS_109: "CloudFormation service role requires IAM policy management permissions to attach policies to created roles during infrastructure deployment. Constrained by trust policy."
+    # checkov:skip=CKV_AWS_108: "CloudFormation service role requires S3/KMS permissions to create and configure encrypted data buckets for the LMA solution. All buckets use customer-managed KMS encryption."
+    # checkov:skip=CKV_AWS_111: "CloudFormation service role requires write permissions across AWS services to deploy complete LMA infrastructure. Trust policy limits to CloudFormation service. Use in conjunction with CloudTrail auditing."
+    # checkov:skip=CKV_AWS_107: "CloudFormation service role may need to create/configure secrets for service integrations. Actual secret values are provided via parameters, not embedded in templates."
+    Properties:
+      RoleName: !Sub '${AWS::StackName}-CFServiceRole'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: !Sub 'cloudformation.${AWS::URLSuffix}'
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: CloudFormationPermissions
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudFormationFullAccess
+                Effect: Allow
+                Action:
+                  - cloudformation:*
+                Resource: '*'
+              - Sid: CloudFormationTransform
+                Effect: Allow
+                Action:
+                  - serverlessrepo:CreateCloudFormationChangeSet
+                  - serverlessrepo:GetApplication
+                Resource: '*'
+              - Sid: IAMRolesAndPolicies
+                Effect: Allow
+                Action:
+                  - iam:CreateRole
+                  - iam:DeleteRole
+                  - iam:GetRole
+                  - iam:UpdateRole
+                  - iam:AttachRolePolicy
+                  - iam:DetachRolePolicy
+                  - iam:PutRolePolicy
+                  - iam:DeleteRolePolicy
+                  - iam:GetRolePolicy
+                  - iam:ListRolePolicies
+                  - iam:ListAttachedRolePolicies
+                  - iam:TagRole
+                  - iam:UntagRole
+                  - iam:CreatePolicy
+                  - iam:DeletePolicy
+                  - iam:GetPolicy
+                  - iam:GetPolicyVersion
+                  - iam:ListPolicyVersions
+                  - iam:CreatePolicyVersion
+                  - iam:DeletePolicyVersion
+                  - iam:CreateInstanceProfile
+                  - iam:DeleteInstanceProfile
+                  - iam:AddRoleToInstanceProfile
+                  - iam:RemoveRoleFromInstanceProfile
+                  - iam:GetInstanceProfile
+                Resource: '*'
+              - Sid: IAMCreateServiceLinkedRole
+                Effect: Allow
+                Action: iam:CreateServiceLinkedRole
+                Resource: !Sub 'arn:${AWS::Partition}:iam::*:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS'
+                Condition:
+                  StringEquals:
+                    iam:AWSServiceName: ecs.amazonaws.com
+              - Sid: IAMPassRole
+                Effect: Allow
+                Action:
+                  - iam:PassRole
+                Resource: '*'
+        - PolicyName: LMAInfraAndDataPermissions
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: LambdaManagement
+                Effect: Allow
+                Action:
+                  - lambda:*
+                Resource: '*'
+              - Sid: DynamoDB
+                Effect: Allow
+                Action:
+                  - dynamodb:*
+                Resource: '*'
+              - Sid: S3Management
+                Effect: Allow
+                Action:
+                  - s3:*
+                Resource: '*'
+              - Sid: S3Vectors
+                Effect: Allow
+                Action:
+                  - s3vectors:*
+                Resource: '*'
+              - Sid: KinesisDataStreams
+                Effect: Allow
+                Action:
+                  - kinesis:*
+                Resource: '*'
+              - Sid: KMS
+                Effect: Allow
+                Action:
+                  - kms:*
+                Resource: '*'
+              - Sid: SecretsManager
+                Effect: Allow
+                Action:
+                  - secretsmanager:*
+                Resource: '*'
+              - Sid: SNS
+                Effect: Allow
+                Action:
+                  - sns:*
+                Resource: '*'
+              - Sid: SES
+                Effect: Allow
+                Action:
+                  - ses:SendEmail
+                  - ses:SendRawEmail
+                Resource: '*'
+              - Sid: SSMParameterStore
+                Effect: Allow
+                Action:
+                  - ssm:*
+                Resource: '*'
+              - Sid: EventBridge
+                Effect: Allow
+                Action:
+                  - events:*
+                Resource: '*'
+              - Sid: EventBridgeScheduler
+                Effect: Allow
+                Action:
+                  - scheduler:*
+                Resource: '*'
+              - Sid: StepFunctions
+                Effect: Allow
+                Action:
+                  - states:*
+                Resource: '*'
+              - Sid: CodeBuild
+                Effect: Allow
+                Action:
+                  - codebuild:*
+                Resource: '*'
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:*
+                Resource: '*'
+        - PolicyName: LMAFrontendComputePermissions
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppSync
+                Effect: Allow
+                Action:
+                  - appsync:*
+                Resource: '*'
+              - Sid: CognitoUserPoolAndIdentity
+                Effect: Allow
+                Action:
+                  - cognito-idp:*
+                  - cognito-identity:*
+                Resource: '*'
+              - Sid: CloudFront
+                Effect: Allow
+                Action:
+                  - cloudfront:*
+                Resource: '*'
+              - Sid: BedrockModelsAndKnowledgeBases
+                Effect: Allow
+                Action:
+                  - bedrock:*
+                Resource: '*'
+              - Sid: BedrockAgentCore
+                Effect: Allow
+                Action:
+                  - bedrock-agentcore:*
+                Resource: '*'
+              - Sid: AWSMarketplace
+                Effect: Allow
+                Action:
+                  - aws-marketplace:Subscribe
+                  - aws-marketplace:Unsubscribe
+                  - aws-marketplace:ViewSubscriptions
+                Resource: '*'
+              - Sid: Transcribe
+                Effect: Allow
+                Action:
+                  - transcribe:*
+                Resource: '*'
+              - Sid: TranslateAndComprehend
+                Effect: Allow
+                Action:
+                  - translate:TranslateText
+                  - comprehend:DetectSentiment
+                  - comprehend:DetectDominantLanguage
+                Resource: '*'
+              - Sid: ECSAndFargate
+                Effect: Allow
+                Action:
+                  - ecs:*
+                Resource: '*'
+              - Sid: ECR
+                Effect: Allow
+                Action:
+                  - ecr:*
+                Resource: '*'
+              - Sid: EC2AndVPC
+                Effect: Allow
+                Action:
+                  - ec2:*
+                Resource: '*'
+              - Sid: ElasticLoadBalancing
+                Effect: Allow
+                Action:
+                  - elasticloadbalancing:*
+                Resource: '*'
+              - Sid: AutoScaling
+                Effect: Allow
+                Action:
+                  - autoscaling:*
+                Resource: '*'
+              - Sid: XRay
+                Effect: Allow
+                Action:
+                  - xray:PutTraceSegments
+                  - xray:PutTelemetryRecords
+                  - xray:GetSamplingRules
+                  - xray:GetSamplingTargets
+                Resource: '*'
+        - PolicyName: LMAOptionalServicesPermissions
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: OpenSearchServerless
+                Effect: Allow
+                Action:
+                  - aoss:*
+                Resource: '*'
+              - Sid: LexBot
+                Effect: Allow
+                Action:
+                  - lex:*
+                Resource: '*'
+              - Sid: QBusiness
+                Effect: Allow
+                Action:
+                  - qbusiness:GetApplication
+                  - qbusiness:ChatSync
+                  - qbusiness:Chat
+                  - qbusiness:ListMessages
+                  - qbusiness:ListConversations
+                Resource: '*'
+              - Sid: SSOIdentityCenter
+                Effect: Allow
+                Action:
+                  - sso:CreateApplication
+                  - sso:DeleteApplication
+                  - sso:DescribeApplication
+                  - sso:PutApplicationGrant
+                  - sso:PutApplicationAuthenticationMethod
+                  - sso:PutApplicationAccessScope
+                  - sso-oauth:CreateTokenWithIAM
+                Resource: '*'
+
+  PassRolePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+            reason: "Explicit policy name required for consistent cross-stack references in delegated deployment model"
+    Properties:
+      ManagedPolicyName: !Sub '${AWS::StackName}-PassRolePolicy'
+      Description: Policy to allow passing the LMA CloudFormation service role
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - iam:PassRole
+            Resource: !GetAtt CloudFormationServiceRole.Arn
+
+Outputs:
+  ServiceRoleArn:
+    Description: ARN of the CloudFormation service role
+    Value: !GetAtt CloudFormationServiceRole.Arn
+    Export:
+      Name: !Sub '${AWS::StackName}-ServiceRoleArn'
+  PassRolePolicyArn:
+    Description: ARN of the PassRole policy for admins to assign to users
+    Value: !Ref PassRolePolicy
+    Export:
+      Name: !Sub '${AWS::StackName}-PassRolePolicyArn'

--- a/iam-roles/cloudformation-management/README.md
+++ b/iam-roles/cloudformation-management/README.md
@@ -1,0 +1,35 @@
+# CloudFormation Service Role for LMA
+
+This directory contains a CloudFormation template that creates a dedicated IAM service role for deploying and managing LMA stacks.
+
+## Quick Start
+
+```bash
+aws cloudformation deploy \
+  --template-file LMA-Cloudformation-Service-Role.yaml \
+  --stack-name LMA-CFServiceRole \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --region <your-region>
+```
+
+Then deploy LMA using the service role:
+
+```bash
+ROLE_ARN=$(aws cloudformation describe-stacks \
+  --stack-name LMA-CFServiceRole \
+  --query 'Stacks[0].Outputs[?OutputKey==`ServiceRoleArn`].OutputValue' \
+  --output text)
+
+lma-cli deploy --stack-name MyLMA --admin-email user@example.com --role-arn $ROLE_ARN --wait
+```
+
+## Documentation
+
+For full documentation — including Console deployment, PassRole policy assignment, security details, service permissions, and troubleshooting — see the [CloudFormation Service Role guide](../../docs/cloudformation-service-role.md).
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `LMA-Cloudformation-Service-Role.yaml` | CloudFormation template creating the service role and PassRole policy |
+| `README.md` | This file |


### PR DESCRIPTION
## Summary

This PR provides a deployable CloudFormation template that creates a dedicated IAM service role for LMA deployment, enabling non-admin users to deploy and manage LMA stacks.

This is an alternative approach to #238 — instead of 4 loose JSON policy files + manual CLI commands, this uses a single CloudFormation template (Infrastructure-as-Code) following the pattern from our IDP accelerator project.

## What's included

- **`iam-roles/cloudformation-management/LMA-Cloudformation-Service-Role.yaml`** — CloudFormation template that creates:
  - A CloudFormation service role (trusted only by `cloudformation.amazonaws.com`) with 4 inline policies covering all ~30 AWS services LMA needs
  - A PassRole managed policy for admin delegation to non-admin users
  - Stack outputs exporting role ARN and policy ARN

- **`docs/cloudformation-service-role.md`** — Full documentation page with deployment instructions, `lma-cli deploy --role-arn` usage, service permissions table, security details, and troubleshooting. Added to docs/INDEX.md for GitHub Pages docs-deploy.

- **`iam-roles/cloudformation-management/README.md`** — Quick-start README with link to full docs

- **`CHANGELOG.md`** — Entry under Unreleased / Added

## Why this approach over #238

| Concern | PR #238 (JSON files + CLI) | This PR (CloudFormation template) |
|---------|---------------------------|-----------------------------------|
| **Deployment** | Manual CLI commands to create 4 policies + role | Single `aws cloudformation deploy` command |
| **Repeatability** | Error-prone manual steps | Infrastructure-as-Code, fully repeatable |
| **Cleanup** | Must manually delete each policy and role | `aws cloudformation delete-stack` removes everything |
| **Auditability** | Policies exist outside version control | Template is versioned alongside the project |
| **Security** | Permissions attached to user identity | Permissions delegated to CloudFormation service only |
| **Root dir clutter** | 4 JSON files in project root | Clean subdirectory under `iam-roles/` |

## Testing

- Template validates with `aws cloudformation validate-template`
- Deployed `LMA-CFServiceRole` stack → `CREATE_COMPLETE`
- Deployed full LMA stack using `lma-cli deploy --role-arn` → successful (all nested stacks created without permission errors)
- Key finding: `iam:PassedToService` condition on PassRole doesn't work for implicit PassRole calls (e.g. `cognito-identity:SetIdentityPoolRoles`). Unconditional `iam:PassRole` is correct since the role's trust policy restricts assumption to `cloudformation.amazonaws.com` only.

## How to use

```bash
# 1. Deploy the service role (one-time admin setup)
aws cloudformation deploy \
  --template-file iam-roles/cloudformation-management/LMA-Cloudformation-Service-Role.yaml \
  --stack-name LMA-CFServiceRole \
  --capabilities CAPABILITY_NAMED_IAM

# 2. Deploy LMA using the role
ROLE_ARN=$(aws cloudformation describe-stacks --stack-name LMA-CFServiceRole \
  --query 'Stacks[0].Outputs[?OutputKey==`ServiceRoleArn`].OutputValue' --output text)

lma-cli deploy --stack-name MyLMA --admin-email user@example.com --role-arn $ROLE_ARN --wait
```

Closes the same problem as #238 (policy too large for a single managed policy).