### PR TITLE
fix(audio-capture-app): install to /Applications, launch via Spotlight (own TCC identity)

### DIFF
--- a/docs/audio-capture-app.md
+++ b/docs/audio-capture-app.md
@@ -48,15 +48,25 @@ options cannot. It adds **no bot** or extra attendee to the meeting.
    ./install-macos.sh
    ```
    It clears the macOS download quarantine, checks prerequisites, builds the
-   app, and bundles it as `LMAAudioClient.app`.
-5. Launch it. macOS prompts for **Microphone** access — approve it. Then open
-   **System Settings ▸ Privacy & Security ▸ Screen Recording**, enable **LMA
-   Audio Client**, and **relaunch** (Screen Recording requires a restart to take
-   effect). Screen Recording is what lets macOS capture system/meeting audio,
-   even for audio-only capture.
-6. Sign in with your LMA username and password. Click **Start**, and your
-   meeting appears in the [Meetings List](web-ui-guide.md) with a live
-   transcript.
+   app, and installs it to `/Applications/LMAAudioClient.app`. (Terminal is only
+   used to build and install — you won't run the app from Terminal.)
+5. **Launch it like a normal app.** Press **⌘-Space** (Spotlight), type **LMA
+   Audio Client** and press Return — or double-click it in Finder. An **LMA**
+   item appears in the menu bar (top-right).
+
+   > ⚠️ **Don't launch it from Terminal.** Always launch via Spotlight, Finder,
+   > or `open -a "LMA Audio Client"` — never the binary inside `Contents/MacOS`.
+   > Only launching through macOS gives the app its own privacy identity; running
+   > it from Terminal makes macOS attribute Microphone / Screen Recording to
+   > **Terminal**, and system-audio capture silently won't work.
+6. Approve the **Microphone** prompt. Then open **System Settings ▸ Privacy &
+   Security ▸ Screen Recording**, enable **LMA Audio Client**, and **quit and
+   relaunch** it (Screen Recording requires a restart to take effect). Screen
+   Recording is what lets macOS capture system/meeting audio, even for audio-only
+   capture.
+7. Left-click the **LMA** menu-bar item, sign in with your LMA username and
+   password, and click **Start**. Your meeting appears in the
+   [Meetings List](web-ui-guide.md) with a live transcript.
 
 > **Tip: use headphones.** Otherwise your speakers' meeting audio can bleed into
 > your microphone and appear faintly on both transcript channels.
@@ -90,20 +100,15 @@ Popover options:
 - **Remember my email** — prefills your login next launch (email only; the
   password is never stored).
 - **Start automatically at login** — registers the app as a macOS login item.
-  For this to work the app must live in a stable location, so move it to
-  `/Applications` first:
-  ```bash
-  cp -R build/LMAAudioClient.app /Applications/
-  open /Applications/LMAAudioClient.app
-  ```
-  You can also manage it in **System Settings ▸ General ▸ Login Items**.
+  The installer already placed the app in `/Applications`, so this works out of
+  the box. You can also manage it in **System Settings ▸ General ▸ Login Items**.
 
 ### Running it in the background
 
 The app uses no audio or CPU when idle, so the intended usage is to leave it
 running in the menu bar and click **Start** when a meeting begins. **To relaunch
 after quitting**, press **⌘-Space** (Spotlight), type **LMA Audio Client**, and
-press Return — or run `open -a LMAAudioClient`.
+press Return — or run `open -a "LMA Audio Client"`.
 
 ## Audio Capture App vs Virtual Participant
 

--- a/lma-ai-stack/source/ui/src/components/audio-capture-app-layout/AudioCaptureApp.jsx
+++ b/lma-ai-stack/source/ui/src/components/audio-capture-app-layout/AudioCaptureApp.jsx
@@ -271,21 +271,39 @@ const AudioCaptureApp = () => {
                   ariaLabel="Copy ./install-macos.sh"
                   onClick={() => copyToClipboard('./install-macos.sh')}
                 />
-                . It checks prerequisites, builds the app, and bundles it as <code>LMAAudioClient.app</code>.
+                . It checks prerequisites, builds the app, and installs it to{' '}
+                <code>/Applications/LMAAudioClient.app</code>. (Terminal is only used to build/install &mdash; you
+                won&apos;t run the app from Terminal.)
               </Box>
             </li>
             <li>
               <Box variant="p">
-                Launch the app. macOS prompts for <strong>Microphone</strong> access &mdash; approve it. Then open{' '}
+                <strong>Launch it like a normal app.</strong> Press <strong>⌘-Space</strong> (Spotlight), type{' '}
+                <strong>LMA Audio Client</strong> and press Return (or double-click it in Finder). An{' '}
+                <strong>LMA</strong> item appears in the menu bar (top-right).
+              </Box>
+              <Alert type="warning" header="Don't launch it from Terminal">
+                Always launch via Spotlight, Finder, or <code>open -a &quot;LMA Audio Client&quot;</code> &mdash; never
+                the binary inside <code>Contents/MacOS</code>. Only launching through macOS gives the app its own
+                privacy identity; running it from Terminal makes macOS attribute Microphone / Screen Recording to{' '}
+                <strong>Terminal</strong>, and system-audio capture silently won&apos;t work (you&apos;ll see
+                &quot;Terminal&quot; where the app should be).
+              </Alert>
+            </li>
+            <li>
+              <Box variant="p">
+                Approve the <strong>Microphone</strong> prompt. Then open{' '}
                 <strong>System Settings &rsaquo; Privacy &amp; Security &rsaquo; Screen Recording</strong>, enable{' '}
-                <strong>LMA Audio Client</strong>, and relaunch (Screen Recording requires a restart to take effect).
-                Screen Recording is what lets macOS capture system/meeting audio.
+                <strong>LMA Audio Client</strong>, then <strong>quit and relaunch</strong> it (right-click the LMA
+                menu-bar item &rsaquo; Quit, then reopen via Spotlight) &mdash; Screen Recording only takes effect after
+                a relaunch. Screen Recording is what lets macOS capture system/meeting audio.
               </Box>
             </li>
             <li>
               <Box variant="p">
-                Enter your LMA username and password when prompted. The app signs in, starts streaming, and your meeting
-                appears in the <Link href="#/calls">Meetings List</Link> with a live transcript.
+                Left-click the <strong>LMA</strong> menu-bar item, sign in with your LMA username and password, and
+                click <strong>Start</strong>. Your meeting appears in the <Link href="#/calls">Meetings List</Link> with
+                a live transcript.
               </Box>
             </li>
           </ol>
@@ -325,13 +343,14 @@ const AudioCaptureApp = () => {
               <strong>Right-click</strong> it for <strong>Quit</strong>.
             </li>
             <li>
-              <strong>Start automatically at login:</strong> move the app to <code>/Applications</code>, then turn on
-              the <strong>Start automatically at login</strong> toggle in the popover (or System Settings &rsaquo;
-              General &rsaquo; Login Items).
+              <strong>Start automatically at login:</strong> turn on the login toggle in the popover (or System Settings
+              &rsaquo; General &rsaquo; Login Items). The installer already placed the app in <code>/Applications</code>
+              , so this works out of the box.
             </li>
             <li>
-              <strong>Relaunch after quitting:</strong> press <strong>⌘-Space</strong>, type{' '}
-              <strong>LMA Audio Client</strong>, and press Return &mdash; or run <code>open -a LMAAudioClient</code>.
+              <strong>Launch or relaunch:</strong> press <strong>⌘-Space</strong>, type{' '}
+              <strong>LMA Audio Client</strong>, and press Return &mdash; or run{' '}
+              <code>open -a &quot;LMA Audio Client&quot;</code>.
             </li>
           </ul>
         </SpaceBetween>

--- a/lma-audio-capture-app-stack/source/macos/README.md
+++ b/lma-audio-capture-app-stack/source/macos/README.md
@@ -68,29 +68,45 @@ Requires macOS 13+ and Xcode command-line tools (`xcode-select --install`).
 > re-run. (Building locally means nothing is downloaded pre-built, so once
 > quarantine is cleared the freshly built binary is ad-hoc signed and just runs.)
 
-### Recommended: run as a `.app` bundle (own TCC identity)
+### Recommended: run as a `.app` bundle launched with `open` (own TCC identity)
 
-`swift run` has no bundle, so macOS attributes Mic/Screen-Recording to the
-**parent process (Terminal)**. `make-app.sh` wraps the release binary in a
-minimal `.app` with an `Info.plist` (mic usage string) so permissions are
-attributed to **"LMA Audio Client"** — the way the production build will behave.
+`make-app.sh` wraps the release binary in a minimal `.app` with an `Info.plist`
+(mic usage string) so privacy permissions can be attributed to **"LMA Audio
+Client"**.
+
+> **Critical:** launch it with **`open`** (or double-click in Finder), **not** by
+> running `.../Contents/MacOS/LMAAudioClient` directly. Only `open` goes through
+> macOS **LaunchServices**, which gives the app its own TCC (privacy) identity.
+> Exec'ing the inner binary from a shell makes the process a **child of
+> Terminal**, so macOS attributes Microphone / Screen Recording to *Terminal* —
+> and system-audio capture silently won't work. (This is why `swift run` and the
+> inner-binary path only ever grant Terminal the permissions.)
 
 ```bash
 cd lma-audio-capture-app-stack/source/macos
 ./make-app.sh                       # swift build -c release + assemble build/LMAAudioClient.app
+open build/LMAAudioClient.app       # launches the menu-bar app with its own identity
+```
 
-# Pass config via env vars (keeps tokens out of shell history & `ps` output).
+Then use the **"LMA" menu-bar item** (top-right) to sign in and Start — see
+[Menu-bar (tray) app](#menu-bar-tray-app) below.
+
+#### Headless / CLI mode (dev + debugging only)
+
+Running the inner binary directly (or `swift run`) with `--flag`s runs the
+**headless CLI**. This is useful for scripted testing and the `--debug-wav` tee,
+but macOS attributes Mic/Screen-Recording to **Terminal** in this mode, so grant
+Terminal those permissions if you use it for real capture.
+
+```bash
 export LMA_WS_ENDPOINT="wss://<your-cloudfront-domain>/api/v1/ws"
 export LMA_ACCESS_TOKEN="<cognito-access-token>"
 export LMA_ID_TOKEN="<cognito-id-token>"
 export LMA_CALL_ID="Native Mac test $(date +%H:%M)"
 export LMA_DEBUG_WAV="/tmp/lma-debug.wav"   # optional: tee streamed PCM for offline verify
 
-./build/LMAAudioClient.app/Contents/MacOS/LMAAudioClient
+./build/LMAAudioClient.app/Contents/MacOS/LMAAudioClient --cli   # headless (grants Terminal identity)
 ```
-
-Plain `swift run LMAAudioClient --endpoint ... --token ... --id-token ...` also
-works for a quick spike, but grant permissions to *Terminal* in that case.
 
 ### Menu-bar (tray) app
 

--- a/lma-audio-capture-app-stack/source/macos/install-macos.sh
+++ b/lma-audio-capture-app-stack/source/macos/install-macos.sh
@@ -5,13 +5,17 @@
 # Ships inside the "Download Audio Capture App" zip from the LMA web UI. It:
 #   1. checks/points you at prerequisites (Xcode command-line tools),
 #   2. builds the Swift app in release mode,
-#   3. wraps it in a signed .app bundle with its own TCC (privacy) identity,
-#   4. leaves an lma-config.json (your deployment's endpoint + Cognito ids)
-#      next to the executable so you only need to sign in with username/password.
+#   3. wraps it in a signed .app bundle with an lma-config.json (your
+#      deployment's endpoint + Cognito ids) baked into Contents/Resources/,
+#   4. installs it to /Applications so it's a first-class app — launchable from
+#      Spotlight (Cmd-Space) and eligible for Start-at-login — with its own
+#      privacy (TCC) identity ("LMA Audio Client").
 #
 # Usage:
-#   ./install-macos.sh              # build into ./build/LMAAudioClient.app
-#   ./install-macos.sh --run        # build, then launch (prompts for login)
+#   ./install-macos.sh              # build + install to /Applications
+#   ./install-macos.sh --run        # build + install, then launch it
+#   ./install-macos.sh --no-install # build into ./build only (don't copy to /Applications)
+#   INSTALL_DIR=~/Applications ./install-macos.sh   # override install location
 #
 # This is intentionally source-based: a macOS app using ScreenCaptureKit cannot
 # be cross-compiled by the (Linux) LMA build pipeline, and Apple signing tools
@@ -20,7 +24,13 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 RUN_AFTER=false
-[[ "${1:-}" == "--run" ]] && RUN_AFTER=true
+NO_INSTALL=false
+for arg in "$@"; do
+  case "$arg" in
+    --run) RUN_AFTER=true ;;
+    --no-install) NO_INSTALL=true ;;
+  esac
+done
 
 say() { printf "\n\033[1m==> %s\033[0m\n" "$*"; }
 err() { printf "\n\033[31m✗ %s\033[0m\n" "$*" >&2; }
@@ -91,26 +101,66 @@ say "Building the app (this may take a minute on first run)"
 ./make-app.sh
 
 APP="build/LMAAudioClient.app"
-BIN="${APP}/Contents/MacOS/LMAAudioClient"
+
+# ── 3. Install into /Applications ────────────────────────────────────────────
+# Installing to /Applications makes it a first-class app: launchable from
+# Spotlight (Cmd-Space → "LMA Audio Client"), eligible for Start-at-login, and
+# stable for macOS's privacy (TCC) records. Pass --no-install to skip and just
+# leave the build in ./build. Set INSTALL_DIR to override the destination.
+INSTALL_DIR="${INSTALL_DIR:-/Applications}"
+INSTALLED_APP="${INSTALL_DIR}/LMAAudioClient.app"
+if $NO_INSTALL; then
+  INSTALLED_APP="$(cd "$(dirname "$APP")" && pwd)/$(basename "$APP")"
+  say "Skipping install (--no-install); app left at ${INSTALLED_APP}"
+else
+  say "Installing to ${INSTALL_DIR}"
+  rm -rf "${INSTALLED_APP}"
+  if cp -R "${APP}" "${INSTALLED_APP}" 2>/dev/null; then
+    xattr -dr com.apple.quarantine "${INSTALLED_APP}" 2>/dev/null || true
+    # Refresh LaunchServices so Spotlight indexes it immediately.
+    /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister \
+      -f "${INSTALLED_APP}" 2>/dev/null || true
+    echo "  • Installed: ${INSTALLED_APP}"
+  else
+    INSTALLED_APP="$(cd "$(dirname "$APP")" && pwd)/$(basename "$APP")"
+    err "Couldn't copy to ${INSTALL_DIR} (permission?). Leaving it at ${INSTALLED_APP}."
+    echo "    To install manually: cp -R \"${INSTALLED_APP}\" /Applications/"
+  fi
+fi
+
 say "Done"
 cat <<EOF
-The app is built at:
-  ${APP}
+LMA Audio Capture App is installed at:
+  ${INSTALLED_APP}
 
-First run — grant permissions:
-  1. Launch it (below). macOS will prompt for Microphone; approve it.
-  2. Open System Settings ▸ Privacy & Security ▸ Screen Recording, enable
-     "LMA Audio Client", then relaunch (Screen Recording needs a restart).
-  3. It will ask for your LMA username and password (the same ones you use for
-     the LMA web app), sign in, and start streaming.
+▶ HOW TO LAUNCH IT (do NOT run it from Terminal):
+  • Press Cmd-Space (Spotlight), type "LMA Audio Client", press Return, OR
+  • double-click it in Finder / Launchpad, OR
+  • run:  open -a "LMA Audio Client"
 
-Run it now with:
-  ${BIN} --username you@example.com
+  Launching this way is REQUIRED: it goes through macOS LaunchServices so the
+  app gets its own privacy identity. If you instead run the binary inside
+  Contents/MacOS from Terminal, macOS attributes Microphone / Screen Recording
+  to *Terminal* and system-audio capture will NOT work (you'd see "Terminal"
+  in the recording indicator).
+
+▶ FIRST RUN — grant permissions:
+  1. Launch it (Spotlight/Finder). A menu-bar item "LMA" appears (top-right).
+     Approve the Microphone prompt.
+  2. System Settings ▸ Privacy & Security ▸ Screen Recording → enable
+     "LMA Audio Client". Then QUIT it (right-click the "LMA" menu-bar item ▸
+     Quit) and launch it again — Screen Recording only takes effect after a
+     relaunch. This is what lets it capture meeting/system audio.
+  3. Left-click the "LMA" menu-bar item, sign in with your LMA username/password,
+     and click Start.
+
+▶ START AUTOMATICALLY AT LOGIN:
+  Left-click the "LMA" menu-bar item and enable "Start automatically at login"
+  (or System Settings ▸ General ▸ Login Items ▸ add LMA Audio Client).
 
 EOF
 
 if $RUN_AFTER; then
-  say "Launching (you'll be prompted for username/password)"
-  read -r -p "LMA username (email): " LMA_USER
-  exec "${BIN}" --username "${LMA_USER}"
+  say "Launching via Spotlight/LaunchServices (menu-bar app; sign in from the 'LMA' item)"
+  open "${INSTALLED_APP}"
 fi


### PR DESCRIPTION
## Problem

The macOS Audio Capture App install instructions told users to launch the app by exec'ing the inner Mach-O binary (`build/LMAAudioClient.app/Contents/MacOS/LMAAudioClient`) from Terminal. On macOS that makes the process a **child of Terminal**, so the OS attributes **Microphone / Screen Recording** permissions to *Terminal* rather than to the app. Result: the app launches in the menu bar, but the moment recording starts the privacy indicator flips to "Terminal" and **system-audio capture silently fails**.

## Fix

Launch the app the way macOS intends — through LaunchServices — so it gets its own privacy (TCC) identity ("LMA Audio Client").

- **`install-macos.sh`** — now installs the bundle to `/Applications` (override with `INSTALL_DIR`; `--no-install` to skip), refreshes LaunchServices so Spotlight indexes it, and prints explicit **Spotlight / Finder / `open -a`** launch guidance with a clear warning against running the inner binary from Terminal. Replaces the old `Run it now with: ${BIN} --username …` line that demonstrated the problematic command.
- **UI (`AudioCaptureApp.jsx`)** — rewrote the macOS install steps: run `./install-macos.sh` (installs to `/Applications`), launch via ⌘-Space, a warning `Alert` explaining the Terminal TCC-identity trap, Screen Recording enable + relaunch, and sign-in from the menu-bar item. The "Running in the background" section no longer tells users to manually `cp` into `/Applications` (the installer does it).
- **`README.md`** and **`docs/audio-capture-app.md`** — same `/Applications` + Spotlight guidance; dropped the manual `cp -R build/… /Applications/` step.

## Testing

- `install-macos.sh` verified end-to-end: builds, ad-hoc signs, config in `Contents/Resources/`, installs to `/Applications`, launches via `open` as a menu-bar app with its own identity.
- UI file passes ESLint (max-len 120 / prettier) clean.

No server or CloudFormation changes.