### PR TITLE
fix(extension): detect Microsoft Teams across subdomain variants

### DIFF
--- a/lma-browser-extension-stack/src/context/ProviderIntegrationContext.tsx
+++ b/lma-browser-extension-stack/src/context/ProviderIntegrationContext.tsx
@@ -105,7 +105,14 @@ function IntegrationProvider({ children }: any) {
       setPlatform("Zoom");
     } else if (newMetadata && newMetadata.baseUrl && newMetadata.baseUrl === "https://app.chime.aws") {
       setPlatform("Amazon Chime");
-    } else if (newMetadata.baseUrl === "https://teams.microsoft.com" || newMetadata.baseUrl === "https://teams.live.com") {
+    } else if (
+      newMetadata && newMetadata.baseUrl && (
+        newMetadata.baseUrl.includes("teams.microsoft.com") ||
+        newMetadata.baseUrl.includes("teams.live.com") ||
+        newMetadata.baseUrl.includes("teams.microsoft.us") ||
+        newMetadata.baseUrl.includes("teams.cloud.microsoft")
+      )
+    ) {
       setPlatform("Microsoft Teams");
     } else if (newMetadata && newMetadata.baseUrl && newMetadata.baseUrl.includes("webex.com")) {
       setPlatform("Cisco Webex");


### PR DESCRIPTION
*Issue #, if available:* #182

*Description of changes:*

The browser extension showed **Platform Detected: n/a** for Microsoft Teams meetings even though audio capture and transcription worked.

### Root cause

`ProviderIntegrationContext.updateMetadata` used strict equality:

```ts
newMetadata.baseUrl === "https://teams.microsoft.com"
  || newMetadata.baseUrl === "https://teams.live.com"
```

The Teams content script (`public/content_scripts/providers/teams.js`) emits `baseUrl: window.location.origin` and is registered in the manifest with `all_frames: true`, so the metadata can be reported from a frame whose origin is a Teams subdomain rather than the bare apex. Strict equality then fails and the platform label falls through to `"n/a"`. Recording itself still works because the content script *was* injected via the manifest's top-level match pattern — only the label check was broken. The Webex branch in the same function already uses substring matching (`baseUrl.includes("webex.com")`) for the same reason.

### Fix

Switch the Teams branch to substring matching, mirroring the Webex branch. The four substrings cover Microsoft's current Teams domain variants:

- `teams.microsoft.com` — commercial Teams web (and its regional subdomains)
- `teams.live.com` — personal Teams accounts
- `teams.microsoft.us` — matches `gov.teams.microsoft.us` (GCC) and related US-government Teams URLs via substring
- `teams.cloud.microsoft` — the new Teams web client domain under Microsoft's `cloud.microsoft` consolidation

Single file, +8/-1.

### Test plan

- [x] `npm run build` succeeds; no new warnings/errors introduced
- [x] Loaded the unpacked extension in Chrome and confirmed via DevTools that the Teams content script is injected (`Inside LMA Teams script` log) on `teams.microsoft.com`
- [ ] End-to-end UI verification ("Platform Detected: Microsoft Teams" rendered in the side panel) was **not** completed — see caveat below
- [ ] Other platform branches (Zoom / Chime / Webex / Meet) are untouched in the diff

### Verification caveat

Full end-to-end verification of the rendered platform label was not possible in my environment. While debugging, I observed that the Teams content script gates the `UpdateMetadata` message (which carries `baseUrl`) behind a successful DOM scrape of **both** `userName` and `meetingTopic` (`teams.js:163`). On the Teams session I tested against, those scrapes did not complete — likely because the script's four fallback selectors in `checkForMeetingMetadata()` have drifted from the current Teams web DOM — so `UpdateMetadata` was never dispatched and `setPlatform` therefore never ran, independent of this PR's change.

This appears to be a separate, larger bug than #182 and is out of scope here: it would require re-auditing the DOM selectors against the current Teams web clients (commercial, new-Teams, and government variants). I'd suggest opening a follow-up issue to track that work, since it touches DOM-dependent code that drifts with every Teams update and warrants its own discussion per CONTRIBUTING.md ("open an issue to discuss any significant work").

The change in this PR is correct for the code path it touches. The reporter of #182 confirmed transcription worked, which implies the DOM scrape did succeed for them and `UpdateMetadata` was being dispatched — only the strict-equality check on `baseUrl` was failing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.