### PR TITLE
fix: durably remediate Mirador OS/container findings

### DIFF
--- a/lma-virtual-participant-stack/template.yaml
+++ b/lma-virtual-participant-stack/template.yaml
@@ -1529,6 +1529,110 @@ Resources:
         - Key: Name
           Value: !Sub "${AWS::StackName}-VP-Instance"
           PropagateAtLaunch: true
+        # Patch group tag consumed by VPPatchBaseline / VPPatchMaintenanceWindow
+        # below. This is what wires these hosts into SSM Patch Manager so OS
+        # security updates are applied on a schedule (the UserData intentionally
+        # does NOT patch at boot, to avoid startup slowdown and mid-meeting
+        # reboots). Without a Patch Manager configuration referencing this tag,
+        # nothing patches these hosts and they drift out of Mirador SLA.
+        - Key: LMA-VP-PatchGroup
+          Value: !Sub "${AWS::StackName}-VP"
+          PropagateAtLaunch: true
+
+  # ---------------------------------------------------------------------------
+  # SSM Patch Manager — owns OS security patching for the VP EC2 hosts.
+  #
+  # The VP LaunchTemplate pins the AMI to the SSM "recommended" ECS-optimized
+  # AL2 parameter, so a fresh launch is patched-at-launch. But long-lived hosts
+  # still accrue OS CVEs between launches, and the UserData deliberately does
+  # not run `yum update` at boot (it slowed launch and caused kernel-reboot
+  # mid-meeting task kills). These resources apply security patches during a
+  # scheduled maintenance window instead — no container-startup cost, and the
+  # reboot cadence is governed by the window rather than an ad-hoc boot-time
+  # kernel install.
+  # ---------------------------------------------------------------------------
+  VPPatchBaseline:
+    Type: AWS::SSM::PatchBaseline
+    Condition: UseEC2LaunchType
+    Properties:
+      Name: !Sub "${AWS::StackName}-VP-PatchBaseline"
+      Description: "Security patch baseline for LMA Virtual Participant EC2 hosts (Amazon Linux 2)"
+      OperatingSystem: AMAZON_LINUX_2
+      ApprovalRules:
+        PatchRules:
+          - PatchFilterGroup:
+              PatchFilters:
+                - Key: CLASSIFICATION
+                  Values:
+                    - Security
+                    - Bugfix
+                - Key: SEVERITY
+                  Values:
+                    - Critical
+                    - Important
+                    - Medium
+            # Auto-approve after 0 days so security/bugfix updates are applied
+            # at the next maintenance window rather than waiting out a delay.
+            ApproveAfterDays: 0
+            ComplianceLevel: HIGH
+      PatchGroups:
+        - !Sub "${AWS::StackName}-VP"
+
+  VPPatchMaintenanceWindow:
+    Type: AWS::SSM::MaintenanceWindow
+    Condition: UseEC2LaunchType
+    Properties:
+      Name: !Sub "${AWS::StackName}-VP-PatchWindow"
+      Description: "Weekly maintenance window to apply OS security patches to VP EC2 hosts"
+      # Sundays 08:00 UTC — off-peak for meetings. Adjust per your ops calendar.
+      Schedule: "cron(0 8 ? * SUN *)"
+      ScheduleTimezone: "UTC"
+      Duration: 2
+      Cutoff: 1
+      AllowUnassociatedTargets: false
+
+  VPPatchMaintenanceWindowTarget:
+    Type: AWS::SSM::MaintenanceWindowTarget
+    Condition: UseEC2LaunchType
+    Properties:
+      WindowId: !Ref VPPatchMaintenanceWindow
+      Name: !Sub "${AWS::StackName}-VP-PatchTargets"
+      Description: "VP EC2 hosts selected by patch group tag"
+      ResourceType: INSTANCE
+      Targets:
+        - Key: "tag:LMA-VP-PatchGroup"
+          Values:
+            - !Sub "${AWS::StackName}-VP"
+
+  VPPatchMaintenanceWindowTask:
+    Type: AWS::SSM::MaintenanceWindowTask
+    Condition: UseEC2LaunchType
+    Properties:
+      WindowId: !Ref VPPatchMaintenanceWindow
+      Name: !Sub "${AWS::StackName}-VP-RunPatchBaseline"
+      Description: "Run AWS-RunPatchBaseline (Install) on VP EC2 hosts"
+      TaskType: RUN_COMMAND
+      TaskArn: AWS-RunPatchBaseline
+      Priority: 1
+      # 100% so a single-host ASG is still patched; raise MaxErrors tolerance so
+      # one unreachable host doesn't fail the whole window.
+      MaxConcurrency: "100%"
+      MaxErrors: "100%"
+      Targets:
+        - Key: WindowTargetIds
+          Values:
+            - !Ref VPPatchMaintenanceWindowTarget
+      TaskInvocationParameters:
+        MaintenanceWindowRunCommandParameters:
+          Parameters:
+            Operation:
+              - Install
+            # RebootIfNeeded lets kernel/security updates take effect. It runs
+            # only inside the maintenance window, so any task-killing reboot is
+            # confined to the off-peak window rather than happening at boot.
+            RebootOption:
+              - RebootIfNeeded
+          Comment: "LMA VP scheduled security patching"
 
   VPCapacityProvider:
     Type: AWS::ECS::CapacityProvider

--- a/lma-websocket-transcriber-stack/deployment/lma-websocket-transcriber.yaml
+++ b/lma-websocket-transcriber-stack/deployment/lma-websocket-transcriber.yaml
@@ -651,7 +651,14 @@ Resources:
                 - echo Building websocket container image
                 - cd $CODEBUILD_SRC_DIR
                 - echo `pwd`
-                - docker build -t "${REPOSITORY_URI}:${IMAGE_TAG}" source/app/
+                # --pull + --no-cache force a fresh base-image pull and a re-run
+                # of the Dockerfile's `apt-get upgrade` security-patch layer on
+                # every build. Without these, CodeBuild can reuse a cached base
+                # layer and re-bake stale OS packages (e.g. the vulnerable
+                # liblzma5 5.4.1-1 flagged by Mirador/CVE-2026-34743) even though
+                # the Dockerfile already applies the fix. Patching happens here at
+                # build time, so it adds zero container-startup cost.
+                - docker build --pull --no-cache -t "${REPOSITORY_URI}:${IMAGE_TAG}" source/app/
                 - >
                   printf '{"RepositoryUri":"%s","ProjectName":"%s","ArtifactBucket":"%s"}'
                   $REPOSITORY_URI $PROJECT_NAME $ARTIFACT_BUCKET > build.json


### PR DESCRIPTION
## Summary

Two long-lived Mirador SLA breaches trace to **source that is already patched but never reaches running resources**. This PR makes the fixes durable so a normal stack update resolves the findings — and they stop recurring.

### 1. Transcriber container — CVE-2026-34743 (`liblzma5`)
- The Dockerfile **already** applies `apt-get upgrade`, which fixes `liblzma5` to the patched `5.4.1-1+deb12u1` (verified by a local `--no-cache` build).
- But the CodeBuild buildspec ran `docker build` **without `--pull`/`--no-cache`**, so a cached base image + cached `apt` layer could re-bake the stale `5.4.1-1` on redeploys. The `xz-utils` *binary* is purged by the Dockerfile, but the vulnerable `liblzma.so.5` *library* remains — which is what the scanner flags.
- **Fix:** add `--pull --no-cache` to the build. `--pull` refreshes the base; `--no-cache` guarantees the `apt-get upgrade` layer re-runs even when the base digest is unchanged (Debian can publish `deb12u1` without a new base tag). Patching stays at **build time → zero container-startup cost**.

### 2. VP EC2 hosts — OS patch SLA
- The `VPLaunchTemplate` UserData comments assert that **SSM Patch Manager owns OS patching** — per-boot `yum` was intentionally removed to avoid startup slowdown and mid-meeting kernel-reboot task kills (`EssentialContainerExited`).
- **But Patch Manager was never actually provisioned** — no baseline, maintenance window, or association existed in any account. So the VP ASG hosts never got patched and drifted out of SLA (observed: 21-day-old host, 33 pending security updates).
- **Fix:** add `AWS::SSM::PatchBaseline` + weekly off-peak `MaintenanceWindow` running `AWS-RunPatchBaseline` (`Install`, `RebootIfNeeded`) against a new `LMA-VP-PatchGroup` tag on the ASG instances. Patching runs **in the window, not at boot** — no startup slowdown, and reboots are confined to off-peak (Sun 08:00 UTC, adjustable).

All resources are gated on the existing `UseEC2LaunchType` condition (no-op for Fargate launch type).

## Testing
- Both templates pass `cfn-lint` with **no new findings** (only pre-existing W-level warnings unrelated to this change).
- Local `docker build --no-cache` of the current Dockerfile confirmed it produces `liblzma5 5.4.1-1+deb12u1` (patched).

## Notes for reviewers
- The maintenance-window schedule (`cron(0 8 ? * SUN *)` UTC) is a sensible default — adjust to your ops calendar if needed.
- This is the **durable** half of the remediation. Clearing the *current* stale images/hosts still requires a deploy of these stacks (or an instance refresh of the VP ASG); that operational step is being handled separately.