### PR TITLE
chore(deps): batch3 — align boto3 to 1.43 (lift legacy pin) + TS 5.9 for websocket-client

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -111,11 +111,12 @@ updates:
       browser-ext-major:
         update-types: [major]
     ignore:
-      # react-scripts (CRA) pins typescript <5 and the eslint 8 ecosystem via
-      # eslint-config-react-app. typescript >=6 (incl. native tsgo 7) and eslint
-      # 9/10 (flat-config-only) both break the CRA build. Hold until CRA is replaced.
+      # react-scripts 5.0.1 (CRA) hard-pins `typescript ^3.2.1 || ^4` as a peer
+      # and the eslint 8 ecosystem via eslint-config-react-app. typescript >=5
+      # (verified: npm ERESOLVE, react-scripts won't install) and eslint 9/10
+      # (flat-config-only) both break the CRA build. Hold until CRA is replaced.
       - dependency-name: typescript
-        versions: [">=6"]
+        versions: [">=5"]
       - dependency-name: eslint
         versions: [">=9"]
 
@@ -183,14 +184,13 @@ updates:
       python-major:
         update-types: [major]
     ignore:
-      # cfn-lint 1.x and cfn-policy-validator >=0.0.32 both pull an
-      # aws-sam-translator / boto3 >=1.34 that conflicts with the intentional
-      # `boto3~=1.22.12` pin in requirements-dev.txt. Unblock only by moving that
-      # pin first. Held to their last 0.x-compatible majors.
-      - dependency-name: cfn-lint
-        versions: [">=1"]
-      - dependency-name: cfn-policy-validator
-        versions: [">=0.0.32"]
+      # (cfn-lint >=1 and cfn-policy-validator >=0.0.32 were previously held here
+      # because the legacy `boto3~=1.22.12` pin conflicted with their
+      # aws-sam-translator/boto3 >=1.34 requirement. That pin has been lifted to
+      # ~=1.43.54 — boto3 1.43 already ran in the deployed lambdas — so those
+      # tools now resolve cleanly and are no longer ignored; dependabot may raise
+      # them as normal PRs.)
+      #
       # gql 4.x is incompatible with AWS AppSync. LMA builds mutations with gql's
       # DSL, which requires a client-side schema, and the only way it obtains one
       # is runtime introspection (fetch_schema_from_transport=True). gql 4's

--- a/lma-ai-stack/requirements/requirements-dev.txt
+++ b/lma-ai-stack/requirements/requirements-dev.txt
@@ -10,7 +10,7 @@ toml>=0.10.2
 yamllint~=1.38.0
 
 # runtime and typing dependencies included to hint IDEs and make it easier to test/debug locally
-boto3~=1.22.12
+boto3~=1.43.54
 boto3-stubs[comprehend,codebuild,dynamodb,lambda,lexv2-runtime,s3,sqs,sns]~=1.43.54
 gql[botocore,aiohttp,requests]~=3.5.3
 aws-lambda-powertools~=3.31.1

--- a/lma-ai-stack/source/lambda_functions/bedrock_summary_lambda/requirements.txt
+++ b/lma-ai-stack/source/lambda_functions/bedrock_summary_lambda/requirements.txt
@@ -1,3 +1,3 @@
 requests
-urllib3<2
+urllib3<3
 boto3==1.43.54

--- a/lma-ai-stack/source/lambda_functions/mcp_analytics/requirements.txt
+++ b/lma-ai-stack/source/lambda_functions/mcp_analytics/requirements.txt
@@ -1,3 +1,3 @@
 boto3>=1.43.54
-botocore>=1.34.0
-requests>=2.31.0
+botocore>=1.43.54
+requests>=2.34.2

--- a/lma-ai-stack/source/lambda_functions/meeting_invitation_parser/requirements.txt
+++ b/lma-ai-stack/source/lambda_functions/meeting_invitation_parser/requirements.txt
@@ -1,2 +1,2 @@
 boto3>=1.43.54
-botocore>=1.29.0
+botocore>=1.43.54

--- a/lma-ai-stack/source/lambda_functions/oauth_manager/requirements.txt
+++ b/lma-ai-stack/source/lambda_functions/oauth_manager/requirements.txt
@@ -1,2 +1,2 @@
-requests>=2.31.0
+requests>=2.34.2
 boto3>=1.43.54

--- a/lma-ai-stack/source/lambda_functions/virtual_participant_manager/requirements.txt
+++ b/lma-ai-stack/source/lambda_functions/virtual_participant_manager/requirements.txt
@@ -1,3 +1,3 @@
 # Virtual Participant Manager Lambda Dependencies
 boto3>=1.43.54
-botocore>=1.29.0
+botocore>=1.43.54

--- a/lma-ai-stack/source/lambda_layers/transcript_enrichment_layer/requirements.txt
+++ b/lma-ai-stack/source/lambda_layers/transcript_enrichment_layer/requirements.txt
@@ -1,5 +1,5 @@
 # keep in sync with local dev dependencies in requirements-dev.txt
-boto3~=1.22.12
+boto3~=1.43.54
 gql[botocore,aiohttp,requests]~=3.5.3
 aws-lambda-powertools~=3.31.1
 phonenumbers~=9.0.34

--- a/utilities/websocket-client/package-lock.json
+++ b/utilities/websocket-client/package-lock.json
@@ -28,7 +28,7 @@
         "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^10.7.0",
         "ts-node": "^10.9.2",
-        "typescript": "^4.8.2"
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@aws-sdk/client-kinesis": {
@@ -612,9 +612,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.7",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.7.tgz",
-      "integrity": "sha512-BiEE2bnnGoPKdlGe3L+gOYORDHFGPuYVRLP7iUow/Sflm0B4hC4XY3FC1MRuc7ltzpW2xNnXopKi34TTkULlKQ==",
+      "version": "3.29.8",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.8.tgz",
+      "integrity": "sha512-rpCbCV+TimOBi3VLNBMmtTvgfOWcFIEAru3+TFlG87SL2F+te4jOnnNR+cf3uR4eJ5Qf4LnT80fqnBKgPRS6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -625,12 +625,12 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.12",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.12.tgz",
-      "integrity": "sha512-ZZPDbl/aRp77aycuoMlo3BTayT4CE2a3uoqETYZU5ySnVbhpl5IJiY7dCZedn+ZusyDLqVv44IvKBiXd2/nK0Q==",
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.13.tgz",
+      "integrity": "sha512-X+2HNZhWi5i3rJsCas0LPf6fTQUaKyJ40zd8aTO/bwpRfpU3biYaqLr7C1WMibL7PVKJalpi1PyybjGPNoHC8Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.7",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -639,12 +639,12 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.9",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.9.tgz",
-      "integrity": "sha512-EJktha5m5MXCwzdXrlWyqb9UCNHNFKlg+PmTpRsdX3dncJPTiqYleM9OKj2mLgdVJHR01d2tU4alG+z2NdH5rQ==",
+      "version": "5.6.10",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.10.tgz",
+      "integrity": "sha512-5/Yj9mS2JjTsB3B8ZX7euh77mrY9aXW23ag1yAmFykSRmA6vldqBrgqmSeQ50EjY+5SB8+aE4w14B6LKbBVEhQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.7",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -653,12 +653,12 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.9",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.9.tgz",
-      "integrity": "sha512-xVBZ3hptB99iNO9XyWqEhC7KD9bP9UPXhuy3h5Y2ItCfBv160D9IIC/Fmmp3EbnWwit4C+KVqlSE+E29Nk/pPg==",
+      "version": "4.9.10",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.10.tgz",
+      "integrity": "sha512-ETQz9v/Z+nTQc6fRWTXxUpxJqwpmzB3Tn3WKAdHwWkeT+m+HE5czs6GNG8vW+4vyxXSls65RVcvOZwk7Q/PS/Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.7",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -667,12 +667,12 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.8",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.8.tgz",
-      "integrity": "sha512-iGBm6hIwD2MGvVRSgrjVWa4FXtXDq3akxu0DCpnkmBo0xtEHZ/siMRt7ycfZAefYr2UdywUgmGtoRLaq5u56pg==",
+      "version": "5.6.9",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.9.tgz",
+      "integrity": "sha512-g5rnEii/mkT0mjVJmlsaOfyNBtHNTecD9Lo4NP8D5HzMUEnZNpz7/FbvBCjNcV4vteHFAxOGiLUYNxPkDZZAPw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.7",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -2546,9 +2546,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2556,7 +2556,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/uri-js": {

--- a/utilities/websocket-client/package.json
+++ b/utilities/websocket-client/package.json
@@ -36,7 +36,7 @@
     "@typescript-eslint/parser": "^8.65.0",
     "eslint": "^10.7.0",
     "ts-node": "^10.9.2",
-    "typescript": "^4.8.2"
+    "typescript": "^5.9.3"
   },
   "overrides": {
     "sjcl": "^1.0.9"

--- a/utilities/websocket-client/src/index.ts
+++ b/utilities/websocket-client/src/index.ts
@@ -7,7 +7,7 @@ import { emitKeypressEvents } from 'readline';
 import { Command } from 'commander';
 import { WebSocket } from 'ws';
 import * as fs from 'fs';
-import { chain } from 'stream-chain';
+import { chainUnchecked } from 'stream-chain';
 import { randomUUID } from 'crypto';
 import { CallMetaData } from '../../../lma-websocket-transcriber-stack/source/app/src/lca';
 
@@ -73,14 +73,18 @@ new Command()
 
                 const CHUNK_SIZE = SAMPLE_RATE * (CHUNK_SIZE_IN_MS / 1000) * BYTES_PER_SAMPLE * 2;
 
-                // stream-chain v4 is ESM: the `chain` export is a factory
-                // function (not a constructable `Chain` class as in v2).
-                const audiopipeline = chain([
+                // stream-chain v4 is ESM: `chain`/`chainUnchecked` are factory
+                // functions (not a constructable `Chain` class as in v2). The
+                // pipeline mixes a ReadStream with an async transform; under TS
+                // 5.x `chain()`'s tuple inference rejects that heterogeneous
+                // array, so use `chainUnchecked` — the library's supported escape
+                // hatch for dynamically-typed pipelines.
+                const audiopipeline = chainUnchecked([
                     fs.createReadStream(options.wavfile as fs.PathLike, { highWaterMark: CHUNK_SIZE }),
                     async (data: Buffer) => {
                         await timer(CHUNK_SIZE_IN_MS);
                         return data;
-                    }
+                    },
                 ]);
 
                 console.log('Sending the audio data chunks');


### PR DESCRIPTION
## Summary

Third Dependabot wave (#443–#457) — raised after #442 merged and dependabot re-scanned. This one mostly exists because the earlier batches left a **boto3 version inconsistency**, which this PR resolves at the root.

## boto3 pin lifted (resolves #446–#457)

The legacy `boto3~=1.22.12` pin (dating to the original LCA→LMA rename, no documented rationale) was inconsistent: most lambdas already ran `boto3>=1.43.54` (deployed, passing integ-tests), but `transcript_enrichment_layer` + `requirements-dev` still pinned 1.22. **Verified boto3 1.43 imports cleanly with the full transcript-layer dep set** and already runs in the deployed lambdas, so:
- Aligned boto3/botocore/urllib3/requests → 1.43.54 / <3 / 2.34.2 across the holdout files.
- **Removed the `cfn-lint>=1` / `cfn-policy-validator>=0.0.32` dependabot ignores** — they existed *only* because of the boto3 1.22 pin. Verified both now resolve with boto3 1.43, so dependabot can raise them normally going forward.

## typescript 5.9

- **websocket-client (#443): upgraded** 4.9→5.9. Migrated the stream-chain pipeline to `chainUnchecked()` (TS 5.x rejected the heterogeneous `chain()` tuple as `never[]`). Lint clean; build has only the known pre-existing TS2307 (stale `lca` import, unrelated).
- **browser-ext (#444): CANNOT UPGRADE** — react-scripts 5.0.1 hard-pins `typescript ^3.2.1 || ^4` (npm ERESOLVE, react-scripts won't install). Reverted to 4.9.5; tightened the dependabot ignore to `typescript>=5` for that dir.

## #445
transcriber-minor aws-sdk 3.1093 — already satisfied on develop by #442.

## Verification
Lambda unit tests pass; transcriber Docker image builds; deploying to lma-integtest1 + full integ-test suite (incl. real-WAV audio e2e, which exercises the boto3-fed Call Event Processor) before merge.
