### PR TITLE
fix: upgrade Virtual
  Participant base to node:22-alpine3.21

### DIFF
--- a/lma-virtual-participant-stack/backend/Dockerfile
+++ b/lma-virtual-participant-stack/backend/Dockerfile
@@ -1,6 +1,6 @@
 # checkov:skip=CKV_DOCKER_2: "Health monitored by ECS target-group health check on port 5901 rather than container HEALTHCHECK"
 
-FROM public.ecr.aws/docker/library/node:20-alpine
+FROM public.ecr.aws/docker/library/node:22-alpine3.21
 USER root
 WORKDIR /srv
 COPY . /srv


### PR DESCRIPTION
## Summary
  - Upgrade Virtual Participant container base from node:20-alpine to node:22-alpine3.21
  - Node 20 enters EOL April 30, 2026; Node 22 is Active LTS (EOL April 2027)
  - Alpine 3.23.4 (shipped with node:20-alpine) has unpatched CVEs in mesa and ffmpeg packages flagged by vulnerability scanners (Shepherd VMR)
  - Alpine 3.21.5 ships patched versions (mesa 24.2.8-r0, ffmpeg 6.1.2-r1)
  - Pinning the Alpine minor version makes builds reproducible

  ## Testing
  - Built and deployed to ECS (EC2 launch type) in a sandbox account
  - TypeScript compilation succeeds on Node 22.21.1
  - All npm dependencies resolve cleanly
  - Container starts, initializes Xvfb/VNC/PulseAudio/Chromium stack as expected
  - Virtual Participant successfully joins Zoom meeting, records audio, uploads to S3

  ## Test plan
  - [ ] Deploy stack from scratch with this change
  - [ ] Join a test meeting and verify transcription works end-to-end
  - [ ] Confirm VNC viewer shows the meeting browser correctly
  - [ ] Run ECR image scan -- no HIGH/CRITICAL findings