### PR TITLE
chore(deps): batch5 — tavily-python 0.7.26 (strands_layer) (#462/#463)

### DIFF
--- a/lma-meetingassist-setup-stack/strands_layer/requirements.txt
+++ b/lma-meetingassist-setup-stack/strands_layer/requirements.txt
@@ -1,3 +1,3 @@
 strands-agents
 boto3
-tavily-python>=0.3.0
+tavily-python>=0.7.26


### PR DESCRIPTION
Fifth Dependabot wave. #462 and #463 both target the same strands_layer/requirements.txt (glob duplicate). tavily-python >=0.3.0 -> >=0.7.26. Code uses only the stable TavilyClient + .search API; verified imports in 0.7.26.