### PR TITLE
fix(audio-capture-mac): persistent signing identity so Screen Recording permission survives rebuilds

### DIFF
--- a/docs/audio-capture-app.md
+++ b/docs/audio-capture-app.md
@@ -309,6 +309,15 @@ voice assistant, screen/video capture, or hands-off unattended recording.
 - **No remote-participant audio in the transcript.** Grant **Screen Recording**
   to "LMA Audio Client" in System Settings and relaunch. Audio-only capture
   still requires the Screen Recording permission on macOS.
+- **macOS keeps asking for Screen Recording permission even though it's
+  enabled.** This happens when the app was rebuilt with an ad-hoc signature —
+  macOS ties the permission to the exact binary, so every rebuild invalidates
+  it while System Settings still shows it "enabled". Fix: rebuild with the
+  current `install-macos.sh` (it now signs with a persistent local identity),
+  then clear the stale records and re-grant once:
+  `tccutil reset ScreenCapture com.amazon.lma.audioclient`, relaunch the app,
+  start a recording, and approve the prompt. If System Settings shows duplicate
+  "LMA Audio Client" rows, remove them with the **–** button first.
 - **Build errors / `xcode-select: command not found`.** Install Apple's
   command-line tools (`xcode-select --install`), complete the popup, and re-run
   `bash install-macos.sh`.

--- a/lma-audio-capture-app-stack/source/macos/README.md
+++ b/lma-audio-capture-app-stack/source/macos/README.md
@@ -73,13 +73,23 @@ Requires macOS 13+ and Xcode command-line tools (`xcode-select --install`).
 > file), so it runs and then clears the flag from the rest of the folder.
 > Equivalently, clear it yourself first with `xattr -dr com.apple.quarantine .`
 > then `./install-macos.sh`. (Building locally means nothing is downloaded
-> pre-built, so once quarantine is cleared the ad-hoc-signed binary just runs.)
+> pre-built, so once quarantine is cleared the locally signed binary just runs.)
 
 ### Recommended: run as a `.app` bundle launched with `open` (own TCC identity)
 
 `make-app.sh` wraps the release binary in a minimal `.app` with an `Info.plist`
 (mic usage string) so privacy permissions can be attributed to **"LMA Audio
 Client"**.
+
+It signs the bundle with a **persistent self-signed identity** ("LMA Audio
+Client Local Signing", created in your login keychain on first build — you may
+be prompted once for your login password to trust it). This matters: an ad-hoc
+signature (`codesign -s -`) pins the app's identity to a per-build hash, so
+**every rebuild invalidated the Screen Recording permission** — System Settings
+still showed it enabled, but macOS re-prompted on every capture. With the
+certificate-backed signature the TCC grant is anchored to the cert and
+survives rebuilds. Set `LMA_ADHOC_SIGN=1` to force the old ad-hoc behavior
+(e.g. throwaway CI builds).
 
 > **Critical:** launch it with **`open`** (or double-click in Finder), **not** by
 > running `.../Contents/MacOS/LMAAudioClient` directly. Only `open` goes through

--- a/lma-audio-capture-app-stack/source/macos/install-macos.sh
+++ b/lma-audio-capture-app-stack/source/macos/install-macos.sh
@@ -105,8 +105,11 @@ fi
 # ── 2. Build + bundle ────────────────────────────────────────────────────────
 say "Building the app (this may take a minute on first run)"
 # make-app.sh does the release build, .app assembly, bakes lma-config.json into
-# Contents/Resources/, strips quarantine, and ad-hoc signs. (Config must NOT go
-# in Contents/MacOS/ — codesign rejects non-code files there.)
+# Contents/Resources/, strips quarantine, and signs with a persistent local
+# self-signed identity (created on first build; may prompt once for your login
+# password to trust it). This keeps the Screen Recording permission valid
+# across rebuilds — an ad-hoc signature would invalidate it every build.
+# (Config must NOT go in Contents/MacOS/ — codesign rejects non-code files there.)
 ./make-app.sh
 
 APP="build/LMAAudioClient.app"

--- a/lma-audio-capture-app-stack/source/macos/make-app.sh
+++ b/lma-audio-capture-app-stack/source/macos/make-app.sh
@@ -146,8 +146,10 @@ ensure_signing_identity() {
   # Trust our own cert for code signing so codesign doesn't reject it as
   # untrusted (may prompt once for your login password — expected, one time).
   security add-trusted-cert -p codeSign -k "${login_keychain}" "${tmp}/cert.pem" || true
-  # Let codesign use the private key without a per-build password prompt.
-  security set-key-partition-list -S apple-tool:,apple: -s -k "" "${login_keychain}" 2>/dev/null || true
+  # Let codesign use the private key without a per-build keychain prompt. The
+  # partition list MUST include codesign: — with only apple-tool:/apple:,
+  # codesign still pops the "allow signing" dialog, which hangs a headless run.
+  security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "" "${login_keychain}" 2>/dev/null || true
   rm -rf "${tmp}"
   # Verify the identity actually formed (cert + private key + trust).
   security find-identity -v -p codesigning 2>/dev/null | grep -q "${SIGN_IDENTITY}"

--- a/lma-audio-capture-app-stack/source/macos/make-app.sh
+++ b/lma-audio-capture-app-stack/source/macos/make-app.sh
@@ -101,13 +101,86 @@ echo "    baked AppIcon.icns into Contents/Resources/"
 # and won't trip Gatekeeper when launched.
 xattr -dr com.apple.quarantine "${APP_DIR}" 2>/dev/null || true
 
-# Ad-hoc sign the bundle with entitlements. On Apple Silicon a signature is
-# mandatory just to run; the entitlements match what a notarized build needs.
-echo "==> ad-hoc codesign (with entitlements)"
-codesign --force --sign - \
-  --entitlements LMAAudioClient.entitlements \
-  --options runtime \
-  "${APP_DIR}"
+# Sign the bundle with a PERSISTENT SELF-SIGNED identity (created on first
+# build), NOT ad-hoc. Why this matters: an ad-hoc signature has no identity, so
+# its designated requirement is a literal cdhash of that exact binary — and TCC
+# binds the Screen Recording grant to it. Every rebuild produces a new cdhash,
+# invalidating the grant: System Settings still SHOWS the app enabled, but
+# macOS re-prompts on every capture. A certificate-backed signature (even
+# self-signed) anchors the designated requirement to the cert identity, so the
+# grant survives rebuilds on this machine. (An Apple Developer ID would also
+# fix Gatekeeper warnings; this fixes the TCC re-prompt loop without one.)
+SIGN_IDENTITY="LMA Audio Client Local Signing"
+
+ensure_signing_identity() {
+  # Already have a usable identity? Done. (find-identity only lists certs that
+  # are valid for codesigning AND have their private key in the keychain.)
+  if security find-identity -v -p codesigning 2>/dev/null | grep -q "${SIGN_IDENTITY}"; then
+    return 0
+  fi
+  echo "==> creating one-time self-signed codesigning certificate: ${SIGN_IDENTITY}"
+  # Generate the cert + key with OpenSSL, then import into the login keychain.
+  # codesign requires the extendedKeyUsage=codeSigning extension.
+  local tmp
+  tmp="$(mktemp -d)"
+  openssl req -x509 -newkey rsa:2048 -keyout "${tmp}/key.pem" -out "${tmp}/cert.pem" \
+    -days 3650 -nodes -subj "/CN=${SIGN_IDENTITY}" \
+    -addext "extendedKeyUsage=codeSigning" \
+    -addext "keyUsage=digitalSignature" 2>/dev/null
+  # OpenSSL 3.x defaults PKCS#12 to AES/PBKDF2, which `security import` can't
+  # extract the PRIVATE KEY from — the cert imports but no identity forms
+  # ("0 valid identities found"). -legacy restores compatible encryption.
+  # LibreSSL (/usr/bin/openssl) has no -legacy flag but its defaults are
+  # already compatible, so fall back to plain -export if -legacy is unknown.
+  if ! openssl pkcs12 -export -legacy -out "${tmp}/identity.p12" \
+      -inkey "${tmp}/key.pem" -in "${tmp}/cert.pem" \
+      -name "${SIGN_IDENTITY}" -passout pass:lma-local 2>/dev/null; then
+    openssl pkcs12 -export -out "${tmp}/identity.p12" \
+      -inkey "${tmp}/key.pem" -in "${tmp}/cert.pem" \
+      -name "${SIGN_IDENTITY}" -passout pass:lma-local 2>/dev/null
+  fi
+  local login_keychain
+  login_keychain="$(security default-keychain -d user | tr -d ' "')"
+  security import "${tmp}/identity.p12" -k "${login_keychain}" -P lma-local \
+    -T /usr/bin/codesign -T /usr/bin/security
+  # Trust our own cert for code signing so codesign doesn't reject it as
+  # untrusted (may prompt once for your login password — expected, one time).
+  security add-trusted-cert -p codeSign -k "${login_keychain}" "${tmp}/cert.pem" || true
+  # Let codesign use the private key without a per-build password prompt.
+  security set-key-partition-list -S apple-tool:,apple: -s -k "" "${login_keychain}" 2>/dev/null || true
+  rm -rf "${tmp}"
+  # Verify the identity actually formed (cert + private key + trust).
+  security find-identity -v -p codesigning 2>/dev/null | grep -q "${SIGN_IDENTITY}"
+}
+
+if [[ "${LMA_ADHOC_SIGN:-0}" == "1" ]]; then
+  # Escape hatch (CI, throwaway builds): LMA_ADHOC_SIGN=1 restores old behavior.
+  echo "==> ad-hoc codesign (LMA_ADHOC_SIGN=1)"
+  codesign --force --sign - \
+    --entitlements LMAAudioClient.entitlements \
+    --options runtime \
+    "${APP_DIR}"
+elif ensure_signing_identity; then
+  echo "==> codesign with persistent identity: ${SIGN_IDENTITY}"
+  if ! codesign --force --sign "${SIGN_IDENTITY}" \
+      --entitlements LMAAudioClient.entitlements \
+      --options runtime \
+      "${APP_DIR}"; then
+    echo "    WARNING: identity signing failed — falling back to ad-hoc."
+    echo "    (Screen Recording permission will need re-granting after each rebuild.)"
+    codesign --force --sign - \
+      --entitlements LMAAudioClient.entitlements \
+      --options runtime \
+      "${APP_DIR}"
+  fi
+else
+  echo "    WARNING: couldn't create signing identity — falling back to ad-hoc."
+  echo "    (Screen Recording permission will need re-granting after each rebuild.)"
+  codesign --force --sign - \
+    --entitlements LMAAudioClient.entitlements \
+    --options runtime \
+    "${APP_DIR}"
+fi
 
 echo ""
 echo "Built ${APP_DIR}"


### PR DESCRIPTION
## Problem

Users hit a loop where macOS repeatedly prompts for Screen Recording permission even though System Settings shows "LMA Audio Client" enabled.

Root cause: `make-app.sh` ad-hoc signed the bundle (`codesign -s -`). An ad-hoc signature has no identity, so its **designated requirement is a literal cdhash of that exact binary**, and TCC binds the Screen Recording grant to it. Every rebuild → new cdhash → grant invalidated, while the stale System Settings toggle still shows enabled. Confirmed live on a machine with 3 stale TCC records (one per rebuild), each reported by `tccutil reset`.

## Fix

`make-app.sh` now creates a **one-time self-signed codesigning certificate** ("LMA Audio Client Local Signing") in the login keychain and signs with it. The designated requirement becomes:

```
identifier "com.amazon.lma.audioclient" and certificate leaf = H"..."
```

— anchored to the cert, not the build, so the TCC grant survives rebuilds.

Implementation notes:
- OpenSSL 3.x pkcs12 defaults to AES/PBKDF2 which `security import` can't extract the private key from ("0 valid identities found"); `-legacy` fixes it, with a fallback for LibreSSL which lacks the flag but has compatible defaults.
- `add-trusted-cert` may prompt once for the login password — documented as expected.
- Graceful fallback to ad-hoc (with warning) if identity creation fails; `LMA_ADHOC_SIGN=1` escape hatch for CI.

## Docs
- macOS README: explains the signing rationale and escape hatch.
- `docs/audio-capture-app.md`: new troubleshooting entry with `tccutil reset` recovery steps for users already stuck in the loop.

## Testing
On macOS 26.5: identity created once (subsequent builds reuse it); rebuilt twice — designated requirement identical across builds; app installs, launches, and captures normally. Verified `LMA_ADHOC_SIGN=1` fallback path still ad-hoc signs.