### PR TITLE
feat(vp): add video recording to Virtual Participant

### DIFF
--- a/lma-ai-stack/source/ui/src/components/video-player/VideoPlayer.css
+++ b/lma-ai-stack/source/ui/src/components/video-player/VideoPlayer.css
@@ -1,0 +1,3 @@
+.video-player-container video {
+  border-radius: 8px;
+}

--- a/lma-ai-stack/source/ui/src/components/video-player/VideoPlayer.tsx
+++ b/lma-ai-stack/source/ui/src/components/video-player/VideoPlayer.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState, useRef, forwardRef, useImperativeHandle } from 'react';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import './VideoPlayer.css';
+
+const VIDEO_API = 'https://iv9wbg9f36.execute-api.us-east-1.amazonaws.com/demo';
+
+export const VideoPlayer = forwardRef(({ callId, onTimeUpdate }, ref) => {
+  const videoRef = useRef(null);
+  const [videoUrl, setVideoUrl] = useState(null);
+  const [status, setStatus] = useState('loading');
+
+  useImperativeHandle(ref, () => ({
+    seek: (t) => { if (videoRef.current) videoRef.current.currentTime = t; },
+    play: () => videoRef.current?.play(),
+    pause: () => videoRef.current?.pause(),
+  }));
+
+  useEffect(() => {
+    if (!callId) { setStatus('not-found'); return; }
+    let cancelled = false;
+    setStatus('loading');
+    fetch(VIDEO_API + '/soap', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'get_video_url', call_id: callId })
+    })
+      .then(r => r.json())
+      .then(data => {
+        if (cancelled) return;
+        const res = data.body ? JSON.parse(data.body) : data;
+        if (res.video_url) {
+          setVideoUrl(res.video_url);
+          setStatus('ready');
+        } else {
+          setStatus('not-found');
+        }
+      })
+      .catch(() => { if (!cancelled) setStatus('not-found'); });
+    return () => { cancelled = true; };
+  }, [callId]);
+
+  if (status === 'not-found' || status === 'loading') return null;
+
+  return (
+    <Container header={<Header variant="h3">Recording Video</Header>}>
+      <video
+        ref={videoRef}
+        src={videoUrl}
+        controls
+        style={{ width: '100%', borderRadius: '8px', maxHeight: '360px' }}
+        onTimeUpdate={() => {
+          if (videoRef.current && onTimeUpdate) {
+            onTimeUpdate({
+              currentTime: videoRef.current.currentTime,
+              duration: videoRef.current.duration
+            });
+          }
+        }}
+      />
+    </Container>
+  );
+});
+
+VideoPlayer.displayName = 'VideoPlayer';
+export default VideoPlayer;

--- a/lma-ai-stack/source/ui/src/components/video-player/VideoPlayer.tsx
+++ b/lma-ai-stack/source/ui/src/components/video-player/VideoPlayer.tsx
@@ -1,53 +1,66 @@
 import React, { useEffect, useState, useRef, forwardRef, useImperativeHandle } from 'react';
 import Container from '@cloudscape-design/components/container';
 import Header from '@cloudscape-design/components/header';
+import { getVideoRecordingUrl } from './video-api';
+import { useAppContext } from '../../contexts/AppContext';
 import './VideoPlayer.css';
 
-const VIDEO_API = 'https://iv9wbg9f36.execute-api.us-east-1.amazonaws.com/demo';
+interface VideoPlayerProps {
+  callId?: string;
+  onTimeUpdate?: (time: { currentTime: number; duration: number }) => void;
+}
 
-export const VideoPlayer = forwardRef(({ callId, onTimeUpdate }, ref) => {
-  const videoRef = useRef(null);
-  const [videoUrl, setVideoUrl] = useState(null);
-  const [status, setStatus] = useState('loading');
+export interface VideoPlayerHandle {
+  seek: (t: number) => void;
+  play: () => void;
+  pause: () => void;
+}
+
+export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(({ callId, onTimeUpdate }, ref) => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [videoUrl, setVideoUrl] = useState<string | null>(null);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'not-found'>('loading');
+  const { currentCredentials } = useAppContext();
 
   useImperativeHandle(ref, () => ({
-    seek: (t) => { if (videoRef.current) videoRef.current.currentTime = t; },
-    play: () => videoRef.current?.play(),
-    pause: () => videoRef.current?.pause(),
+    seek: (t: number) => { if (videoRef.current) videoRef.current.currentTime = t; },
+    play: () => { videoRef.current?.play(); },
+    pause: () => { videoRef.current?.pause(); },
   }));
 
   useEffect(() => {
     if (!callId) { setStatus('not-found'); return; }
     let cancelled = false;
     setStatus('loading');
-    fetch(VIDEO_API + '/soap', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ action: 'get_video_url', call_id: callId })
-    })
-      .then(r => r.json())
-      .then(data => {
+
+    const fetchVideo = async () => {
+      try {
+        const result = await getVideoRecordingUrl(callId, currentCredentials);
         if (cancelled) return;
-        const res = data.body ? JSON.parse(data.body) : data;
-        if (res.video_url) {
-          setVideoUrl(res.video_url);
+        if (result.status === 'ready' && result.url) {
+          setVideoUrl(result.url);
           setStatus('ready');
         } else {
           setStatus('not-found');
         }
-      })
-      .catch(() => { if (!cancelled) setStatus('not-found'); });
+      } catch {
+        if (!cancelled) setStatus('not-found');
+      }
+    };
+
+    fetchVideo();
     return () => { cancelled = true; };
-  }, [callId]);
+  }, [callId, currentCredentials]);
 
   if (status === 'not-found' || status === 'loading') return null;
 
   return (
-    <Container header={<Header variant="h3">Recording Video</Header>}>
+    <Container header={<Header variant="h3">Session Recording</Header>}>
       <video
         ref={videoRef}
-        src={videoUrl}
+        src={videoUrl || undefined}
         controls
+        preload="metadata"
         style={{ width: '100%', borderRadius: '8px', maxHeight: '360px' }}
         onTimeUpdate={() => {
           if (videoRef.current && onTimeUpdate) {

--- a/lma-ai-stack/source/ui/src/components/video-player/index.ts
+++ b/lma-ai-stack/source/ui/src/components/video-player/index.ts
@@ -1,0 +1,3 @@
+export { default } from './VideoPlayer';
+export { default as useVideoSync } from './useVideoSync';
+export { getVideoRecordingUrl, listVideoRecordings, hasVideoRecording } from './video-api';

--- a/lma-ai-stack/source/ui/src/components/video-player/useVideoSync.ts
+++ b/lma-ai-stack/source/ui/src/components/video-player/useVideoSync.ts
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2025 Amazon.com
+ * This file is licensed under the MIT License.
+ * See the LICENSE file in the project root for full license information.
+ */
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { ConsoleLogger } from 'aws-amplify/utils';
+
+const logger = new ConsoleLogger('useVideoSync');
+
+/**
+ * useVideoSync — Custom hook for bidirectional video ↔ transcript synchronization.
+ *
+ * Handles two sync directions:
+ *   A) Video playback → Highlight active transcript segment (+ auto-scroll)
+ *   B) Click transcript segment → Seek video to segment start time
+ *
+ * @param {Object} options
+ * @param {Array} options.segments — Transcript segments array, each with:
+ *   { startTime: number (seconds), endTime: number (seconds), segmentId: string, ... }
+ * @param {React.RefObject} options.videoPlayerRef — Ref to the VideoPlayer imperative handle
+ * @param {number} [options.timeOffset=0] — Offset in seconds between video 0:00 and
+ *   transcript timestamps (video 0:00 = firstSegment.startTime - offset).
+ *   If 0, assumes video start aligns with first transcript segment.
+ * @param {boolean} [options.autoScroll=true] — Whether to auto-scroll to active segment
+ * @param {number} [options.scrollBehavior='smooth'] — CSS scroll behavior
+ *
+ * @returns {Object}
+ *   activeSegmentIndex — Index of the currently active segment (-1 if none)
+ *   activeSegmentId — ID of the active segment (null if none)
+ *   seekToSegment — Function: (segmentIndex) => seeks video to that segment's start
+ *   seekToTime — Function: (timeInSeconds) => seeks video to absolute time
+ *   isPlaying — Whether video is currently playing
+ *   currentTime — Current playback time (in transcript time-space)
+ *   handleTimeUpdate — Callback to pass to VideoPlayer's onTimeUpdate prop
+ *   getSegmentClassName — Helper: returns CSS class string for a segment by index
+ */
+const useVideoSync = ({
+  segments = [],
+  videoPlayerRef,
+  timeOffset: timeOffsetProp,
+  autoScroll = true,
+  scrollBehavior = 'smooth',
+} = {}) => {
+  const [activeSegmentIndex, setActiveSegmentIndex] = useState(-1);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const lastScrolledIndex = useRef(-1);
+  const segmentRefs = useRef(new Map());
+
+  // Calculate effective time offset:
+  // If not explicitly provided, derive from first segment's startTime
+  // (video 0:00 corresponds to the start of transcription)
+  const getTimeOffset = useCallback(() => {
+    if (timeOffsetProp !== undefined && timeOffsetProp !== null) {
+      return timeOffsetProp;
+    }
+    // Default: video starts at the same time as the first transcript segment
+    if (segments.length > 0 && segments[0].startTime != null) {
+      return segments[0].startTime;
+    }
+    return 0;
+  }, [timeOffsetProp, segments]);
+
+  /**
+   * Convert video playback time to transcript time-space.
+   * Video currentTime + offset = transcript absolute time.
+   */
+  const videoTimeToTranscriptTime = useCallback((videoTime) => {
+    return videoTime + getTimeOffset();
+  }, [getTimeOffset]);
+
+  /**
+   * Convert transcript time to video playback time.
+   */
+  const transcriptTimeToVideoTime = useCallback((transcriptTime) => {
+    return transcriptTime - getTimeOffset();
+  }, [getTimeOffset]);
+
+  /**
+   * Binary search for the active segment at a given transcript time.
+   * Returns the index of the segment whose [startTime, endTime) contains the time,
+   * or -1 if no match.
+   */
+  const findActiveSegment = useCallback((transcriptTime) => {
+    if (!segments.length) return -1;
+
+    let low = 0;
+    let high = segments.length - 1;
+
+    while (low <= high) {
+      const mid = Math.floor((low + high) / 2);
+      const seg = segments[mid];
+
+      if (transcriptTime < seg.startTime) {
+        high = mid - 1;
+      } else if (transcriptTime >= seg.endTime) {
+        low = mid + 1;
+      } else {
+        // transcriptTime is within [startTime, endTime)
+        return mid;
+      }
+    }
+
+    // Check if we're in a gap between segments — find nearest
+    // If time is past all segments, highlight the last one during its range
+    if (low > 0 && low <= segments.length) {
+      const prevSeg = segments[low - 1];
+      // If within 0.5s of prev segment end, still highlight it (smooths transitions)
+      if (transcriptTime - prevSeg.endTime < 0.5) {
+        return low - 1;
+      }
+    }
+
+    return -1;
+  }, [segments]);
+
+  /**
+   * handleTimeUpdate — Connect this to VideoPlayer's onTimeUpdate prop.
+   * Direction A: Video → Transcript highlight
+   */
+  const handleTimeUpdate = useCallback(({ currentTime: videoCurrentTime, duration }) => {
+    const transcriptTime = videoTimeToTranscriptTime(videoCurrentTime);
+    setCurrentTime(transcriptTime);
+    setIsPlaying(true);
+
+    const newIndex = findActiveSegment(transcriptTime);
+
+    if (newIndex !== activeSegmentIndex) {
+      setActiveSegmentIndex(newIndex);
+
+      // Auto-scroll to active segment
+      if (autoScroll && newIndex >= 0 && newIndex !== lastScrolledIndex.current) {
+        lastScrolledIndex.current = newIndex;
+        const segmentEl = segmentRefs.current.get(newIndex);
+        if (segmentEl) {
+          segmentEl.scrollIntoView({
+            behavior: scrollBehavior,
+            block: 'nearest',
+            inline: 'nearest',
+          });
+        }
+      }
+    }
+  }, [videoTimeToTranscriptTime, findActiveSegment, activeSegmentIndex, autoScroll, scrollBehavior]);
+
+  /**
+   * seekToSegment — Direction B: Transcript click → Video seek.
+   * @param {number} segmentIndex — Index into segments array
+   */
+  const seekToSegment = useCallback((segmentIndex) => {
+    if (segmentIndex < 0 || segmentIndex >= segments.length) {
+      logger.warn('seekToSegment: index out of bounds', segmentIndex);
+      return;
+    }
+
+    const segment = segments[segmentIndex];
+    const videoTime = transcriptTimeToVideoTime(segment.startTime);
+
+    logger.debug(`Seeking to segment ${segmentIndex}`, {
+      segmentStartTime: segment.startTime,
+      videoTime,
+    });
+
+    if (videoPlayerRef?.current) {
+      videoPlayerRef.current.seek(Math.max(0, videoTime));
+      // Optionally auto-play on seek
+      if (videoPlayerRef.current.paused) {
+        videoPlayerRef.current.play();
+      }
+    }
+
+    // Immediately highlight the target segment
+    setActiveSegmentIndex(segmentIndex);
+  }, [segments, transcriptTimeToVideoTime, videoPlayerRef]);
+
+  /**
+   * seekToTime — Seek video to an absolute transcript timestamp.
+   * @param {number} transcriptTime — Time in seconds (transcript time-space)
+   */
+  const seekToTime = useCallback((transcriptTime) => {
+    const videoTime = transcriptTimeToVideoTime(transcriptTime);
+    if (videoPlayerRef?.current) {
+      videoPlayerRef.current.seek(Math.max(0, videoTime));
+    }
+  }, [transcriptTimeToVideoTime, videoPlayerRef]);
+
+  /**
+   * getSegmentClassName — Returns a CSS class name for styling the segment.
+   * @param {number} index — Segment index
+   * @returns {string} CSS class name(s)
+   */
+  const getSegmentClassName = useCallback((index) => {
+    const classes = ['transcript-segment'];
+    if (index === activeSegmentIndex) {
+      classes.push('transcript-segment--active');
+    }
+    return classes.join(' ');
+  }, [activeSegmentIndex]);
+
+  /**
+   * registerSegmentRef — Call this with a ref callback on each segment element
+   * to enable auto-scrolling.
+   * Usage: <div ref={(el) => registerSegmentRef(index, el)} ...>
+   */
+  const registerSegmentRef = useCallback((index, element) => {
+    if (element) {
+      segmentRefs.current.set(index, element);
+    } else {
+      segmentRefs.current.delete(index);
+    }
+  }, []);
+
+  // Compute active segment ID
+  const activeSegmentId = activeSegmentIndex >= 0 && segments[activeSegmentIndex]
+    ? (segments[activeSegmentIndex].segmentId || segments[activeSegmentIndex].SegmentId || null)
+    : null;
+
+  // Reset state when segments change
+  useEffect(() => {
+    setActiveSegmentIndex(-1);
+    lastScrolledIndex.current = -1;
+  }, [segments]);
+
+  return {
+    // State
+    activeSegmentIndex,
+    activeSegmentId,
+    isPlaying,
+    currentTime,
+
+    // Actions
+    seekToSegment,
+    seekToTime,
+    handleTimeUpdate,
+
+    // Helpers
+    getSegmentClassName,
+    registerSegmentRef,
+
+    // Utilities
+    videoTimeToTranscriptTime,
+    transcriptTimeToVideoTime,
+  };
+};
+
+export default useVideoSync;

--- a/lma-ai-stack/source/ui/src/components/video-player/video-api.ts
+++ b/lma-ai-stack/source/ui/src/components/video-player/video-api.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2025 Amazon.com
+ * This file is licensed under the MIT License.
+ * See the LICENSE file in the project root for full license information.
+ */
+import { ConsoleLogger } from 'aws-amplify/utils';
+import { S3Client, ListObjectsV2Command, HeadObjectCommand } from '@aws-sdk/client-s3';
+import generateS3PresignedUrl from '../common/generate-s3-presigned-url';
+
+const logger = new ConsoleLogger('VideoAPI');
+
+// Configuration — these should come from environment/settings
+const VIDEO_BUCKET = process.env.REACT_APP_VIDEO_BUCKET || '';
+const VIDEO_PREFIX = 'lma-video-recordings/';
+const VIDEO_REGION = process.env.REACT_APP_AWS_REGION || 'us-east-1';
+
+/**
+ * Get the video recording URL for a given callId.
+ *
+ * Video recordings are stored in S3 at:
+ *   s3://{bucket}/lma-video-recordings/call_{callId}_{timestamp}.mp4
+ *
+ * Strategy:
+ *   1. List objects with prefix `lma-video-recordings/call_{callId}_`
+ *   2. Return the most recent one (by LastModified)
+ *   3. If none found, return { status: 'not-found' }
+ *   4. If object exists but is 0 bytes or very small, return { status: 'processing' }
+ *
+ * @param {string} callId — The call/meeting ID
+ * @param {Object} credentials — AWS credentials from Cognito
+ * @returns {Promise<{ status: string, url?: string, key?: string }>}
+ */
+export const getVideoRecordingUrl = async (callId, credentials) => {
+  if (!callId) {
+    return { status: 'not-found' };
+  }
+
+  if (!VIDEO_BUCKET) {
+    logger.warn('VIDEO_BUCKET not configured — video playback disabled');
+    return { status: 'not-found' };
+  }
+
+  try {
+    const s3Client = new S3Client({
+      region: VIDEO_REGION,
+      credentials,
+    });
+
+    // List objects matching this callId
+    const prefix = `${VIDEO_PREFIX}call_${callId}_`;
+    logger.debug('Listing video objects with prefix:', prefix);
+
+    const listCommand = new ListObjectsV2Command({
+      Bucket: VIDEO_BUCKET,
+      Prefix: prefix,
+      MaxKeys: 10,
+    });
+
+    const listResponse = await s3Client.send(listCommand);
+
+    if (!listResponse.Contents || listResponse.Contents.length === 0) {
+      logger.debug('No video recordings found for callId:', callId);
+      return { status: 'not-found' };
+    }
+
+    // Sort by LastModified descending — get the most recent recording
+    const sortedObjects = listResponse.Contents.sort(
+      (a, b) => new Date(b.LastModified) - new Date(a.LastModified)
+    );
+
+    const latestObject = sortedObjects[0];
+    logger.debug('Found video recording:', latestObject.Key, 'Size:', latestObject.Size);
+
+    // If the file is very small, it might still be processing/uploading
+    if (latestObject.Size < 1000) {
+      logger.debug('Video file too small, likely still processing');
+      return { status: 'processing', key: latestObject.Key };
+    }
+
+    // Construct the S3 URL
+    const s3Url = `https://${VIDEO_BUCKET}.s3.${VIDEO_REGION}.amazonaws.com/${latestObject.Key}`;
+
+    return {
+      status: 'ready',
+      url: s3Url,
+      key: latestObject.Key,
+      size: latestObject.Size,
+      lastModified: latestObject.LastModified,
+    };
+  } catch (error) {
+    logger.error('Error looking up video recording:', error);
+
+    // If access denied, the bucket might not have video recording enabled
+    if (error.name === 'AccessDenied' || error.$metadata?.httpStatusCode === 403) {
+      return { status: 'not-found' };
+    }
+
+    throw error;
+  }
+};
+
+/**
+ * List all video recordings available in the bucket.
+ * Useful for admin/debugging views.
+ *
+ * @param {Object} credentials — AWS credentials from Cognito
+ * @param {Object} [options]
+ * @param {number} [options.maxResults=50] — Maximum results to return
+ * @param {string} [options.continuationToken] — For pagination
+ * @returns {Promise<{ recordings: Array, nextToken?: string }>}
+ */
+export const listVideoRecordings = async (credentials, options = {}) => {
+  const { maxResults = 50, continuationToken } = options;
+
+  if (!VIDEO_BUCKET) {
+    logger.warn('VIDEO_BUCKET not configured');
+    return { recordings: [] };
+  }
+
+  try {
+    const s3Client = new S3Client({
+      region: VIDEO_REGION,
+      credentials,
+    });
+
+    const command = new ListObjectsV2Command({
+      Bucket: VIDEO_BUCKET,
+      Prefix: VIDEO_PREFIX,
+      MaxKeys: maxResults,
+      ContinuationToken: continuationToken,
+    });
+
+    const response = await s3Client.send(command);
+
+    const recordings = (response.Contents || [])
+      .filter((obj) => obj.Key.endsWith('.mp4') && obj.Size > 1000)
+      .map((obj) => {
+        // Extract callId from key: lma-video-recordings/call_{callId}_{timestamp}.mp4
+        const filename = obj.Key.replace(VIDEO_PREFIX, '');
+        const match = filename.match(/^call_(.+?)_(\d+)\.mp4$/);
+
+        return {
+          key: obj.Key,
+          callId: match ? match[1] : null,
+          timestamp: match ? new Date(parseInt(match[2], 10)) : null,
+          size: obj.Size,
+          lastModified: obj.LastModified,
+          url: `https://${VIDEO_BUCKET}.s3.${VIDEO_REGION}.amazonaws.com/${obj.Key}`,
+        };
+      })
+      .filter((r) => r.callId); // Only include valid recordings
+
+    return {
+      recordings,
+      nextToken: response.IsTruncated ? response.NextContinuationToken : undefined,
+    };
+  } catch (error) {
+    logger.error('Error listing video recordings:', error);
+    return { recordings: [] };
+  }
+};
+
+/**
+ * Check if a video recording exists for a callId without fetching the full URL.
+ * Lighter weight than getVideoRecordingUrl — good for conditional rendering.
+ *
+ * @param {string} callId
+ * @param {Object} credentials
+ * @returns {Promise<boolean>}
+ */
+export const hasVideoRecording = async (callId, credentials) => {
+  const result = await getVideoRecordingUrl(callId, credentials);
+  return result.status === 'ready';
+};
+
+export default {
+  getVideoRecordingUrl,
+  listVideoRecordings,
+  hasVideoRecording,
+};

--- a/lma-ai-stack/source/ui/src/components/video-player/video-api.ts
+++ b/lma-ai-stack/source/ui/src/components/video-player/video-api.ts
@@ -4,15 +4,15 @@
  * See the LICENSE file in the project root for full license information.
  */
 import { ConsoleLogger } from 'aws-amplify/utils';
-import { S3Client, ListObjectsV2Command, HeadObjectCommand } from '@aws-sdk/client-s3';
+import { S3Client, ListObjectsV2Command } from '@aws-sdk/client-s3';
 import generateS3PresignedUrl from '../common/generate-s3-presigned-url';
 
 const logger = new ConsoleLogger('VideoAPI');
 
 // Configuration — these should come from environment/settings
-const VIDEO_BUCKET = process.env.REACT_APP_VIDEO_BUCKET || '';
+const VIDEO_BUCKET = import.meta.env.VITE_VIDEO_BUCKET || '';
 const VIDEO_PREFIX = 'lma-video-recordings/';
-const VIDEO_REGION = process.env.REACT_APP_AWS_REGION || 'us-east-1';
+const VIDEO_REGION = import.meta.env.VITE_AWS_REGION || 'us-east-1';
 
 /**
  * Get the video recording URL for a given callId.

--- a/lma-virtual-participant-stack/backend/src/video-recorder.ts
+++ b/lma-virtual-participant-stack/backend/src/video-recorder.ts
@@ -1,0 +1,447 @@
+/**
+ * video-recorder.ts — X11 screen recording with chunked S3 upload
+ *
+ * Captures the VP's X11 display (the meeting browser window visible via VNC)
+ * using FFmpeg, uploads .ts segments to S3 incrementally, and assembles a
+ * seekable .mp4 on call end.
+ *
+ * Architecture mirrors the existing audio RecordingService:
+ *   FFmpeg → local .ts chunks → S3 upload → concat to .mp4
+ *
+ * Feature-flagged via ENABLE_VIDEO_RECORDING environment variable.
+ * Default: disabled (no impact on existing audio-only deployments).
+ *
+ * @see recording.ts for the parallel audio recording implementation
+ */
+
+import { spawn, execSync, ChildProcess } from 'child_process';
+import {
+  existsSync,
+  statSync,
+  createReadStream,
+  readdirSync,
+  mkdirSync,
+  unlinkSync,
+  writeFileSync,
+} from 'fs';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { details } from './details.js';
+import path from 'path';
+
+// ─── Configuration (from environment) ────────────────────────────────────────
+const ENABLE_VIDEO = process.env.ENABLE_VIDEO_RECORDING === 'true';
+const RESOLUTION = process.env.VIDEO_RESOLUTION || '1920x1080';
+const FRAMERATE = process.env.VIDEO_FRAMERATE || '5';
+const DISPLAY = process.env.DISPLAY || ':99';
+const SEGMENT_DURATION = parseInt(process.env.VIDEO_SEGMENT_DURATION || '60', 10);
+const BUCKET = process.env.RECORDINGS_BUCKET_NAME || '';
+const VIDEO_PREFIX = process.env.VIDEO_RECORDINGS_KEY_PREFIX || 'lma-video-recordings/';
+const CHUNKS_PREFIX = process.env.VIDEO_CHUNKS_KEY_PREFIX || 'lma-video-chunks/';
+const REGION = process.env.AWS_REGION || 'us-east-1';
+const CHUNKS_DIR = '/tmp/video_chunks';
+const AUDIO_SINK = 'combined_audio.monitor';
+const AUDIO_WAIT_TIMEOUT_MS = 15_000;
+const CHUNK_POLL_INTERVAL_MS = 5_000;
+const FFMPEG_STOP_TIMEOUT_MS = 8_000;
+
+/**
+ * VideoRecorder — Singleton class that manages the lifecycle of an FFmpeg
+ * screen-recording process with incremental S3 upload.
+ */
+class VideoRecorder {
+  private ffmpegProcess: ChildProcess | null = null;
+  private s3Client: S3Client;
+  private callId: string = '';
+  private uploadedChunks: string[] = [];
+  private chunkWatcher: ReturnType<typeof setInterval> | null = null;
+  private lastChunkIndex: number = -1;
+  private _isRecording: boolean = false;
+
+  constructor() {
+    this.s3Client = new S3Client({ region: REGION });
+  }
+
+  /** Whether video recording is currently active. */
+  get isRecording(): boolean {
+    return this._isRecording;
+  }
+
+  /**
+   * Poll for a PulseAudio source to become available.
+   *
+   * The `combined_audio.monitor` source is created by the transcription service
+   * after the WebRTC audio pipeline is established. It may not exist when video
+   * recording starts (race condition), so we poll with a timeout.
+   *
+   * @returns true if the sink is available, false if timeout reached
+   */
+  private async waitForAudioSink(
+    sinkName: string,
+    timeoutMs: number = AUDIO_WAIT_TIMEOUT_MS
+  ): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      try {
+        const result = execSync(
+          `pactl list short sources 2>/dev/null | grep ${sinkName}`,
+          { encoding: 'utf-8', timeout: 2000 }
+        );
+        if (result.trim().length > 0) {
+          console.log(`[VideoRecorder] Audio sink '${sinkName}' is available`);
+          return true;
+        }
+      } catch {
+        // Source not available yet — continue polling
+      }
+      await new Promise((r) => setTimeout(r, 1000));
+    }
+    console.warn(
+      `[VideoRecorder] Audio sink '${sinkName}' not available after ${timeoutMs}ms — recording video only`
+    );
+    return false;
+  }
+
+  /**
+   * Start recording the X11 display to segmented MPEG-TS files.
+   *
+   * Each segment is uploaded to S3 as it completes (streaming upload pattern).
+   * This ensures minimal data loss if the container is terminated unexpectedly.
+   *
+   * @param callId — Unique identifier for this call (used in S3 key naming)
+   */
+  async start(callId: string): Promise<void> {
+    if (!ENABLE_VIDEO) {
+      console.log('[VideoRecorder] Disabled (ENABLE_VIDEO_RECORDING != true)');
+      return;
+    }
+    if (!BUCKET) {
+      console.error('[VideoRecorder] RECORDINGS_BUCKET_NAME not set, cannot record');
+      return;
+    }
+
+    this.callId = callId;
+    this.uploadedChunks = [];
+    this.lastChunkIndex = -1;
+    this._isRecording = true;
+
+    // Prepare chunk directory
+    if (!existsSync(CHUNKS_DIR)) {
+      mkdirSync(CHUNKS_DIR, { recursive: true });
+    }
+    // Clean leftover chunks from any previous recording
+    try {
+      for (const f of readdirSync(CHUNKS_DIR)) {
+        unlinkSync(path.join(CHUNKS_DIR, f));
+      }
+    } catch {
+      // Ignore cleanup errors
+    }
+
+    const segmentPattern = path.join(CHUNKS_DIR, 'segment_%03d.ts');
+    console.log(`[VideoRecorder] Starting: ${DISPLAY} @ ${RESOLUTION} ${FRAMERATE}fps`);
+    console.log(`[VideoRecorder] Segments: ${SEGMENT_DURATION}s chunks to ${CHUNKS_DIR}`);
+
+    // Wait for PulseAudio combined_audio.monitor to become available
+    const audioAvailable = await this.waitForAudioSink(AUDIO_SINK);
+
+    // Build FFmpeg arguments dynamically based on audio availability
+    const ffmpegArgs: string[] = [
+      '-f', 'x11grab',
+      '-video_size', RESOLUTION,
+      '-framerate', FRAMERATE,
+      '-i', DISPLAY,
+    ];
+
+    if (audioAvailable) {
+      console.log('[VideoRecorder] Audio sink available — recording video + audio');
+      ffmpegArgs.push('-f', 'pulse', '-i', AUDIO_SINK);
+      ffmpegArgs.push('-map', '0:v', '-map', '1:a');
+    } else {
+      console.warn('[VideoRecorder] Audio sink NOT available — recording video only');
+    }
+
+    // Video codec settings (optimized for low CPU usage on shared instance)
+    ffmpegArgs.push(
+      '-c:v', 'libx264',
+      '-preset', 'ultrafast',
+      '-crf', '28',
+      '-pix_fmt', 'yuv420p'
+    );
+
+    // Audio codec (if audio available)
+    if (audioAvailable) {
+      ffmpegArgs.push('-c:a', 'aac', '-b:a', '128k');
+    }
+
+    // Segmentation settings
+    ffmpegArgs.push(
+      '-f', 'segment',
+      '-segment_time', String(SEGMENT_DURATION),
+      '-segment_format', 'mpegts',
+      '-reset_timestamps', '1',
+      '-y',
+      segmentPattern
+    );
+
+    // Launch FFmpeg
+    this.ffmpegProcess = spawn('ffmpeg', ffmpegArgs);
+
+    this.ffmpegProcess.on('error', (error: Error) => {
+      console.error(`[VideoRecorder] FFmpeg error: ${error.message}`);
+      this.ffmpegProcess = null;
+    });
+
+    this.ffmpegProcess.on('exit', (code: number | null, signal: string | null) => {
+      this._isRecording = false;
+      if (code !== 0 && signal !== 'SIGTERM' && signal !== 'SIGINT') {
+        console.warn(`[VideoRecorder] FFmpeg exited: code=${code}, signal=${signal}`);
+      } else {
+        console.log(`[VideoRecorder] FFmpeg stopped (code=${code}, signal=${signal})`);
+      }
+    });
+
+    // Log FFmpeg errors (filter out noisy progress lines)
+    this.ffmpegProcess.stderr?.on('data', (data: Buffer) => {
+      const msg = data.toString();
+      if (
+        !msg.includes('frame=') &&
+        !msg.includes('fps=') &&
+        !msg.includes('size=') &&
+        !msg.includes('time=') &&
+        !msg.includes('bitrate=') &&
+        !msg.includes('speed=') &&
+        !msg.includes('Past duration')
+      ) {
+        console.log('[VideoRecorder] FFmpeg:', msg.trim());
+      }
+    });
+
+    // Start background chunk uploader
+    this.startChunkUploader();
+  }
+
+  /**
+   * Poll for completed .ts segment files and upload to S3 incrementally.
+   * Only uploads segments that are no longer being written (all except the last).
+   */
+  private startChunkUploader(): void {
+    this.chunkWatcher = setInterval(async () => {
+      try {
+        const files = readdirSync(CHUNKS_DIR)
+          .filter((f) => f.startsWith('segment_') && f.endsWith('.ts'))
+          .sort();
+
+        // Upload all segments except the last (still being written by FFmpeg)
+        for (let i = 0; i < files.length - 1; i++) {
+          const idx = parseInt(files[i].replace('segment_', '').replace('.ts', ''), 10);
+          if (idx <= this.lastChunkIndex) continue; // Already uploaded
+
+          const filePath = path.join(CHUNKS_DIR, files[i]);
+          const key = `${CHUNKS_PREFIX}${this.callId}/${files[i]}`;
+
+          try {
+            const fileStream = createReadStream(filePath);
+            const fileSize = statSync(filePath).size;
+            await this.s3Client.send(
+              new PutObjectCommand({
+                Bucket: BUCKET,
+                Key: key,
+                Body: fileStream,
+                ContentType: 'video/mp2t',
+              })
+            );
+            this.uploadedChunks.push(key);
+            this.lastChunkIndex = idx;
+            console.log(
+              `[VideoRecorder] Uploaded chunk ${files[i]} (${(fileSize / 1024).toFixed(0)}KB)`
+            );
+          } catch (uploadErr: any) {
+            console.error(`[VideoRecorder] Chunk upload failed: ${uploadErr.message}`);
+          }
+        }
+      } catch {
+        // Directory may not exist yet during startup
+      }
+    }, CHUNK_POLL_INTERVAL_MS);
+  }
+
+  /**
+   * Stop recording, upload remaining segments, concatenate into MP4, and upload.
+   *
+   * @returns S3 URI of the final .mp4 recording, or null if no recording was made
+   */
+  async stop(): Promise<string | null> {
+    if (!this._isRecording && !this.ffmpegProcess) {
+      return null;
+    }
+
+    // Stop chunk uploader
+    if (this.chunkWatcher) {
+      clearInterval(this.chunkWatcher);
+      this.chunkWatcher = null;
+    }
+
+    // Graceful stop: SIGINT first (FFmpeg finalizes current segment), SIGTERM fallback
+    if (this.ffmpegProcess) {
+      console.log('[VideoRecorder] Stopping FFmpeg (SIGINT)...');
+      this.ffmpegProcess.kill('SIGINT');
+
+      await new Promise<void>((resolve) => {
+        const timeout = setTimeout(() => {
+          if (this.ffmpegProcess) {
+            console.log('[VideoRecorder] SIGTERM fallback');
+            this.ffmpegProcess.kill('SIGTERM');
+          }
+          resolve();
+        }, FFMPEG_STOP_TIMEOUT_MS);
+
+        if (this.ffmpegProcess) {
+          this.ffmpegProcess.on('exit', () => {
+            clearTimeout(timeout);
+            resolve();
+          });
+        } else {
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+      this.ffmpegProcess = null;
+    }
+
+    // Upload any remaining chunks that weren't caught by the poller
+    try {
+      const files = readdirSync(CHUNKS_DIR)
+        .filter((f) => f.startsWith('segment_') && f.endsWith('.ts'))
+        .sort();
+
+      for (const file of files) {
+        const idx = parseInt(file.replace('segment_', '').replace('.ts', ''), 10);
+        if (idx <= this.lastChunkIndex) continue;
+
+        const filePath = path.join(CHUNKS_DIR, file);
+        const fileSize = statSync(filePath).size;
+        if (fileSize === 0) continue;
+
+        const fileStream = createReadStream(filePath);
+        const key = `${CHUNKS_PREFIX}${this.callId}/${file}`;
+        await this.s3Client.send(
+          new PutObjectCommand({
+            Bucket: BUCKET,
+            Key: key,
+            Body: fileStream,
+            ContentType: 'video/mp2t',
+          })
+        );
+        this.uploadedChunks.push(key);
+        this.lastChunkIndex = idx;
+        console.log(
+          `[VideoRecorder] Uploaded final chunk ${file} (${(fileSize / 1024).toFixed(0)}KB)`
+        );
+      }
+    } catch (e: any) {
+      console.error(`[VideoRecorder] Final chunk upload error: ${e.message}`);
+    }
+
+    // If no chunks were recorded, nothing to concatenate
+    if (this.uploadedChunks.length === 0) {
+      console.log('[VideoRecorder] No chunks recorded');
+      this.cleanup();
+      return null;
+    }
+
+    // Concatenate all segments into a single seekable MP4
+    try {
+      const finalUri = await this.concatenateAndUpload();
+      this.cleanup();
+      return finalUri;
+    } catch (e: any) {
+      console.error(`[VideoRecorder] Concat/upload failed: ${e.message}`);
+      this.cleanup();
+      return null;
+    }
+  }
+
+  /**
+   * Concatenate local .ts chunks into a single .mp4 and upload to S3.
+   * Uses FFmpeg concat demuxer with +faststart for seekable browser playback.
+   */
+  private async concatenateAndUpload(): Promise<string | null> {
+    const files = readdirSync(CHUNKS_DIR)
+      .filter((f) => f.startsWith('segment_') && f.endsWith('.ts'))
+      .sort();
+
+    if (files.length === 0) return null;
+
+    // Write FFmpeg concat list file
+    const concatList = files.map((f) => `file '${path.join(CHUNKS_DIR, f)}'`).join('\n');
+    const concatFile = '/tmp/video_concat_list.txt';
+    writeFileSync(concatFile, concatList);
+
+    const outputFile = '/tmp/video_final.mp4';
+
+    // Concat with +faststart moov atom for seekable browser playback
+    await new Promise<void>((resolve, reject) => {
+      const proc = spawn('ffmpeg', [
+        '-f', 'concat',
+        '-safe', '0',
+        '-i', concatFile,
+        '-c', 'copy',
+        '-movflags', '+faststart',
+        '-y',
+        outputFile,
+      ]);
+      proc.on('error', reject);
+      proc.on('exit', (code) => {
+        if (code === 0) resolve();
+        else reject(new Error(`ffmpeg concat exited with code ${code}`));
+      });
+      proc.stderr?.on('data', (data: Buffer) => {
+        const msg = data.toString();
+        if (msg.includes('error') || msg.includes('Error')) {
+          console.error('[VideoRecorder] Concat:', msg.trim());
+        }
+      });
+    });
+
+    // Upload final MP4 to S3
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const callName = this.callId || 'call';
+    const finalKey = `${VIDEO_PREFIX}call_${callName}_${timestamp}.mp4`;
+    const fileSize = statSync(outputFile).size;
+    const fileStream = createReadStream(outputFile);
+
+    await this.s3Client.send(
+      new PutObjectCommand({
+        Bucket: BUCKET,
+        Key: finalKey,
+        Body: fileStream,
+        ContentType: 'video/mp4',
+      })
+    );
+
+    const uri = `s3://${BUCKET}/${finalKey}`;
+    console.log(
+      `[VideoRecorder] Final video uploaded: ${uri} (${(fileSize / 1024 / 1024).toFixed(1)}MB)`
+    );
+    return uri;
+  }
+
+  /**
+   * Clean up temporary files from /tmp.
+   */
+  private cleanup(): void {
+    try {
+      const files = readdirSync(CHUNKS_DIR);
+      for (const f of files) {
+        unlinkSync(path.join(CHUNKS_DIR, f));
+      }
+      if (existsSync('/tmp/video_concat_list.txt')) unlinkSync('/tmp/video_concat_list.txt');
+      if (existsSync('/tmp/video_final.mp4')) unlinkSync('/tmp/video_final.mp4');
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+}
+
+// Export singleton instance (mirrors recordingService pattern from recording.ts)
+export const videoRecorder = new VideoRecorder();


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><p node="[object Object]"><strong>Author:</strong> Ken Beauvais (<a href="mailto:kenbeau@amazon.com" target="_blank" rel="noopener noreferrer">kenbeau@amazon.com</a>)<br>
<strong>Branch:</strong> <code class="inline-code">feat/video-recording</code> → <code class="inline-code">develop</code><br>
<strong>Files:</strong> <code class="inline-code">lma-virtual-participant-stack/backend/src/video-recorder.ts</code> (NEW) + <code class="inline-code">lma-ai-stack/source/ui/src/components/video-player/</code> (NEW, 5 files)</p>
<hr>
<h2>Problem</h2>
<p node="[object Object]">LMA's Virtual Participant currently <strong>only records audio</strong> (WAV). When reviewing past meetings, users see transcripts and hear audio but have <strong>no visual context</strong> — they can't see screen shares, participant expressions, whiteboard content, or the meeting platform UI. This limits the value of meeting recordings for:</p>
<ul>
<li>Post-meeting review and documentation</li>
<li>Compliance and audit requirements</li>
<li>AI-powered video analysis (facial expressions, screen content OCR, visual context)</li>
<li>Training and coaching scenarios</li>
</ul>
<h2>Solution</h2>
<p node="[object Object]">Add <strong>X11 screen recording</strong> to the Virtual Participant using FFmpeg. The VP already renders the meeting in a browser via X11/VNC — this PR captures that display as video and uploads it to S3 alongside the existing audio recording. Also includes a <strong>UI VideoPlayer component</strong> for playback within the LMA call detail view.</p>
<h3>Key Design Decisions</h3>

Decision | Choice | Rationale
-- | -- | --
Capture source | ffmpeg -f x11grab | X11 display already shows the meeting; no WebRTC interception needed
Frame rate | 5 fps (configurable) | Readable text/slides at minimal CPU cost (~5-10% overhead)
Segmentation | 60s .ts chunks → S3 | Incremental upload prevents data loss on container crash
Audio source | PulseAudio combined_audio.monitor | Same sink as transcription; captures all meeting participants
Final format | .mp4 with +faststart | Seekable browser playback without full download
Codec | libx264 -preset ultrafast -crf 28 | Minimizes CPU load on shared ECS instance
Feature flag | ENABLE_VIDEO_RECORDING | Default: disabled. Zero impact on existing deployments


<h3>No New Dependencies</h3>
<p node="[object Object]">Uses only <code class="inline-code">child_process</code>, <code class="inline-code">fs</code>, <code class="inline-code">path</code> (Node.js built-ins) + <code class="inline-code">@aws-sdk/client-s3</code> (already in package.json). FFmpeg is already in the container.</p>
<h3>UI Notes</h3>
<ul>
<li><strong>VideoPlayer.tsx</strong> — Renders inside a Cloudscape <code class="inline-code">Container</code>. Uses <code class="inline-code">video-api.ts</code> to look up recordings via S3 with Cognito credentials. Self-hides when no video exists for the call (zero visual impact on calls without recordings).</li>
<li><strong>video-api.ts</strong> — Looks up videos via <code class="inline-code">ListObjectsV2</code> using prefix <code class="inline-code">lma-video-recordings/call_{callId}_*</code>. Matches the naming convention used by <code class="inline-code">video-recorder.ts</code>. Uses authenticated credentials from the app's Cognito identity pool.</li>
<li><strong>useVideoSync.ts</strong> — Included as a <strong>ready-to-integrate utility</strong> for future bidirectional transcript↔video synchronization (click transcript segment → seek video, video playback → highlight active segment). <strong>Not yet wired</strong> into CallPanel — provided so the integration can be done without rewriting the sync logic.</li>
</ul>
<h2>Integration Points (index.ts)</h2>
<pre><div class="code-block-wrapper"><pre class="code-block" style="background-color: rgb(40, 44, 52); color: rgb(171, 178, 191); text-shadow: rgba(0, 0, 0, 0.3) 0px 1px; margin: 0px;"><div class="token-line" style="color: rgb(171, 178, 191); text-shadow: rgba(0, 0, 0, 0.3) 0px 1px;"><span class="token keyword" style="color: rgb(198, 120, 221);">import</span><span class="token plain"> </span><span class="token punctuation" style="color: rgb(171, 178, 191);">{</span><span class="token plain"> videoRecorder </span><span class="token punctuation" style="color: rgb(171, 178, 191);">}</span><span class="token plain"> </span><span class="token keyword" style="color: rgb(198, 120, 221);">from</span><span class="token plain"> </span><span class="token string" style="color: rgb(152, 195, 121);">'./video-recorder.js'</span><span class="token punctuation" style="color: rgb(171, 178, 191);">;</span><span class="token plain"></span></div><div class="token-line" style="color: rgb(171, 178, 191); text-shadow: rgba(0, 0, 0, 0.3) 0px 1px;"><span class="token plain" style="display: inline-block;">
</span></div><div class="token-line" style="color: rgb(171, 178, 191); text-shadow: rgba(0, 0, 0, 0.3) 0px 1px;"><span class="token plain"></span><span class="token comment" style="color: rgb(92, 99, 112);">// After recordingService.startRecording():</span><span class="token plain"></span></div><div class="token-line" style="color: rgb(171, 178, 191); text-shadow: rgba(0, 0, 0, 0.3) 0px 1px;"><span class="token plain"></span><span class="token keyword" style="color: rgb(198, 120, 221);">await</span><span class="token plain"> videoRecorder</span><span class="token punctuation" style="color: rgb(171, 178, 191);">.</span><span class="token function" style="color: rgb(97, 175, 239);">start</span><span class="token punctuation" style="color: rgb(171, 178, 191);">(</span><span class="token plain">callId</span><span class="token punctuation" style="color: rgb(171, 178, 191);">)</span><span class="token punctuation" style="color: rgb(171, 178, 191);">;</span><span class="token plain"></span></div><div class="token-line" style="color: rgb(171, 178, 191); text-shadow: rgba(0, 0, 0, 0.3) 0px 1px;"><span class="token plain" style="display: inline-block;">
</span></div><div class="token-line" style="color: rgb(171, 178, 191); text-shadow: rgba(0, 0, 0, 0.3) 0px 1px;"><span class="token plain"></span><span class="token comment" style="color: rgb(92, 99, 112);">// In finally{} block, before recordingService.cleanup():</span><span class="token plain"></span></div><div class="token-line" style="color: rgb(171, 178, 191); text-shadow: rgba(0, 0, 0, 0.3) 0px 1px;"><span class="token plain"></span><span class="token keyword" style="color: rgb(198, 120, 221);">const</span><span class="token plain"> videoUri </span><span class="token operator" style="color: rgb(97, 175, 239);">=</span><span class="token plain"> </span><span class="token keyword" style="color: rgb(198, 120, 221);">await</span><span class="token plain"> videoRecorder</span><span class="token punctuation" style="color: rgb(171, 178, 191);">.</span><span class="token function" style="color: rgb(97, 175, 239);">stop</span><span class="token punctuation" style="color: rgb(171, 178, 191);">(</span><span class="token punctuation" style="color: rgb(171, 178, 191);">)</span><span class="token punctuation" style="color: rgb(171, 178, 191);">;</span><span class="token plain"></span></div><div class="token-line" style="color: rgb(171, 178, 191); text-shadow: rgba(0, 0, 0, 0.3) 0px 1px;"><span class="token plain"></span><span class="token keyword" style="color: rgb(198, 120, 221);">if</span><span class="token plain"> </span><span class="token punctuation" style="color: rgb(171, 178, 191);">(</span><span class="token plain">videoUri</span><span class="token punctuation" style="color: rgb(171, 178, 191);">)</span><span class="token plain"> </span><span class="token keyword" style="color: rgb(198, 120, 221);">await</span><span class="token plain"> kinesisStreamManager</span><span class="token punctuation" style="color: rgb(171, 178, 191);">.</span><span class="token function" style="color: rgb(97, 175, 239);">sendCallRecording</span><span class="token punctuation" style="color: rgb(171, 178, 191);">(</span><span class="token plain">videoUri</span><span class="token punctuation" style="color: rgb(171, 178, 191);">)</span><span class="token punctuation" style="color: rgb(171, 178, 191);">;</span></div></pre></div></pre>
<h2>Testing</h2>
<h3>Expected logs (video enabled):</h3>
<pre><div class="code-block-wrapper"><pre class="code-block" style="background-color: rgb(40, 44, 52); color: rgb(171, 178, 191); text-shadow: rgba(0, 0, 0, 0.3) 0px 1px; margin: 0px;"><div class="token-line" style="color: rgb(171, 178, 191); text-shadow: rgba(0, 0, 0, 0.3) 0px 1px;"><span class="token plain">[VideoRecorder] Starting: :99 @ 1920x1080 5fps</span></div><div class="token-line" style="color: rgb(171, 178, 191); text-shadow: rgba(0, 0, 0, 0.3) 0px 1px;"><span class="token plain">[VideoRecorder] Audio sink 'combined_audio.monitor' is available</span></div><div class="token-line" style="color: rgb(171, 178, 191); text-shadow: rgba(0, 0, 0, 0.3) 0px 1px;"><span class="token plain">[VideoRecorder] Uploaded chunk segment_000.ts (3421KB)</span></div><div class="token-line" style="color: rgb(171, 178, 191); text-shadow: rgba(0, 0, 0, 0.3) 0px 1px;"><span class="token plain">[VideoRecorder] Final video: s3://bucket/lma-video-recordings/call_MyMeeting_2026-06-15T01-30-00Z.mp4 (18.2MB)</span></div></pre></div></pre>
<h3>Expected logs (video disabled):</h3>
<pre><code class="inline-code">[VideoRecorder] Disabled (ENABLE_VIDEO_RECORDING != true)
</code></pre>
<h3>Verification:</h3>
<ol>
<li>Set <code class="inline-code">ENABLE_VIDEO_RECORDING=true</code> in task definition</li>
<li>Launch VP into any meeting</li>
<li>After call ends, check S3 for <code class="inline-code">lma-video-recordings/call_{id}_*.mp4</code></li>
<li>Play in browser — should be seekable with audio</li>
</ol>
<h2>Rollback</h2>
<p node="[object Object]">Set <code class="inline-code">ENABLE_VIDEO_RECORDING=false</code> in the task definition. No image rebuild needed — the recorder checks this flag at startup and exits immediately if disabled.</p>
<h2>Related</h2>
<ul>
<li>Discussed in #live-meeting-assistant-interest (June 5, 2026)</li>
<li>Bob Strahan requested PR submission: "Do you want to do it? Send a PR?"</li>
<li>Jeremy Feldman confirmed FFmpeg approach feasibility</li>
<li>3+ confirmed end-to-end recordings in S3 (June 8-15, 2026)</li>
</ul>
<hr>
<p node="[object Object]"></p><!--EndFragment-->
</body>
</html>Author: Ken Beauvais ([kenbeau@amazon.com](mailto:kenbeau@amazon.com))
Branch: feat/video-recording → develop
Files: lma-virtual-participant-stack/backend/src/video-recorder.ts (NEW) + lma-ai-stack/source/ui/src/components/video-player/ (NEW, 5 files)

Problem
LMA's Virtual Participant currently only records audio (WAV). When reviewing past meetings, users see transcripts and hear audio but have no visual context — they can't see screen shares, participant expressions, whiteboard content, or the meeting platform UI. This limits the value of meeting recordings for:

Post-meeting review and documentation
Compliance and audit requirements
AI-powered video analysis (facial expressions, screen content OCR, visual context)
Training and coaching scenarios
Solution
Add X11 screen recording to the Virtual Participant using FFmpeg. The VP already renders the meeting in a browser via X11/VNC — this PR captures that display as video and uploads it to S3 alongside the existing audio recording. Also includes a UI VideoPlayer component for playback within the LMA call detail view.

Key Design Decisions
Decision	Choice	Rationale
Capture source	ffmpeg -f x11grab	X11 display already shows the meeting; no WebRTC interception needed
Frame rate	5 fps (configurable)	Readable text/slides at minimal CPU cost (~5-10% overhead)
Segmentation	60s .ts chunks → S3	Incremental upload prevents data loss on container crash
Audio source	PulseAudio combined_audio.monitor	Same sink as transcription; captures all meeting participants
Final format	.mp4 with +faststart	Seekable browser playback without full download
Codec	libx264 -preset ultrafast -crf 28	Minimizes CPU load on shared ECS instance
Feature flag	ENABLE_VIDEO_RECORDING	Default: disabled. Zero impact on existing deployments
Relationship to Existing Recording
This parallels the existing recording.ts (audio) pattern:

Aspect	Audio (existing)	Video (new)
Capture	PulseAudio → PCM stream	X11grab → MPEG-TS segments
Storage	Single WAV file	Chunked .ts → assembled .mp4
Upload trigger	On call end	Incremental (5s poll) + final on call end
S3 prefix	lma-audio-recordings/	lma-video-recordings/
Kinesis event	ADD_S3_RECORDING_URL	Same event type (reused)
Feature flag	ENABLE_AUDIO_RECORDING	ENABLE_VIDEO_RECORDING
Configuration
Variable	Default	Description
ENABLE_VIDEO_RECORDING	false	Feature flag — set true to enable
VIDEO_FRAMERATE	5	Capture frame rate (fps)
VIDEO_RESOLUTION	1920x1080	Capture resolution (matches display)
VIDEO_SEGMENT_DURATION	60	Seconds per .ts segment
VIDEO_RECORDINGS_KEY_PREFIX	lma-video-recordings/	S3 prefix for final .mp4 files
VIDEO_CHUNKS_KEY_PREFIX	lma-video-chunks/	S3 prefix for in-progress segments
Resource Requirements (when video enabled)
Resource	Without Video	With Video
CPU	2 vCPU	4 vCPU
Memory	4 GB	8 GB
S3 storage	~5 MB/call (WAV)	~30-50 MB/call (MP4 @ 5fps)
No local buffering of the full video — segments are uploaded as they complete (~3-5 MB per 60s segment max on disk).

Files Changed
File	Change	Lines
backend/src/video-recorder.ts	NEW — Core recording engine	~340
ui/src/components/video-player/VideoPlayer.tsx	NEW — React video player (Cloudscape Container, S3 lookup via Cognito credentials)	~80
ui/src/components/video-player/useVideoSync.ts	NEW — Utility hook for future transcript↔video sync (provided for integration, not yet wired to CallPanel)	~220
ui/src/components/video-player/video-api.ts	NEW — S3 video lookup service (ListObjectsV2 with call_{callId}_* prefix matching)	~160
ui/src/components/video-player/VideoPlayer.css	NEW — Minimal styling	3
ui/src/components/video-player/index.ts	NEW — Re-export	1
No New Dependencies
Uses only child_process, fs, path (Node.js built-ins) + @aws-sdk/client-s3 (already in package.json). FFmpeg is already in the container.

UI Notes
VideoPlayer.tsx — Renders inside a Cloudscape Container. Uses video-api.ts to look up recordings via S3 with Cognito credentials. Self-hides when no video exists for the call (zero visual impact on calls without recordings).
video-api.ts — Looks up videos via ListObjectsV2 using prefix lma-video-recordings/call_{callId}_*. Matches the naming convention used by video-recorder.ts. Uses authenticated credentials from the app's Cognito identity pool.
useVideoSync.ts — Included as a ready-to-integrate utility for future bidirectional transcript↔video synchronization (click transcript segment → seek video, video playback → highlight active segment). Not yet wired into CallPanel — provided so the integration can be done without rewriting the sync logic.
Integration Points (index.ts)

import { videoRecorder } from './video-recorder.js';

// After recordingService.startRecording():
await videoRecorder.start(callId);

// In finally{} block, before recordingService.cleanup():
const videoUri = await videoRecorder.stop();
if (videoUri) await kinesisStreamManager.sendCallRecording(videoUri);
Testing
Expected logs (video enabled):

[VideoRecorder] Starting: :99 @ 1920x1080 5fps
[VideoRecorder] Audio sink 'combined_audio.monitor' is available
[VideoRecorder] Uploaded chunk segment_000.ts (3421KB)
[VideoRecorder] Final video: s3://bucket/lma-video-recordings/call_MyMeeting_2026-06-15T01-30-00Z.mp4 (18.2MB)
Expected logs (video disabled):
[VideoRecorder] Disabled (ENABLE_VIDEO_RECORDING != true)
Verification:
Set ENABLE_VIDEO_RECORDING=true in task definition
Launch VP into any meeting
After call ends, check S3 for lma-video-recordings/call_{id}_*.mp4
Play in browser — should be seekable with audio
Rollback
Set ENABLE_VIDEO_RECORDING=false in the task definition. No image rebuild needed — the recorder checks this flag at startup and exits immediately if disabled.

Related
Discussed in #live-meeting-assistant-interest (June 5, 2026)
Bob Strahan requested PR submission: "Do you want to do it? Send a PR?"
Jeremy Feldman confirmed FFmpeg approach feasibility
3+ confirmed end-to-end recordings in S3 (June 8-15, 2026)