### PR TITLE
fix(ui): repair blank meeting detail & Stream Audio pages (Vite 8 CJS interop)

### DIFF
--- a/lma-ai-stack/source/ui/package-lock.json
+++ b/lma-ai-stack/source/ui/package-lock.json
@@ -34,7 +34,6 @@
         "docx": "^9.5.1",
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
-        "react-audio-player": "^0.17.0",
         "react-dom": "^18.3.1",
         "react-icons": "^4.12.0",
         "react-markdown": "^9.1.0",
@@ -10005,19 +10004,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-audio-player": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/react-audio-player/-/react-audio-player-0.17.0.tgz",
-      "integrity": "sha512-aCZgusPxA9HK7rLZcTdhTbBH9l6do9vn3NorgoDZRxRxJlOy9uZWzPaKjd7QdcuP2vXpxGA/61JMnnOEY7NXeA==",
-      "license": "MIT",
-      "dependencies": {
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
       }
     },
     "node_modules/react-dom": {

--- a/lma-ai-stack/source/ui/package.json
+++ b/lma-ai-stack/source/ui/package.json
@@ -34,7 +34,6 @@
     "docx": "^9.5.1",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
-    "react-audio-player": "^0.17.0",
     "react-dom": "^18.3.1",
     "react-icons": "^4.12.0",
     "react-markdown": "^9.1.0",

--- a/lma-ai-stack/source/ui/src/components/embed/EmbedMeetingLoader.jsx
+++ b/lma-ai-stack/source/ui/src/components/embed/EmbedMeetingLoader.jsx
@@ -35,11 +35,15 @@ import {
   Alert,
 } from '@cloudscape-design/components';
 import '@cloudscape-design/global-styles/index.css';
-import useWebSocket from 'react-use-websocket';
+import * as ReactUseWebSocket from 'react-use-websocket';
 import { DEFAULT_OTHER_SPEAKER_NAME, DEFAULT_LOCAL_SPEAKER_NAME, SYSTEM } from '../common/constants';
 import useAppContext from '../../contexts/app';
 import useSettingsContext from '../../contexts/settings';
 import { getTimestampStr } from '../common/utilities';
+
+// See StreamAudio.jsx: unwrap the double-wrapped CJS default for Vite 8 interop.
+const useWebSocket =
+  typeof ReactUseWebSocket.default === 'function' ? ReactUseWebSocket.default : ReactUseWebSocket.default.default;
 
 const logger = new ConsoleLogger('EmbedMeetingLoader');
 

--- a/lma-ai-stack/source/ui/src/components/embed/EmbedStreamAudio.jsx
+++ b/lma-ai-stack/source/ui/src/components/embed/EmbedStreamAudio.jsx
@@ -29,11 +29,15 @@ import {
   Link,
 } from '@cloudscape-design/components';
 import '@cloudscape-design/global-styles/index.css';
-import useWebSocket from 'react-use-websocket';
+import * as ReactUseWebSocket from 'react-use-websocket';
 import { DEFAULT_OTHER_SPEAKER_NAME, DEFAULT_LOCAL_SPEAKER_NAME, SYSTEM } from '../common/constants';
 import useAppContext from '../../contexts/app';
 import useSettingsContext from '../../contexts/settings';
 import { getTimestampStr } from '../common/utilities';
+
+// See StreamAudio.jsx: unwrap the double-wrapped CJS default for Vite 8 interop.
+const useWebSocket =
+  typeof ReactUseWebSocket.default === 'function' ? ReactUseWebSocket.default : ReactUseWebSocket.default.default;
 
 const logger = new ConsoleLogger('EmbedStreamAudio');
 

--- a/lma-ai-stack/source/ui/src/components/recording-player/RecordingPlayer.jsx
+++ b/lma-ai-stack/source/ui/src/components/recording-player/RecordingPlayer.jsx
@@ -5,7 +5,6 @@
  */
 import { ConsoleLogger } from 'aws-amplify/utils';
 import React, { useEffect, useState } from 'react';
-import ReactAudioPlayer from 'react-audio-player';
 
 import useAppContext from '../../contexts/app';
 import generateS3PresignedUrl from '../common/generate-s3-presigned-url';
@@ -35,7 +34,15 @@ export const RecordingPlayer = ({ recordingUrl }) => {
     fetchUrl();
   }, [recordingUrl, currentCredentials]);
 
-  return preSignedUrl?.length ? <ReactAudioPlayer src={preSignedUrl} controls /> : null;
+  // Native <audio> element (equivalent to the old react-audio-player wrapper,
+  // which was just a thin <audio> shim). Dropped that dependency: it shipped an
+  // ancient webpack UMD/CJS bundle whose default export the rolldown bundler
+  // (Vite 8) resolved to an object instead of a component, throwing React error
+  // #130 ("Element type is invalid") and blanking the meeting detail page
+  // whenever a recording was present. Native <audio> also removes the library's
+  // direct-`eval` build warning.
+  // eslint-disable-next-line jsx-a11y/media-has-caption
+  return preSignedUrl?.length ? <audio src={preSignedUrl} controls /> : null;
 };
 
 export default RecordingPlayer;

--- a/lma-ai-stack/source/ui/src/components/stream-audio/StreamAudio.jsx
+++ b/lma-ai-stack/source/ui/src/components/stream-audio/StreamAudio.jsx
@@ -25,7 +25,7 @@ import {
   Alert,
 } from '@cloudscape-design/components';
 import '@cloudscape-design/global-styles/index.css';
-import useWebSocket from 'react-use-websocket';
+import * as ReactUseWebSocket from 'react-use-websocket';
 import { generateClient } from 'aws-amplify/api';
 import { fetchUserAttributes } from 'aws-amplify/auth';
 
@@ -34,6 +34,14 @@ import useAppContext from '../../contexts/app';
 import useSettingsContext from '../../contexts/settings';
 import { getTimestampStr } from '../common/utilities';
 import createUploadMeeting from '../../graphql/queries/createUploadMeeting';
+
+// react-use-websocket ships a CJS bundle. Vite 8 / rolldown exports the CJS
+// module.exports OBJECT as the ESM default (a "double-wrapped default"), so the
+// hook is not the default itself but one level in. Unwrap to whichever level is
+// actually the function so this works regardless of bundler interop. (Same
+// interop class as the react-audio-player fix; blanks the page if wrong.)
+const useWebSocket =
+  typeof ReactUseWebSocket.default === 'function' ? ReactUseWebSocket.default : ReactUseWebSocket.default.default;
 
 let SOURCE_SAMPLING_RATE;
 const DEFAULT_BLANK_FIELD_MSG = 'This will be set back to the default value if left blank.';


### PR DESCRIPTION
## Problem

The Vite 8 / rolldown build-toolchain upgrade (#315) changed CommonJS default-export interop, silently breaking **two UI pages that now render blank** on any deployment built with the new toolchain:

1. **Meeting detail page** — clicking a meeting with a recording shows a blank screen. `react-audio-player` (an old webpack UMD/CJS bundle) resolves to an object instead of a component under rolldown, throwing **React error #130** ("Element type is invalid"). Only triggers once the recording's presigned URL loads, which is why the page paints then blanks.

2. **Stream Audio page** (`/#/stream`) and its two embed variants — blank with `useWebSocket is not a function`. `react-use-websocket`'s CJS default is **double-wrapped** by rolldown (the `module.exports` object is exported as the ESM default), so `import useWebSocket from 'react-use-websocket'` isn't the hook.

## Fix

- **RecordingPlayer**: replace `react-audio-player` with a native `<audio controls>` element (the library was just a thin `<audio>` shim) and **remove the dependency**. Also clears its `direct-eval` build warning.
- **StreamAudio / EmbedStreamAudio / EmbedMeetingLoader**: import the namespace and unwrap to whichever level is actually the function — bundler-interop-agnostic:
  ```js
  const useWebSocket =
    typeof ReactUseWebSocket.default === 'function' ? ReactUseWebSocket.default : ReactUseWebSocket.default.default;
  ```

## Testing

- `npm run build` succeeds; the removed dependency's `eval` warning is gone.
- Both pages verified working against a live LMA backend via the local dev server (`make ui-start`): the meeting detail page opens with a working audio player, and the Stream Audio page renders.
- ESLint clean on all changed files.

## Scope

UI-only, 6 files. No infrastructure or server changes. Independent of any feature work.