### PR TITLE
feat(audio-capture): Settings gear — editable speaker labels + microphone picker (macOS + Windows)

### DIFF
--- a/docs/audio-capture-app.md
+++ b/docs/audio-capture-app.md
@@ -200,6 +200,14 @@ Popover options:
 - **Start automatically at login** — registers the app as a macOS login item.
   The installer already placed the app in `/Applications`, so this works out of
   the box. You can also manage it in **System Settings ▸ General ▸ Login Items**.
+- **Settings (⚙ gear, top-right of the popover)** — customize how the two
+  channels are labeled in the LMA transcript and which microphone is captured:
+  - **My mic** speaker label — defaults to your signed-in email address.
+  - **System** speaker label — defaults to **"Other participants"**.
+  - **Microphone** — pick a specific input device, or leave **System Default**
+    to follow your Sound settings. If a chosen mic is unplugged, recording
+    falls back to the default. Changes are saved immediately and apply to the
+    **next** recording (the gear is disabled while recording).
 
 ### Running it in the background
 
@@ -260,6 +268,14 @@ Panel options:
   password is never stored).
 - **Start automatically at login** — adds a per-user startup entry that launches
   the tray app when you sign in; the toggle reflects the real system state.
+- **Settings (⚙ gear, top-right of the panel)** — customize how the two
+  channels are labeled in the LMA transcript and which microphone is captured:
+  - **My mic** speaker label — defaults to your signed-in email address.
+  - **System audio** speaker label — defaults to **"Other participants"**.
+  - **Microphone** — pick a specific input device, or leave **System Default**
+    to follow Windows' input device setting. If a chosen mic is unplugged,
+    recording falls back to the default. Changes are saved immediately and
+    apply to the **next** recording (the gear is disabled while recording).
 
 The app uses no audio or CPU when idle, so the intended usage is to leave it in
 the tray and click **Start** when a meeting begins. **To relaunch after

--- a/lma-ai-stack/source/ui/src/components/audio-capture-app-layout/AudioCaptureApp.jsx
+++ b/lma-ai-stack/source/ui/src/components/audio-capture-app-layout/AudioCaptureApp.jsx
@@ -311,6 +311,11 @@ const MacInstall = ({ zipName, copyToClipboard }) => (
             so this works out of the box.
           </li>
           <li>
+            <strong>Settings (⚙ gear):</strong> set the transcript <strong>speaker labels</strong> for each channel
+            (your mic defaults to your email, system audio to &quot;Other participants&quot;) and pick a specific{' '}
+            <strong>microphone</strong> (or leave System Default). Changes apply to your next recording.
+          </li>
+          <li>
             <strong>Launch or relaunch:</strong> press <strong>⌘-Space</strong>, type <strong>LMA Audio Client</strong>,
             and press Return &mdash; or run <code>open -a &quot;LMA Audio Client&quot;</code>.
           </li>
@@ -473,6 +478,11 @@ const WindowsInstall = ({ zipName, copyToClipboard }) => (
           <li>
             <strong>Remember my email</strong> prefills your login next launch (email only; the password is never
             stored).
+          </li>
+          <li>
+            <strong>Settings (⚙ gear):</strong> set the transcript <strong>speaker labels</strong> for each channel
+            (your mic defaults to your email, system audio to &quot;Other participants&quot;) and pick a specific{' '}
+            <strong>microphone</strong> (or leave System Default). Changes apply to your next recording.
           </li>
         </ul>
       </SpaceBetween>

--- a/lma-audio-capture-app-stack/source/macos/Sources/LMAAudioClient/AudioCapture.swift
+++ b/lma-audio-capture-app-stack/source/macos/Sources/LMAAudioClient/AudioCapture.swift
@@ -2,6 +2,7 @@ import Foundation
 import AVFoundation
 import ScreenCaptureKit
 import CoreMedia
+import AudioToolbox
 
 /// Captures the two audio sources and feeds mono Float samples (resampled to the
 /// target rate) into a StereoMixer.
@@ -32,16 +33,40 @@ final class AudioCapture: NSObject, SCStreamOutput, SCStreamDelegate {
         interleaved: false
     )!
 
-    init(mixer: StereoMixer, targetRate: Int) {
+    /// CoreAudio UID of the mic to use; empty = system default (Settings picker).
+    private let micDeviceUID: String
+
+    init(mixer: StereoMixer, targetRate: Int, micDeviceUID: String = "") {
         self.mixer = mixer
         self.targetRate = Double(targetRate)
+        self.micDeviceUID = micDeviceUID
         super.init()
     }
 
     func start() async throws {
+        applyMicDeviceSelection()
         try startMic()
         observeDeviceChanges()
         try await startSystemAudio()
+    }
+
+    /// Point AVAudioEngine's input AUHAL at the chosen device (Settings picker).
+    /// No-op for "" (system default) or if the device is unplugged — both fall
+    /// back to the default input, matching the pre-Settings behavior.
+    private func applyMicDeviceSelection() {
+        guard !micDeviceUID.isEmpty, var devId = MicDevices.deviceID(forUID: micDeviceUID) else {
+            if !micDeviceUID.isEmpty {
+                print("⚠ selected mic not connected; using system default input")
+            }
+            return
+        }
+        let au = engine.inputNode.audioUnit!
+        let err = AudioUnitSetProperty(
+            au, kAudioOutputUnitProperty_CurrentDevice,
+            kAudioUnitScope_Global, 0, &devId, UInt32(MemoryLayout<AudioDeviceID>.size))
+        if err != noErr {
+            print("⚠ couldn't select mic (\(err)); using system default input")
+        }
     }
 
     func stop() {

--- a/lma-audio-capture-app-stack/source/macos/Sources/LMAAudioClient/CaptureController.swift
+++ b/lma-audio-capture-app-stack/source/macos/Sources/LMAAudioClient/CaptureController.swift
@@ -34,6 +34,16 @@ final class CaptureController {
     /// The callId of the active/most-recent stream (for "Open in LMA" deep link).
     private(set) var activeCallId: String = ""
 
+    // Settings (persisted by the GUI, applied at start). Empty = use the
+    // config/CLI value, so the headless CLI path is completely unaffected.
+    /// Speaker label for the mic channel (ch_1 → agentId). GUI default: the
+    /// signed-in email.
+    var micLabel: String = ""
+    /// Speaker label for the system-audio channel (ch_0 → fromNumber).
+    var systemLabel: String = ""
+    /// CoreAudio UID of the mic to capture from. Empty = system default.
+    var micDeviceUID: String = ""
+
     init(config: Config) { self.config = config }
 
     var state: State { lock.lock(); defer { lock.unlock() }; return _state }
@@ -97,9 +107,14 @@ final class CaptureController {
         if let c = callId, !c.isEmpty { config.callId = c }
         activeCallId = config.callId
 
+        // Apply Settings overrides: speaker labels ride the START frame as
+        // agentId (mic/ch_1) and fromNumber (system/ch_0).
+        if !micLabel.isEmpty { config.agentId = micLabel }
+        if !systemLabel.isEmpty { config.fromNumber = systemLabel }
+
         let sock = TranscriberSocket(config: config)
         let mix = StereoMixer(sampleRate: config.sampleRate) { [weak sock] chunk in sock?.sendPCM(chunk) }
-        let cap = AudioCapture(mixer: mix, targetRate: config.sampleRate)
+        let cap = AudioCapture(mixer: mix, targetRate: config.sampleRate, micDeviceUID: micDeviceUID)
 
         sock.onStateChange = { connected in mix.setConnected(connected) }
         mix.onLevels = { [weak self] mRMS, kRMS, connected, paused in

--- a/lma-audio-capture-app-stack/source/macos/Sources/LMAAudioClient/MenuBarApp.swift
+++ b/lma-audio-capture-app-stack/source/macos/Sources/LMAAudioClient/MenuBarApp.swift
@@ -30,11 +30,25 @@ final class MenuBarAppState: ObservableObject {
 
     @Published var rememberLogin = false
 
+    // Settings (gear panel): per-channel speaker labels + mic device. Persisted
+    // in UserDefaults; applied to the controller so they ride the START frame.
+    @Published var showSettings = false
+    @Published var micLabel = ""
+    @Published var systemLabel = ""
+    @Published var micDeviceUID = ""            // "" = System Default
+    @Published var micDevices: [MicDevices.Device] = []
+
     let controller: CaptureController
     // UserDefaults keys for the optional "remember login id" feature. Only the
     // username (email) is stored — never the password, which stays in memory.
     private static let kRemember = "lma.rememberLogin"
     private static let kUsername = "lma.savedUsername"
+    private static let kMicLabel = "lma.micLabel"
+    private static let kSystemLabel = "lma.systemLabel"
+    private static let kMicDeviceUID = "lma.micDeviceUID"
+
+    /// Default label for the system channel when the user hasn't set one.
+    static let defaultSystemLabel = "Other participants"
 
     init(controller: CaptureController) {
         self.controller = controller
@@ -42,11 +56,52 @@ final class MenuBarAppState: ObservableObject {
         self.rememberLogin = defaults.bool(forKey: Self.kRemember)
         // Prefill the login id from the remembered value, else the config.
         self.username = rememberLogin ? (defaults.string(forKey: Self.kUsername) ?? "") : controller.config.username
+        self.micLabel = defaults.string(forKey: Self.kMicLabel) ?? ""
+        self.systemLabel = defaults.string(forKey: Self.kSystemLabel) ?? ""
+        self.micDeviceUID = defaults.string(forKey: Self.kMicDeviceUID) ?? ""
+        pushSettingsToController()
         controller.onStateChange = { [weak self] s in self?.state = s }
         controller.onLevels = { [weak self] m, k, c, p in
             self?.meetingLevel = m; self?.micLevel = k; self?.connected = c; self?.paused = p
         }
         controller.onLog = { [weak self] msg in self?.lastLog = msg }
+    }
+
+    // MARK: - Settings
+
+    /// The mic label shown/used when the user hasn't customized one: their
+    /// signed-in email, else the config's agentId ("Me").
+    var effectiveMicLabel: String {
+        if !micLabel.isEmpty { return micLabel }
+        if !username.isEmpty { return username }
+        return controller.config.agentId
+    }
+    var effectiveSystemLabel: String {
+        systemLabel.isEmpty ? Self.defaultSystemLabel : systemLabel
+    }
+
+    func saveSettings() {
+        let defaults = UserDefaults.standard
+        defaults.set(micLabel, forKey: Self.kMicLabel)
+        defaults.set(systemLabel, forKey: Self.kSystemLabel)
+        defaults.set(micDeviceUID, forKey: Self.kMicDeviceUID)
+        pushSettingsToController()
+    }
+
+    /// Refresh the device list each time the panel opens (hotplug-friendly).
+    func refreshMicDevices() {
+        micDevices = MicDevices.list()
+        // If the saved device disappeared, show System Default rather than a
+        // stale selection (capture already falls back at start).
+        if !micDeviceUID.isEmpty && !micDevices.contains(where: { $0.uid == micDeviceUID }) {
+            micDeviceUID = ""
+        }
+    }
+
+    private func pushSettingsToController() {
+        controller.micLabel = effectiveMicLabel
+        controller.systemLabel = effectiveSystemLabel
+        controller.micDeviceUID = micDeviceUID
     }
 
     var isStreaming: Bool { if case .streaming = state { return true }; return false }
@@ -94,6 +149,8 @@ final class MenuBarAppState: ObservableObject {
         }
     }
     func start() {
+        // Push current settings (labels may depend on the signed-in email).
+        pushSettingsToController()
         let name = meetingName.isEmpty ? "" : "\(meetingName) - \(Self.timestamp())"
         controller.start(callId: name.isEmpty ? nil : name)
     }
@@ -119,9 +176,27 @@ struct MenuBarContentView: View {
                 Text("LMA Audio Capture").font(.headline)
                 Spacer()
                 Text(statusText).font(.caption).foregroundColor(.secondary)
+                // Settings gear: speaker labels + mic picker. Disabled while
+                // streaming — labels ride the START frame, so mid-meeting
+                // changes wouldn't take effect anyway.
+                Button {
+                    s.showSettings.toggle()
+                    if s.showSettings { s.refreshMicDevices() }
+                } label: {
+                    Image(systemName: "gearshape")
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(s.showSettings ? .accentColor : .secondary)
+                .disabled(s.isStreaming)
+                .help(s.isStreaming ? "Stop recording to change settings" : "Settings")
             }
 
             Divider()
+
+            if s.showSettings {
+                SettingsView(s: s)
+                Divider()
+            }
 
             if !s.controller.isAuthenticated {
                 // Sign-in form
@@ -215,6 +290,47 @@ struct MenuBarContentView: View {
         case .streaming: return "Recording"
         case .stopping: return "Stopping…"
         case .error: return "Error"
+        }
+    }
+}
+
+/// Settings section (gear): speaker labels for the two channels + mic picker.
+/// Labels are applied to the next recording's START frame; the mic choice is
+/// applied when capture starts. Saved on every edit (no Apply button).
+@available(macOS 13.0, *)
+struct SettingsView: View {
+    @ObservedObject var s: MenuBarAppState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Speaker labels").font(.caption).foregroundColor(.secondary)
+            HStack {
+                Text("My mic").font(.caption).frame(width: 70, alignment: .leading)
+                TextField(s.username.isEmpty ? "Me" : s.username,
+                          text: Binding(get: { s.micLabel }, set: { s.micLabel = $0; s.saveSettings() }))
+                    .textFieldStyle(.roundedBorder).font(.caption)
+            }
+            HStack {
+                Text("System").font(.caption).frame(width: 70, alignment: .leading)
+                TextField(MenuBarAppState.defaultSystemLabel,
+                          text: Binding(get: { s.systemLabel }, set: { s.systemLabel = $0; s.saveSettings() }))
+                    .textFieldStyle(.roundedBorder).font(.caption)
+            }
+            Text("These appear as the speaker names in the LMA transcript. Leave blank for the defaults shown.")
+                .font(.caption2).foregroundColor(.secondary)
+
+            Text("Microphone").font(.caption).foregroundColor(.secondary).padding(.top, 2)
+            Picker("", selection: Binding(get: { s.micDeviceUID }, set: { s.micDeviceUID = $0; s.saveSettings() })) {
+                Text("System Default").tag("")
+                ForEach(s.micDevices) { d in
+                    Text(d.name).tag(d.uid)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .font(.caption)
+            Text("System Default follows your Sound settings. If a chosen mic is unplugged, recording falls back to the default.")
+                .font(.caption2).foregroundColor(.secondary)
         }
     }
 }

--- a/lma-audio-capture-app-stack/source/macos/Sources/LMAAudioClient/MicDevices.swift
+++ b/lma-audio-capture-app-stack/source/macos/Sources/LMAAudioClient/MicDevices.swift
@@ -1,0 +1,88 @@
+import Foundation
+import CoreAudio
+
+/// Enumerate audio INPUT devices and resolve a persisted selection, for the
+/// Settings mic picker.
+///
+/// Devices are identified by their CoreAudio UID (a stable string like
+/// "BuiltInMicrophoneDevice" or a USB serial-derived id) — NOT the transient
+/// AudioDeviceID integer, which changes across reboots/hotplug. An empty UID
+/// means "System Default": follow whatever the user picks in Sound settings
+/// (the pre-Settings behavior, and the fallback when a chosen device is
+/// unplugged).
+enum MicDevices {
+    struct Device: Identifiable, Equatable {
+        let uid: String
+        let name: String
+        var id: String { uid }
+    }
+
+    /// All devices that have at least one input stream, sorted by name.
+    static func list() -> [Device] {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &size) == noErr,
+              size > 0 else { return [] }
+        var ids = [AudioDeviceID](repeating: 0, count: Int(size) / MemoryLayout<AudioDeviceID>.size)
+        guard AudioObjectGetPropertyData(AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &size, &ids) == noErr
+        else { return [] }
+
+        return ids.compactMap { devId -> Device? in
+            guard inputChannelCount(devId) > 0,
+                  let uid = stringProperty(devId, kAudioDevicePropertyDeviceUID),
+                  let name = stringProperty(devId, kAudioObjectPropertyName) else { return nil }
+            return Device(uid: uid, name: name)
+        }
+        .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    /// AudioDeviceID for a stored UID, or nil if that device isn't connected
+    /// right now (caller should fall back to the system default).
+    static func deviceID(forUID uid: String) -> AudioDeviceID? {
+        guard !uid.isEmpty else { return nil }
+        var addr = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &size) == noErr
+        else { return nil }
+        var ids = [AudioDeviceID](repeating: 0, count: Int(size) / MemoryLayout<AudioDeviceID>.size)
+        guard AudioObjectGetPropertyData(AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &size, &ids) == noErr
+        else { return nil }
+        return ids.first { stringProperty($0, kAudioDevicePropertyDeviceUID) == uid }
+    }
+
+    // MARK: - CoreAudio property helpers
+
+    private static func inputChannelCount(_ devId: AudioDeviceID) -> Int {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreamConfiguration,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain)
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(devId, &addr, 0, nil, &size) == noErr, size > 0 else { return 0 }
+        let bufListPtr = UnsafeMutableRawPointer.allocate(byteCount: Int(size), alignment: MemoryLayout<AudioBufferList>.alignment)
+        defer { bufListPtr.deallocate() }
+        guard AudioObjectGetPropertyData(devId, &addr, 0, nil, &size, bufListPtr) == noErr else { return 0 }
+        let bufList = bufListPtr.assumingMemoryBound(to: AudioBufferList.self)
+        return UnsafeMutableAudioBufferListPointer(bufList).reduce(0) { $0 + Int($1.mNumberChannels) }
+    }
+
+    private static func stringProperty(_ devId: AudioDeviceID, _ selector: AudioObjectPropertySelector) -> String? {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var cf: CFString? = nil
+        var size = UInt32(MemoryLayout<CFString?>.size)
+        let err = withUnsafeMutablePointer(to: &cf) { ptr in
+            AudioObjectGetPropertyData(devId, &addr, 0, nil, &size, ptr)
+        }
+        guard err == noErr, let s = cf else { return nil }
+        return s as String
+    }
+}

--- a/lma-audio-capture-app-stack/source/windows/App/AppSettings.cs
+++ b/lma-audio-capture-app-stack/source/windows/App/AppSettings.cs
@@ -52,6 +52,36 @@ public static class AppSettings
             k.DeleteValue(UsernameValue, throwOnMissingValue: false);
     }
 
+    // MARK: - Settings gear (speaker labels + mic device)
+
+    private const string MicLabelValue = "MicLabel";
+    private const string SystemLabelValue = "SystemLabel";
+    private const string MicDeviceValue = "MicDeviceId";
+
+    /// <summary>Default label for the system channel when the user hasn't set one.</summary>
+    public const string DefaultSystemLabel = "Other participants";
+
+    /// <summary>Custom mic-channel speaker label ("" = default: signed-in email).</summary>
+    public static string MicLabel
+    {
+        get { using var k = Registry.CurrentUser.OpenSubKey(SettingsKeyPath); return (k?.GetValue(MicLabelValue) as string) ?? ""; }
+        set { using var k = Registry.CurrentUser.CreateSubKey(SettingsKeyPath); k.SetValue(MicLabelValue, value, RegistryValueKind.String); }
+    }
+
+    /// <summary>Custom system-channel speaker label ("" = DefaultSystemLabel).</summary>
+    public static string SystemLabel
+    {
+        get { using var k = Registry.CurrentUser.OpenSubKey(SettingsKeyPath); return (k?.GetValue(SystemLabelValue) as string) ?? ""; }
+        set { using var k = Registry.CurrentUser.CreateSubKey(SettingsKeyPath); k.SetValue(SystemLabelValue, value, RegistryValueKind.String); }
+    }
+
+    /// <summary>MMDevice ID of the chosen mic ("" = system default).</summary>
+    public static string MicDeviceId
+    {
+        get { using var k = Registry.CurrentUser.OpenSubKey(SettingsKeyPath); return (k?.GetValue(MicDeviceValue) as string) ?? ""; }
+        set { using var k = Registry.CurrentUser.CreateSubKey(SettingsKeyPath); k.SetValue(MicDeviceValue, value, RegistryValueKind.String); }
+    }
+
     // MARK: - Start at login (HKCU ...\Run)
 
     /// <summary>

--- a/lma-audio-capture-app-stack/source/windows/App/PanelView.cs
+++ b/lma-audio-capture-app-stack/source/windows/App/PanelView.cs
@@ -53,6 +53,18 @@ public sealed class PanelView : Border
     private readonly Button _openLma = new();
     private readonly TextBlock _logLine = new() { Foreground = Secondary, FontSize = 10, TextWrapping = TextWrapping.Wrap };
 
+    // Settings gear (speaker labels + mic picker)
+    private bool _showSettings;
+    private readonly Button _gear = new()
+    {
+        Content = "⚙", FontSize = 14, Padding = new Thickness(4, 0, 4, 0),
+        Background = Brushes.Transparent, BorderThickness = new Thickness(0),
+        VerticalAlignment = VerticalAlignment.Center, Cursor = System.Windows.Input.Cursors.Hand,
+    };
+    private readonly TextBox _micLabel = new();
+    private readonly TextBox _systemLabel = new();
+    private readonly ComboBox _micPicker = new() { FontSize = 11, Margin = new Thickness(0, 0, 0, 6) };
+
     private readonly StackPanel _body = new();
 
     public Action? RequestClosePopup;
@@ -84,8 +96,10 @@ public sealed class PanelView : Border
             VerticalAlignment = VerticalAlignment.Center,
         });
         DockPanel.SetDock(left, Dock.Left);
+        DockPanel.SetDock(_gear, Dock.Right);
         DockPanel.SetDock(_statusText, Dock.Right);
         header.Children.Add(left);
+        header.Children.Add(_gear);
         header.Children.Add(_statusText);
         root.Children.Add(header);
         root.Children.Add(Sep());
@@ -110,16 +124,77 @@ public sealed class PanelView : Border
             catch (Exception ex) { OnLog($"Couldn't change Start-at-login: {ex.Message}"); }
         };
 
-        StyleBox(_email); StyleBox(_meetingName);
+        StyleBox(_email); StyleBox(_meetingName); StyleBox(_micLabel); StyleBox(_systemLabel);
         _password.Margin = _email.Margin = _meetingName.Margin = new Thickness(0, 0, 0, 6);
         _password.Padding = new Thickness(4);
+
+        // Settings gear: toggle the section; save on every edit (no Apply).
+        // Disabled while streaming — labels ride the START frame, so mid-meeting
+        // changes wouldn't take effect anyway.
+        _gear.Click += (_, _) =>
+        {
+            _showSettings = !_showSettings;
+            if (_showSettings) RefreshMicPicker();
+            Refresh();
+        };
+        _micLabel.TextChanged += (_, _) => AppSettings.MicLabel = _micLabel.Text;
+        _systemLabel.TextChanged += (_, _) => AppSettings.SystemLabel = _systemLabel.Text;
+        _micPicker.SelectionChanged += (_, _) =>
+        {
+            if (_micPicker.SelectedItem is ComboBoxItem it)
+                AppSettings.MicDeviceId = (it.Tag as string) ?? "";
+        };
     }
 
     public void InitFromSettings()
     {
         _remember.IsChecked = AppSettings.RememberLogin;
         _email.Text = AppSettings.RememberLogin ? AppSettings.SavedUsername : _c.Config.Username;
+        _micLabel.Text = AppSettings.MicLabel;
+        _systemLabel.Text = AppSettings.SystemLabel;
+        PushSettingsToController();
         Refresh();
+    }
+
+    /// <summary>
+    /// Apply persisted settings to the controller. The effective mic label
+    /// falls back to the signed-in email (the requested default), then the
+    /// config's AgentId ("Me"); the system label falls back to
+    /// "Other participants".
+    /// </summary>
+    public void PushSettingsToController()
+    {
+        var mic = AppSettings.MicLabel;
+        if (string.IsNullOrEmpty(mic)) mic = CurrentEmail();
+        if (string.IsNullOrEmpty(mic)) mic = _c.Config.AgentId;
+        _c.MicLabel = mic;
+        var sys = AppSettings.SystemLabel;
+        _c.SystemLabel = string.IsNullOrEmpty(sys) ? AppSettings.DefaultSystemLabel : sys;
+        _c.MicDeviceId = AppSettings.MicDeviceId;
+    }
+
+    private string CurrentEmail()
+    {
+        if (!string.IsNullOrEmpty(_email.Text)) return _email.Text;
+        return AppSettings.RememberLogin ? AppSettings.SavedUsername : _c.Config.Username;
+    }
+
+    /// <summary>Repopulate the mic dropdown from live device enumeration (hotplug-friendly).</summary>
+    private void RefreshMicPicker()
+    {
+        _micPicker.Items.Clear();
+        var selected = AppSettings.MicDeviceId;
+        var def = new ComboBoxItem { Content = "System Default", Tag = "" };
+        _micPicker.Items.Add(def);
+        _micPicker.SelectedItem = def;
+        foreach (var (id, name) in AudioCapture.ListMicDevices())
+        {
+            var item = new ComboBoxItem { Content = name, Tag = id };
+            _micPicker.Items.Add(item);
+            if (id == selected) _micPicker.SelectedItem = item;
+        }
+        // Saved device unplugged → selection stays on System Default, matching
+        // the engine's fallback at capture start.
     }
 
     public void FocusFirstField()
@@ -175,6 +250,36 @@ public sealed class PanelView : Border
     public void Refresh()
     {
         _body.Children.Clear();
+
+        // Settings gear is only actionable between recordings.
+        bool isStreaming = _c.CurrentState.Kind == CaptureController.StateKind.Streaming;
+        _gear.IsEnabled = !isStreaming;
+        _gear.ToolTip = isStreaming ? "Stop recording to change settings" : "Settings";
+        _gear.Foreground = _showSettings ? Brushes.SteelBlue : Secondary;
+
+        if (_showSettings && !isStreaming)
+        {
+            _body.Children.Add(Label("Speaker labels — shown in the LMA transcript"));
+            _body.Children.Add(Label("My mic"));
+            // Placeholder semantics: blank = default (signed-in email).
+            if (string.IsNullOrEmpty(_micLabel.Text))
+                _micLabel.ToolTip = $"Default: {(string.IsNullOrEmpty(CurrentEmail()) ? "Me" : CurrentEmail())}";
+            _body.Children.Add(_micLabel);
+            _body.Children.Add(Label("System audio"));
+            if (string.IsNullOrEmpty(_systemLabel.Text))
+                _systemLabel.ToolTip = $"Default: {AppSettings.DefaultSystemLabel}";
+            _body.Children.Add(_systemLabel);
+            _body.Children.Add(Label("Microphone"));
+            _body.Children.Add(_micPicker);
+            _body.Children.Add(new TextBlock
+            {
+                Text = "Leave a label blank for its default. System Default follows Windows' input device; " +
+                       "if a chosen mic is unplugged, recording falls back to the default.",
+                Foreground = Secondary, FontSize = 10, TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 0, 0, 4),
+            });
+            _body.Children.Add(Sep());
+        }
 
         if (!_c.IsAuthenticated)
         {
@@ -253,6 +358,8 @@ public sealed class PanelView : Border
 
     private void DoStart()
     {
+        // Push current settings (the mic label may depend on the signed-in email).
+        PushSettingsToController();
         var name = string.IsNullOrEmpty(_meetingName.Text)
             ? null
             : $"{_meetingName.Text} - {DateTime.Now:yyyy-MM-dd HH:mm}";

--- a/lma-audio-capture-app-stack/source/windows/App/TrayApp.cs
+++ b/lma-audio-capture-app-stack/source/windows/App/TrayApp.cs
@@ -435,6 +435,9 @@ public sealed class TrayApp
                 if (_controller.IsAuthenticated &&
                     _controller.CurrentState.Kind != CaptureController.StateKind.Streaming)
                 {
+                    // Same settings path as the panel's Start button, so
+                    // JumpList-started recordings get the right speaker labels.
+                    _panel.PushSettingsToController();
                     _controller.Start();
                 }
                 else

--- a/lma-audio-capture-app-stack/source/windows/Engine/AudioCapture.cs
+++ b/lma-audio-capture-app-stack/source/windows/Engine/AudioCapture.cs
@@ -44,10 +44,35 @@ public sealed class AudioCapture : IMMNotificationClient
     private volatile bool _running;
     private volatile bool _rebuildScheduled;
 
-    public AudioCapture(StereoMixer mixer, int targetRate)
+    /// <summary>MMDevice ID of the mic to use; empty = system default (Settings picker).</summary>
+    private readonly string _micDeviceId;
+
+    public AudioCapture(StereoMixer mixer, int targetRate, string micDeviceId = "")
     {
         _mixer = mixer;
         _targetRate = targetRate;
+        _micDeviceId = micDeviceId;
+    }
+
+    /// <summary>
+    /// Input devices for the Settings mic picker: (MMDevice ID, friendly name).
+    /// IDs are stable across reboots/hotplug, unlike device indexes.
+    /// </summary>
+    public static List<(string Id, string Name)> ListMicDevices()
+    {
+        var result = new List<(string, string)>();
+        try
+        {
+            using var e = new MMDeviceEnumerator();
+            foreach (var d in e.EnumerateAudioEndPoints(DataFlow.Capture, DeviceState.Active))
+            {
+                result.Add((d.ID, d.FriendlyName));
+                d.Dispose();
+            }
+        }
+        catch { /* enumeration failure → empty list; picker shows only System Default */ }
+        result.Sort((a, b) => string.Compare(a.Item2, b.Item2, StringComparison.OrdinalIgnoreCase));
+        return result;
     }
 
     public void Start()
@@ -118,7 +143,23 @@ public sealed class AudioCapture : IMMNotificationClient
         {
             try
             {
-                var device = _enumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Communications);
+                // Settings picker: use the chosen device if it's still connected,
+                // else fall back to the system default (same as no selection).
+                MMDevice? device = null;
+                if (!string.IsNullOrEmpty(_micDeviceId))
+                {
+                    try
+                    {
+                        var d = _enumerator.GetDevice(_micDeviceId);
+                        if (d?.State == DeviceState.Active) device = d;
+                        else Console.WriteLine("⚠ selected mic not connected; using system default input");
+                    }
+                    catch
+                    {
+                        Console.WriteLine("⚠ selected mic not found; using system default input");
+                    }
+                }
+                device ??= _enumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Communications);
                 var cap = new WasapiCapture(device);
                 var fmt = cap.WaveFormat;
                 _micChannels = fmt.Channels;

--- a/lma-audio-capture-app-stack/source/windows/Engine/CaptureController.cs
+++ b/lma-audio-capture-app-stack/source/windows/Engine/CaptureController.cs
@@ -111,6 +111,15 @@ public sealed class CaptureController
     /// Begin capture + streaming. Uses a fresh callId per session unless the
     /// caller set one on the config. Safe to call only when authenticated.
     /// </summary>
+    // Settings (persisted by the GUI, applied at start). Empty = use the
+    // config/CLI value, so the headless CLI path is completely unaffected.
+    /// <summary>Speaker label for the mic channel (ch_1 → AgentId). GUI default: the signed-in email.</summary>
+    public string MicLabel = "";
+    /// <summary>Speaker label for the system-audio channel (ch_0 → FromNumber).</summary>
+    public string SystemLabel = "";
+    /// <summary>MMDevice ID of the mic to capture from. Empty = system default.</summary>
+    public string MicDeviceId = "";
+
     public void Start(string? callId = null)
     {
         if (string.IsNullOrEmpty(Config.AccessToken)) { SetState(State.Err("Not signed in")); return; }
@@ -119,9 +128,14 @@ public sealed class CaptureController
         if (!string.IsNullOrEmpty(callId)) Config.CallId = callId!;
         ActiveCallId = Config.CallId;
 
+        // Apply Settings overrides: speaker labels ride the START frame as
+        // AgentId (mic/ch_1) and FromNumber (system/ch_0).
+        if (!string.IsNullOrEmpty(MicLabel)) Config.AgentId = MicLabel;
+        if (!string.IsNullOrEmpty(SystemLabel)) Config.FromNumber = SystemLabel;
+
         var sock = new TranscriberSocket(Config);
         var mix = new StereoMixer(Config.SampleRate, chunk => sock.SendPcm(chunk));
-        var cap = new AudioCapture(mix, Config.SampleRate);
+        var cap = new AudioCapture(mix, Config.SampleRate, MicDeviceId);
 
         // Optional: tee the exact streamed PCM to a local stereo WAV for offline
         // verification (per-channel RMS proves ch0=system / ch1=mic, not swapped).


### PR DESCRIPTION
## What

Adds a **Settings gear** to both native audio-capture clients (macOS menu-bar popover, Windows tray panel) with two capabilities:

### 1. Editable speaker labels
How the two channels appear as speaker names in the LMA transcript:
- **My mic** (ch_1 → `agentId`/`AgentId`) — **defaults to the signed-in email address**.
- **System audio** (ch_0 → `fromNumber`/`FromNumber`) — defaults to **"Other participants"**.

Both editable, persisted (UserDefaults on macOS, HKCU registry on Windows), applied to the next recording's START frame.

### 2. Microphone picker
Previously both platforms always auto-picked the OS default input. Now you can choose a specific device or **System Default**:
- macOS: enumerates CoreAudio input devices by stable UID; points AVAudioEngine's input AUHAL at the selection.
- Windows: enumerates MMDevices by ID; passes to `WasapiCapture`.
- An unplugged selection falls back to the system default (matches prior behavior).

## Notes
- Settings are pushed on **both** the panel Start button **and** the Windows taskbar JumpList "Start Recording", so labels are correct however a recording begins.
- The gear is **disabled while recording** — labels ride the START frame, so mid-recording changes wouldn't take effect.
- **CLI/headless path unaffected**: empty settings mean "use the config value", so `--agent-id`/`--from` still work.

## Files
- macOS: new `MicDevices.swift` (CoreAudio enumeration); `AudioCapture`, `CaptureController`, `MenuBarApp` (gear + SettingsView).
- Windows: `AppSettings` (new persisted keys + device list), `AudioCapture` (device selection + `ListMicDevices`), `CaptureController`, `PanelView` (gear + settings section), `TrayApp` (JumpList start path).
- Docs: `docs/audio-capture-app.md` + in-app help page, both platforms.

## Testing
- macOS: `swift build -c release` clean; app installs and launches; gear toggles the Settings section with label fields + mic dropdown.
- Windows (.NET/WPF): compiles on the Windows box — needs a build + manual check there (I can't build .NET on the Mac). Recommend verifying: gear shows/hides settings, labels persist across relaunch, mic dropdown lists devices, chosen labels appear in the transcript.
- Web UI page: 3 pre-existing lint errors, none introduced.

## Depends on / relates to
Independent of #468 (signing fix). Both branch from `develop`.