### PR TITLE
fix(audio-capture-app): instruct 'bash install-macos.sh' to dodge Gatekeeper SIGKILL

### DIFF
--- a/docs/audio-capture-app.md
+++ b/docs/audio-capture-app.md
@@ -43,13 +43,22 @@ options cannot. It adds **no bot** or extra attendee to the meeting.
    ```bash
    xcode-select --install
    ```
-4. In Terminal, `cd` into the unzipped folder and run the installer:
+4. In Terminal, `cd` into the unzipped folder and run the installer **with
+   `bash`** (not `./`):
    ```bash
-   ./install-macos.sh
+   bash install-macos.sh
    ```
    It clears the macOS download quarantine, checks prerequisites, builds the
    app, and installs it to `/Applications/LMAAudioClient.app`. (Terminal is only
    used to build and install — you won't run the app from Terminal.)
+
+   > ⚠️ **Use `bash install-macos.sh`, not `./install-macos.sh`.** On recent
+   > macOS, running a freshly downloaded script directly makes the kernel
+   > `execve()` a quarantined file, which Gatekeeper blocks with *"Apple could
+   > not verify … is free of malware"* **before the script runs** — so its own
+   > quarantine-clearing never happens. Running it via `bash` reads the script as
+   > data (no `execve` on a quarantined file), so it runs and clears the flag
+   > from the rest of the folder itself.
 5. **Launch it like a normal app.** Press **⌘-Space** (Spotlight), type **LMA
    Audio Client** and press Return — or double-click it in Finder. An **LMA**
    item appears in the menu bar (top-right).
@@ -73,9 +82,17 @@ options cannot. It adds **no bot** or extra attendee to the meeting.
 
 ### "Apple could not verify… is free of malware" (Gatekeeper)
 
-macOS flags files downloaded from a browser. The installer clears this
-automatically, but if you hit the warning before running it, clear the quarantine
-flag from the unzipped folder and re-run:
+macOS flags files downloaded from a browser, and on recent versions it **blocks
+running a downloaded script directly** (`./install-macos.sh`) — the kernel
+`execve()`s a quarantined file, Gatekeeper kills it, and the script's own
+quarantine-clearing never gets to run. Run it via `bash` instead, which isn't
+blocked:
+
+```bash
+bash install-macos.sh
+```
+
+To clear the whole folder up front instead (then either form works):
 
 ```bash
 xattr -dr com.apple.quarantine .
@@ -150,7 +167,7 @@ voice assistant, screen/video capture, or hands-off unattended recording.
   not apply — use the [Chrome Extension](browser-extension.md) instead.
 - **Build errors / `xcode-select: command not found`.** Install Apple's
   command-line tools (`xcode-select --install`), complete the popup, and re-run
-  `./install-macos.sh`.
+  `bash install-macos.sh`.
 
 ## See also
 

--- a/lma-ai-stack/source/ui/src/components/audio-capture-app-layout/AudioCaptureApp.jsx
+++ b/lma-ai-stack/source/ui/src/components/audio-capture-app-layout/AudioCaptureApp.jsx
@@ -263,18 +263,26 @@ const AudioCaptureApp = () => {
             </li>
             <li>
               <Box variant="p">
-                In Terminal, <code>cd</code> into the unzipped folder and run the installer:{' '}
-                <code>./install-macos.sh</code>{' '}
+                In Terminal, <code>cd</code> into the unzipped folder and run the installer with{' '}
+                <strong>
+                  <code>bash install-macos.sh</code>
+                </strong>{' '}
                 <Button
                   variant="inline-icon"
                   iconName="copy"
-                  ariaLabel="Copy ./install-macos.sh"
-                  onClick={() => copyToClipboard('./install-macos.sh')}
+                  ariaLabel="Copy bash install-macos.sh"
+                  onClick={() => copyToClipboard('bash install-macos.sh')}
                 />
                 . It checks prerequisites, builds the app, and installs it to{' '}
                 <code>/Applications/LMAAudioClient.app</code>. (Terminal is only used to build/install &mdash; you
                 won&apos;t run the app from Terminal.)
               </Box>
+              <Alert type="info" header="Run it with “bash”, not “./install-macos.sh”">
+                On recent macOS, launching a freshly downloaded script directly (<code>./install-macos.sh</code>) is
+                blocked by Gatekeeper with <em>“Apple could not verify … is free of malware.”</em> Running{' '}
+                <code>bash install-macos.sh</code> sidesteps that &mdash; the script then clears the download flag from
+                the rest of the folder itself. (Or clear it first with the command in Troubleshooting below.)
+              </Alert>
             </li>
             <li>
               <Box variant="p">
@@ -384,8 +392,10 @@ const AudioCaptureApp = () => {
         <SpaceBetween size="s">
           <Box variant="p">
             <strong>&quot;Apple could not verify … is free of malware&quot; (Gatekeeper).</strong> macOS flags files
-            downloaded from a browser. The installer clears this automatically. If you hit the warning first, clear it
-            from the unzipped folder and re-run: <code>xattr -dr com.apple.quarantine .</code>
+            downloaded from a browser, and on recent versions it blocks running a downloaded script <em>directly</em> (
+            <code>./install-macos.sh</code>). Run it as <code>bash install-macos.sh</code> instead &mdash; that
+            isn&apos;t blocked, and the script clears the flag from the rest of the folder. To clear the whole folder up
+            front instead, run: <code>xattr -dr com.apple.quarantine .</code>
             <Button
               variant="inline-icon"
               iconName="copy"
@@ -396,7 +406,7 @@ const AudioCaptureApp = () => {
           <Box variant="p">
             <strong>&quot;xcode-select: command not found&quot; or build errors.</strong> Install Apple&apos;s
             command-line tools with <code>xcode-select --install</code>, complete the popup, and re-run{' '}
-            <code>./install-macos.sh</code>.
+            <code>bash install-macos.sh</code>.
           </Box>
           <Box variant="p">
             <strong>No remote-participant audio in the transcript.</strong> Grant <strong>Screen Recording</strong> to

--- a/lma-audio-capture-app-stack/source/macos/README.md
+++ b/lma-audio-capture-app-stack/source/macos/README.md
@@ -60,13 +60,20 @@ Source layout:
 
 Requires macOS 13+ and Xcode command-line tools (`xcode-select --install`).
 
-> **Downloaded this from the LMA web UI?** Run `./install-macos.sh` — it clears
-> the macOS download quarantine, checks prerequisites, builds, and bundles the
-> app in one step. If you double-click something first and hit *"Apple could not
-> verify … is free of malware"*, that's Gatekeeper's download-quarantine flag;
-> clear it from the unzipped folder with `xattr -dr com.apple.quarantine .` and
-> re-run. (Building locally means nothing is downloaded pre-built, so once
-> quarantine is cleared the freshly built binary is ad-hoc signed and just runs.)
+> **Downloaded this from the LMA web UI?** Run **`bash install-macos.sh`** — it
+> clears the macOS download quarantine, checks prerequisites, builds, and bundles
+> the app in one step.
+>
+> ⚠️ **Use `bash install-macos.sh`, not `./install-macos.sh`.** On recent macOS,
+> running a freshly downloaded script *directly* (`./…`) makes the kernel
+> `execve()` a quarantined file, which Gatekeeper blocks — it kills the process
+> and shows *"Apple could not verify … is free of malware"* **before line 1
+> runs**, so the script's own quarantine-clearing never happens. Invoking it as
+> `bash install-macos.sh` reads the script as data (no `execve` on a quarantined
+> file), so it runs and then clears the flag from the rest of the folder.
+> Equivalently, clear it yourself first with `xattr -dr com.apple.quarantine .`
+> then `./install-macos.sh`. (Building locally means nothing is downloaded
+> pre-built, so once quarantine is cleared the ad-hoc-signed binary just runs.)
 
 ### Recommended: run as a `.app` bundle launched with `open` (own TCC identity)
 

--- a/lma-audio-capture-app-stack/source/macos/install-macos.sh
+++ b/lma-audio-capture-app-stack/source/macos/install-macos.sh
@@ -11,11 +11,20 @@
 #      Spotlight (Cmd-Space) and eligible for Start-at-login — with its own
 #      privacy (TCC) identity ("LMA Audio Client").
 #
-# Usage:
-#   ./install-macos.sh              # build + install to /Applications
-#   ./install-macos.sh --run        # build + install, then launch it
-#   ./install-macos.sh --no-install # build into ./build only (don't copy to /Applications)
-#   INSTALL_DIR=~/Applications ./install-macos.sh   # override install location
+# Usage (IMPORTANT — invoke with `bash`, not `./`):
+#   bash install-macos.sh              # build + install to /Applications
+#   bash install-macos.sh --run        # build + install, then launch it
+#   bash install-macos.sh --no-install # build into ./build only (don't copy to /Applications)
+#   INSTALL_DIR=~/Applications bash install-macos.sh   # override install location
+#
+# Why `bash install-macos.sh` and NOT `./install-macos.sh`:
+#   On recent macOS, running a freshly downloaded script DIRECTLY (`./…`) makes
+#   the kernel execve() a quarantined file, which Gatekeeper blocks — it SIGKILLs
+#   the process and shows "Apple could not verify … is free of malware" BEFORE
+#   line 1 runs, so this script's own quarantine-clearing never gets a chance.
+#   `bash install-macos.sh` reads the script as DATA (no execve on a quarantined
+#   file), so it runs, and then clears the quarantine flag from the rest of the
+#   folder itself. (Equivalently: `xattr -dr com.apple.quarantine .` first.)
 #
 # This is intentionally source-based: a macOS app using ScreenCaptureKit cannot
 # be cross-compiled by the (Linux) LMA build pipeline, and Apple signing tools


### PR DESCRIPTION
## The recurring bug, finally root-caused

The *"Apple could not verify 'lma-audio-capture-app-macos-v0.3.6.dev3' is free of malware"* popup kept coming back despite two prior fixes. This time I reproduced it on a **real Chrome download** on macOS 26.5.2 and captured the actual mechanism.

**Root cause:** running the freshly downloaded installer *directly* as `./install-macos.sh` makes the kernel `execve()` a **quarantined** file. On recent macOS, Gatekeeper assesses that `execve`, **SIGKILLs the process (exit 137), and shows the malware popup before line 1 of the script ever runs.**

That's why the previous fixes could never work — they all lived *inside* the script (`xattr -dr com.apple.quarantine`, config-moved-to-Resources, `make-app.sh` re-signing). The script was being killed at exec, so none of it executed.

**Verified fix:** invoke it as **`bash install-macos.sh`**. `bash <file>` reads the script as *data* — there's no `execve` on a quarantined file, so Gatekeeper's exec gate never fires. The script then runs and clears the quarantine flag from the rest of the folder itself.

### Evidence (real `~/Downloads` copy, quarantine `0081;…;Chrome`)

| Invocation | Result |
|---|---|
| `./install-macos.sh` (quarantined) | **SIGKILL at exec**, empty output, malware popup |
| `bash install-macos.sh` (same quarantined file) | Runs to completion, builds + ad-hoc signs, clears quarantine — **no popup** |

(After a user clicks through the dialog once, macOS caches the assessment for that quarantine UUID, so a later `./` may succeed — but a fresh download with a new UUID is killed again. `bash …` avoids the gate entirely.)

## Changes

- **`install-macos.sh`** — usage/header lead with `bash install-macos.sh` and explain the execve-vs-data distinction.
- **UI (`AudioCaptureApp.jsx`)** — install step uses `bash install-macos.sh` (with copy button) + an info `Alert`; Gatekeeper troubleshooting entry rewritten.
- **`README.md`** and **`docs/audio-capture-app.md`** — same `bash` guidance; `xattr -dr com.apple.quarantine .` kept as the clear-first alternative.

No server or CloudFormation changes. UI passes ESLint clean.