### PR TITLE
fix(audio-capture-win): single instance in the tray, and show label defaults in grey

### DIFF
--- a/docs/audio-capture-app.md
+++ b/docs/audio-capture-app.md
@@ -239,6 +239,9 @@ Tray icon:
 - Want it one click away even when idle? Right-click **LMA Audio Capture** in the
   Start Menu ▸ **More** ▸ **Pin to taskbar**. (Windows 10+ removed the API that
   would let the installer do this for you.)
+- **Only one copy runs at a time.** Opening the app again — from that pinned
+  shortcut, the Start Menu, or the .exe — **opens the controls panel** of the copy
+  already running instead of adding a second tray icon.
 
 Taskbar button (while recording):
 
@@ -269,7 +272,9 @@ Panel options:
 - **Start automatically at login** — adds a per-user startup entry that launches
   the tray app when you sign in; the toggle reflects the real system state.
 - **Settings (⚙ gear, top-right of the panel)** — customize how the two
-  channels are labeled in the LMA transcript and which microphone is captured:
+  channels are labeled in the LMA transcript and which microphone is captured.
+  Each label field shows its **default in grey**; leave the field blank to use
+  it, or type to override.
   - **My mic** speaker label — defaults to your signed-in email address.
   - **System audio** speaker label — defaults to **"Other participants"**.
   - **Microphone** — pick a specific input device, or leave **System Default**
@@ -280,7 +285,8 @@ Panel options:
 The app uses no audio or CPU when idle, so the intended usage is to leave it in
 the tray and click **Start** when a meeting begins. **To relaunch after
 quitting**, press the **Windows key**, type **LMA Audio Capture**, and press
-Enter.
+Enter. If it's already running, that just brings up its controls panel — you
+can't accidentally end up with two.
 
 > **Developer / headless mode.** Any command-line flag runs a headless CLI that
 > streams to stdout with a live VU meter (`--cli` forces it). `--selftest`

--- a/lma-ai-stack/source/ui/src/components/audio-capture-app-layout/AudioCaptureApp.jsx
+++ b/lma-ai-stack/source/ui/src/components/audio-capture-app-layout/AudioCaptureApp.jsx
@@ -311,9 +311,10 @@ const MacInstall = ({ zipName, copyToClipboard }) => (
             so this works out of the box.
           </li>
           <li>
-            <strong>Settings (⚙ gear):</strong> set the transcript <strong>speaker labels</strong> for each channel
-            (your mic defaults to your email, system audio to &quot;Other participants&quot;) and pick a specific{' '}
-            <strong>microphone</strong> (or leave System Default). Changes apply to your next recording.
+            <strong>Settings (⚙ gear):</strong> set the transcript <strong>speaker labels</strong> for each channel and
+            pick a specific <strong>microphone</strong> (or leave System Default). Each label field shows its default in
+            grey &mdash; your email for the mic, &quot;Other participants&quot; for system audio &mdash; so leave it
+            blank to accept that, or type to override. Changes apply to your next recording.
           </li>
           <li>
             <strong>Launch or relaunch:</strong> press <strong>⌘-Space</strong>, type <strong>LMA Audio Client</strong>,
@@ -483,6 +484,11 @@ const WindowsInstall = ({ zipName, copyToClipboard }) => (
             API that would let the installer pin it for you.)
           </li>
           <li>
+            <strong>Only one copy runs at a time.</strong> Opening the app again &mdash; from that pinned shortcut, the
+            Start Menu, or the .exe &mdash; opens the controls panel of the copy already running, rather than adding a
+            second tray icon.
+          </li>
+          <li>
             <strong>Start automatically at login:</strong> turn on the login toggle in the panel &mdash; it adds a
             per-user startup entry that launches the tray app when you sign in.
           </li>
@@ -491,9 +497,10 @@ const WindowsInstall = ({ zipName, copyToClipboard }) => (
             stored).
           </li>
           <li>
-            <strong>Settings (⚙ gear):</strong> set the transcript <strong>speaker labels</strong> for each channel
-            (your mic defaults to your email, system audio to &quot;Other participants&quot;) and pick a specific{' '}
-            <strong>microphone</strong> (or leave System Default). Changes apply to your next recording.
+            <strong>Settings (⚙ gear):</strong> set the transcript <strong>speaker labels</strong> for each channel and
+            pick a specific <strong>microphone</strong> (or leave System Default). Each label field shows its default in
+            grey &mdash; your email for the mic, &quot;Other participants&quot; for system audio &mdash; so leave it
+            blank to accept that, or type to override. Changes apply to your next recording.
           </li>
         </ul>
       </SpaceBetween>

--- a/lma-audio-capture-app-stack/source/windows/App/PanelView.cs
+++ b/lma-audio-capture-app-stack/source/windows/App/PanelView.cs
@@ -64,6 +64,16 @@ public sealed class PanelView : Border
     private readonly TextBox _micLabel = new();
     private readonly TextBox _systemLabel = new();
     private readonly ComboBox _micPicker = new() { FontSize = 11, Margin = new Thickness(0, 0, 0, 6) };
+    // Grey placeholder showing what a blank field will actually be sent as, so the
+    // defaults are visible without having to hover a tooltip.
+    private readonly TextBlock _micHint = HintText();
+    private readonly TextBlock _systemHint = HintText();
+    private readonly Grid _micLabelBox;
+    private readonly Grid _systemLabelBox;
+    // RefreshMicPicker rebuilds the list, and setting SelectedItem fires
+    // SelectionChanged — which would persist a transient "System Default" over the
+    // saved device before the matching item is found.
+    private bool _loadingMicPicker;
 
     private readonly StackPanel _body = new();
 
@@ -128,6 +138,13 @@ public sealed class PanelView : Border
         _password.Margin = _email.Margin = _meetingName.Margin = new Thickness(0, 0, 0, 6);
         _password.Padding = new Thickness(4);
 
+        // The two label fields live inside a placeholder wrapper, which owns the
+        // bottom margin instead of the TextBox (the grey hint has to sit over the
+        // field itself, not over the gap below it).
+        _micLabel.Margin = _systemLabel.Margin = new Thickness(0);
+        _micLabelBox = PlaceholderBox(_micLabel, _micHint);
+        _systemLabelBox = PlaceholderBox(_systemLabel, _systemHint);
+
         // Settings gear: toggle the section; save on every edit (no Apply).
         // Disabled while streaming — labels ride the START frame, so mid-meeting
         // changes wouldn't take effect anyway.
@@ -137,10 +154,16 @@ public sealed class PanelView : Border
             if (_showSettings) RefreshMicPicker();
             Refresh();
         };
-        _micLabel.TextChanged += (_, _) => AppSettings.MicLabel = _micLabel.Text;
-        _systemLabel.TextChanged += (_, _) => AppSettings.SystemLabel = _systemLabel.Text;
+        _micLabel.TextChanged += (_, _) => { AppSettings.MicLabel = _micLabel.Text; UpdateLabelHints(); };
+        _systemLabel.TextChanged += (_, _) => { AppSettings.SystemLabel = _systemLabel.Text; UpdateLabelHints(); };
+        // Typing in the email field changes the mic-label default, so keep the grey
+        // hint honest while the user is still signing in.
+        _email.TextChanged += (_, _) => UpdateLabelHints();
         _micPicker.SelectionChanged += (_, _) =>
         {
+            // Ignore the churn from rebuilding the list — only persist real picks,
+            // or an unplugged device would silently erase the saved selection.
+            if (_loadingMicPicker) return;
             if (_micPicker.SelectedItem is ComboBoxItem it)
                 AppSettings.MicDeviceId = (it.Tag as string) ?? "";
         };
@@ -152,6 +175,7 @@ public sealed class PanelView : Border
         _email.Text = AppSettings.RememberLogin ? AppSettings.SavedUsername : _c.Config.Username;
         _micLabel.Text = AppSettings.MicLabel;
         _systemLabel.Text = AppSettings.SystemLabel;
+        UpdateLabelHints();
         PushSettingsToController();
         Refresh();
     }
@@ -179,22 +203,48 @@ public sealed class PanelView : Border
         return AppSettings.RememberLogin ? AppSettings.SavedUsername : _c.Config.Username;
     }
 
+    /// <summary>The label that will actually be sent for the mic channel if the field is blank.</summary>
+    private string DefaultMicLabel()
+    {
+        var email = CurrentEmail();
+        return !string.IsNullOrEmpty(email) ? email : _c.Config.AgentId;
+    }
+
+    /// <summary>
+    /// Show/hide the grey placeholder over each label field. A blank field means
+    /// "use the default", so spell that default out in the field itself rather than
+    /// leaving the user to guess (or hover a tooltip).
+    /// </summary>
+    private void UpdateLabelHints()
+    {
+        _micHint.Text = DefaultMicLabel();
+        _micHint.Visibility = string.IsNullOrEmpty(_micLabel.Text) ? Visibility.Visible : Visibility.Collapsed;
+        _systemHint.Text = AppSettings.DefaultSystemLabel;
+        _systemHint.Visibility = string.IsNullOrEmpty(_systemLabel.Text) ? Visibility.Visible : Visibility.Collapsed;
+    }
+
     /// <summary>Repopulate the mic dropdown from live device enumeration (hotplug-friendly).</summary>
     private void RefreshMicPicker()
     {
-        _micPicker.Items.Clear();
-        var selected = AppSettings.MicDeviceId;
-        var def = new ComboBoxItem { Content = "System Default", Tag = "" };
-        _micPicker.Items.Add(def);
-        _micPicker.SelectedItem = def;
-        foreach (var (id, name) in AudioCapture.ListMicDevices())
+        _loadingMicPicker = true;
+        try
         {
-            var item = new ComboBoxItem { Content = name, Tag = id };
-            _micPicker.Items.Add(item);
-            if (id == selected) _micPicker.SelectedItem = item;
+            _micPicker.Items.Clear();
+            var selected = AppSettings.MicDeviceId;
+            var def = new ComboBoxItem { Content = "System Default", Tag = "" };
+            _micPicker.Items.Add(def);
+            _micPicker.SelectedItem = def;
+            foreach (var (id, name) in AudioCapture.ListMicDevices())
+            {
+                var item = new ComboBoxItem { Content = name, Tag = id };
+                _micPicker.Items.Add(item);
+                if (id == selected) _micPicker.SelectedItem = item;
+            }
+            // Saved device unplugged → selection shows System Default, matching the
+            // engine's fallback at capture start. The saved ID is deliberately kept,
+            // so re-plugging the device restores the choice.
         }
-        // Saved device unplugged → selection stays on System Default, matching
-        // the engine's fallback at capture start.
+        finally { _loadingMicPicker = false; }
     }
 
     public void FocusFirstField()
@@ -260,21 +310,22 @@ public sealed class PanelView : Border
         if (_showSettings && !isStreaming)
         {
             _body.Children.Add(Label("Speaker labels — shown in the LMA transcript"));
+            // Blank field = use the default, shown as grey placeholder text in the
+            // field (and echoed in the tooltip for screen readers / narrow panels).
+            UpdateLabelHints();
             _body.Children.Add(Label("My mic"));
-            // Placeholder semantics: blank = default (signed-in email).
-            if (string.IsNullOrEmpty(_micLabel.Text))
-                _micLabel.ToolTip = $"Default: {(string.IsNullOrEmpty(CurrentEmail()) ? "Me" : CurrentEmail())}";
-            _body.Children.Add(_micLabel);
+            _micLabel.ToolTip = $"Default: {DefaultMicLabel()}";
+            _body.Children.Add(_micLabelBox);
             _body.Children.Add(Label("System audio"));
-            if (string.IsNullOrEmpty(_systemLabel.Text))
-                _systemLabel.ToolTip = $"Default: {AppSettings.DefaultSystemLabel}";
-            _body.Children.Add(_systemLabel);
+            _systemLabel.ToolTip = $"Default: {AppSettings.DefaultSystemLabel}";
+            _body.Children.Add(_systemLabelBox);
             _body.Children.Add(Label("Microphone"));
             _body.Children.Add(_micPicker);
             _body.Children.Add(new TextBlock
             {
-                Text = "Leave a label blank for its default. System Default follows Windows' input device; " +
-                       "if a chosen mic is unplugged, recording falls back to the default.",
+                Text = "Greyed text is the default that will be used if you leave a label blank. " +
+                       "System Default follows Windows' input device; if a chosen mic is unplugged, " +
+                       "recording falls back to the default.",
                 Foreground = Secondary, FontSize = 10, TextWrapping = TextWrapping.Wrap,
                 Margin = new Thickness(0, 0, 0, 4),
             });
@@ -379,6 +430,34 @@ public sealed class PanelView : Border
     {
         t.Padding = new Thickness(4);
         t.Margin = new Thickness(0, 0, 0, 6);
+    }
+
+    /// <summary>The grey "this is what you'll get if you leave it blank" overlay text.</summary>
+    private static TextBlock HintText() => new()
+    {
+        FontSize = 12,
+        // Lighter than Secondary so it reads as a placeholder rather than as a
+        // value the user typed.
+        Foreground = new SolidColorBrush(Color.FromRgb(0x8C, 0x8C, 0x8C)),
+        // Line up with the TextBox's own 4px padding + border so the hint sits
+        // exactly where the caret/typed text will.
+        Margin = new Thickness(6, 0, 6, 0),
+        VerticalAlignment = VerticalAlignment.Center,
+        IsHitTestVisible = false,   // clicks fall through to the TextBox underneath
+        TextTrimming = TextTrimming.CharacterEllipsis,
+    };
+
+    /// <summary>
+    /// Stack a grey placeholder behind a TextBox. WPF has no built-in placeholder,
+    /// and a watermark written into Text would get saved as a real value — so the
+    /// hint is a separate, non-hit-testable TextBlock shown only while empty.
+    /// </summary>
+    private static Grid PlaceholderBox(TextBox box, TextBlock hint)
+    {
+        var g = new Grid { Margin = new Thickness(0, 0, 0, 6) };
+        g.Children.Add(box);
+        g.Children.Add(hint);
+        return g;
     }
 
     private static TextBlock Label(string s) => new()

--- a/lma-audio-capture-app-stack/source/windows/App/Program.cs
+++ b/lma-audio-capture-app-stack/source/windows/App/Program.cs
@@ -9,7 +9,9 @@ namespace LMA;
 ///   • --selftest    → run SRP known-answer tests offline and exit.
 ///   • --login-only  → SRP login, print token metadata (not the token), exit.
 ///   • --lma-*       → taskbar JumpList verb: relay it to the running tray app.
-///   • no --flags    → GUI system-tray app (double-clicked .exe).
+///   • no --flags    → GUI system-tray app (double-clicked .exe). Single instance:
+///                     a relaunch raises the existing app's UI instead of adding a
+///                     second tray icon.
 ///   • any --flag    → headless CLI streaming to stdout with the VU meter line.
 ///   • --cli forces CLI, --gui forces GUI.
 ///
@@ -55,6 +57,10 @@ public static class Program
         if (taskbarCmd != null)
         {
             if (TrayIpc.TrySend(taskbarCmd)) return 0;
+            // Nobody answered. Only start a GUI if we can claim the single-instance
+            // slot — an instance that exists but isn't listening yet (still starting
+            // up) must not get a second tray icon bolted onto it.
+            if (!TrayIpc.TryAcquireSingleInstance()) return 0;
             return TrayApp.Run(Config.Parse(args), taskbarCmd);
         }
 
@@ -66,6 +72,18 @@ public static class Program
 
         if (wantGui)
         {
+            // Single instance. Launching the app again — Start Menu, a pinned taskbar
+            // shortcut, double-clicking the exe — must not add a second tray icon:
+            // they'd be indistinguishable, only one would own the recording, and the
+            // click would appear to do nothing. Instead, treat a relaunch as "show me
+            // the app": forward it as the Open-Control-Panel verb so the instance
+            // that's already there raises its UI, and exit.
+            if (!TrayIpc.TryAcquireSingleInstance())
+            {
+                TrayIpc.TrySend(TrayIpc.CmdPanel);
+                return 0;
+            }
+
             // Tray app: no console. (If started from a terminal, don't spam it.)
             return TrayApp.Run(Config.Parse(args));
         }

--- a/lma-audio-capture-app-stack/source/windows/App/TaskbarStatus.cs
+++ b/lma-audio-capture-app-stack/source/windows/App/TaskbarStatus.cs
@@ -126,6 +126,16 @@ internal static class TaskbarImages
 /// </summary>
 internal static class TrayIpc
 {
+    // Lets the *running* instance pull its window to the front in response to a verb
+    // we forward. Windows only honors SetForegroundWindow from the process that
+    // currently owns the foreground — which is us, the freshly-launched relay, not
+    // the tray app. Calling this first hands that right over. ASFW_ANY (-1) means
+    // "any process may take it", which is the documented way to do this when you
+    // don't know the target PID.
+    [System.Runtime.InteropServices.DllImport("user32.dll")]
+    private static extern bool AllowSetForegroundWindow(int dwProcessId);
+    private const int ASFW_ANY = -1;
+
     // Verbs used by both the JumpList tasks (as command-line arguments) and the
     // pipe protocol, so there's exactly one spelling of each.
     public const string CmdStart = "--lma-start";
@@ -139,16 +149,57 @@ internal static class TrayIpc
     public static string? FindCommand(string[] args) =>
         args.FirstOrDefault(a => AllCommands.Contains(a, StringComparer.OrdinalIgnoreCase));
 
-    private static string PipeName
+    private static string PipeName => $"LMAAudioCapture.control.{UserSuffix}";
+
+    /// <summary>
+    /// Pipe and mutex names are machine-global, so scope them by user; strip anything
+    /// that isn't safe in a name (domain\user, spaces, ...).
+    /// </summary>
+    private static string UserSuffix
     {
         get
         {
-            // Pipe names are machine-global, so scope by user; strip anything that
-            // isn't safe in a pipe name (domain\user, spaces, ...).
             var user = new string((Environment.UserName ?? "user")
                 .Where(char.IsLetterOrDigit).ToArray());
-            if (user.Length == 0) user = "user";
-            return $"LMAAudioCapture.control.{user}";
+            return user.Length == 0 ? "user" : user;
+        }
+    }
+
+    // Held for the process lifetime once acquired — never disposed, so the OS
+    // releases it when we exit (including a crash, unlike a lock file).
+    private static Mutex? _singleInstanceMutex;
+
+    /// <summary>
+    /// Claim the right to be *the* tray instance for this user. False means one is
+    /// already running, in which case the caller should forward what it wanted to do
+    /// (see <see cref="TrySend"/>) and exit rather than add a second tray icon.
+    ///
+    /// The mutex — not a "can I connect to the pipe?" probe — is what decides, so two
+    /// launches racing each other (double-clicked twice, or Start Menu while the app
+    /// is still starting up) can't both conclude they're first.
+    /// </summary>
+    public static bool TryAcquireSingleInstance()
+    {
+        try
+        {
+            _singleInstanceMutex = new Mutex(initiallyOwned: false, $"Local\\LMAAudioCapture.instance.{UserSuffix}");
+            // Local\ = per-session, so a second user (or an RDP session) still gets
+            // their own tray icon, matching the per-user pipe.
+            if (_singleInstanceMutex.WaitOne(TimeSpan.Zero)) return true;
+            _singleInstanceMutex.Dispose();
+            _singleInstanceMutex = null;
+            return false;
+        }
+        catch (AbandonedMutexException)
+        {
+            // Previous owner died without releasing (killed / crashed). We now hold it.
+            return true;
+        }
+        catch
+        {
+            // Can't create the mutex at all — don't let single-instancing be the
+            // reason the app won't launch.
+            return true;
         }
     }
 
@@ -158,9 +209,18 @@ internal static class TrayIpc
         try
         {
             using var client = new NamedPipeClientStream(".", PipeName, PipeDirection.Out);
-            client.Connect(500);
+            // Generous timeout: the tray app can be busy starting up (it only begins
+            // listening once its UI is built), and a premature failure here means a
+            // whole second tray icon instead of a forwarded verb.
+            client.Connect(3000);
+            // Cede our foreground right so the running instance can actually raise
+            // its window — otherwise "Open" just flashes the taskbar button.
+            try { AllowSetForegroundWindow(ASFW_ANY); } catch { }
             using var w = new StreamWriter(client) { AutoFlush = true };
             w.WriteLine(command);
+            // Wait for the reader to drain before we exit; disposing the pipe as the
+            // process dies can otherwise cut the message off mid-flight.
+            client.WaitForPipeDrain();
             return true;
         }
         catch
@@ -168,6 +228,7 @@ internal static class TrayIpc
             return false;
         }
     }
+
 
     /// <summary>
     /// Listen for forwarded verbs on a background thread. <paramref name="onCommand"/>

--- a/lma-audio-capture-app-stack/source/windows/App/TrayApp.cs
+++ b/lma-audio-capture-app-stack/source/windows/App/TrayApp.cs
@@ -469,6 +469,11 @@ public sealed class TrayApp
     /// <summary>
     /// Bring up the controls. While recording the taskbar window already exists, so
     /// restore that (keeping the taskbar button); otherwise use the tray flyout.
+    ///
+    /// Also the "show me the app" entry point for a second launch (Start Menu, a
+    /// pinned taskbar shortcut, double-clicked exe): rather than starting a duplicate
+    /// tray icon, that process forwards Open-Control-Panel here and exits, so
+    /// clicking the app again does what the user expects — the UI appears.
     /// </summary>
     private void ShowControlPanel()
     {
@@ -477,6 +482,7 @@ public sealed class TrayApp
             MovePanelTo(_taskbarWindow);
             _taskbarWindow.WindowState = WindowState.Normal;
             _taskbarWindow.Activate();
+            ForceForeground(_taskbarWindow);
             _panel.FocusFirstField();
         }
         else
@@ -484,6 +490,26 @@ public sealed class TrayApp
             ShowPopup();
         }
     }
+
+    /// <summary>
+    /// Nudge a window to the actual foreground. Window.Activate() is a no-op when
+    /// another process owns the foreground, which is exactly the case when a relaunch
+    /// forwards Open-Control-Panel to us — so ask Win32 directly. The relaying process
+    /// calls AllowSetForegroundWindow first (see TrayIpc.TrySend), which is what makes
+    /// this permitted rather than a silent taskbar flash.
+    /// </summary>
+    private static void ForceForeground(Window w)
+    {
+        try
+        {
+            var hwnd = new System.Windows.Interop.WindowInteropHelper(w).Handle;
+            if (hwnd != IntPtr.Zero) SetForegroundWindow(hwnd);
+        }
+        catch { /* cosmetic */ }
+    }
+
+    [System.Runtime.InteropServices.DllImport("user32.dll")]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
 
     private ContextMenu BuildContextMenu()
     {
@@ -540,6 +566,7 @@ public sealed class TrayApp
         _flyout.Top = top;
 
         _flyout.Activate();
+        ForceForeground(_flyout);
         _panel.FocusFirstField();
     }
 

--- a/lma-audio-capture-app-stack/source/windows/README.md
+++ b/lma-audio-capture-app-stack/source/windows/README.md
@@ -182,6 +182,24 @@ the macOS menu-bar `LSUIElement` behavior).
   can't be confused with *Stop*).
 - While recording, the tray icon turns **red**.
 
+**Single instance.** Launching the app again — Start Menu, a pinned taskbar
+shortcut, double-clicking the exe — does **not** add a second tray icon; it
+opens the running app's UI. The instance is claimed with a per-user named mutex
+(`Local\LMAAudioCapture.instance.<user>`), and the losing process relays
+`--lma-panel` over the pipe and exits, so a relaunch behaves like clicking the
+tray icon. Two things this must get right, both of which have bitten:
+
+- The check has to be the **mutex**, not "can I connect to the pipe?" — the pipe
+  server only starts listening once the UI is built, so a relaunch during startup
+  would otherwise conclude nobody was home and open a duplicate.
+- Raising the window needs `AllowSetForegroundWindow` in the *relaying* process
+  plus `SetForegroundWindow` in the owner (`ForceForeground`). `Window.Activate()`
+  alone is a no-op when another process owns the foreground, which is exactly the
+  case here — the symptom is a taskbar flash and no visible panel.
+
+The mutex is released by the OS on exit (including a kill or crash), so a
+relaunch after a crash correctly starts fresh.
+
 ### Recording-time taskbar button
 
 While recording — and **only** while recording — the app also takes a **taskbar
@@ -222,6 +240,14 @@ Implementation notes for anyone touching this:
 Panel options:
 - **Remember my email** — prefills your login next launch (email only; the
   password is never stored — it stays in memory for the session).
+- **Settings (⚙ gear)** — transcript speaker labels for the two channels plus a
+  microphone picker, persisted under `HKCU\...\LMAAudioCapture`. A blank label
+  field means "use the default", and that default is drawn **in grey inside the
+  field** (`PlaceholderBox` + `UpdateLabelHints`) so it's visible without
+  hovering: the mic label defaults to the signed-in email, the system label to
+  "Other participants". WPF has no built-in placeholder, and writing a watermark
+  into `Text` would get persisted as a real value, so the hint is a separate
+  non-hit-testable `TextBlock` layered over the `TextBox`.
 - **Start automatically at login** — toggles an `HKCU\...\Run` entry pointing at
   this exe (`--gui`); the checkbox reflects the real registry state, so it stays
   correct even if changed elsewhere.


### PR DESCRIPTION
## What

Two fixes to the native **Windows** audio capture client, both reported from a real install:

### 1. Settings didn't show the default channel labels

The gear panel's "My mic" / "System audio" label fields are optional — blank means "use the default" — but on Windows the defaults were invisible (only a `ToolTip`), so there was no way to know what a blank field would produce. macOS already showed them as SwiftUI `TextField` prompts.

Each field now renders its effective default as **grey placeholder text inside the field**. The mic hint tracks the email field as you type, since that is what the mic default resolves to.

WPF has no built-in placeholder, and a watermark written into `Text` would be persisted as a real value by the existing `TextChanged` handler — so the hint is a separate non-hit-testable `TextBlock` layered over the `TextBox` (`PlaceholderBox` / `UpdateLabelHints`).

### 2. Relaunching added another tray icon instead of opening the UI

Opening the app from the taskbar/Start Menu while it was already running built a **whole new tray app**: two indistinguishable icons, only one of which owned the recording, and no UI appeared.

The app is now single-instance. The instance is claimed with a per-user named mutex (`Local\LMAAudioCapture.instance.<user>`); the losing process relays `--lma-panel` over the existing named pipe and exits, so a relaunch does what clicking the app implies — the controls panel comes up.

Two details that mattered:

- The gate is the **mutex**, not a "can I connect to the pipe?" probe. The pipe server only starts listening once the UI is built, so a relaunch *during startup* would otherwise conclude nobody was home and open a duplicate anyway.
- Raising the window needs `AllowSetForegroundWindow` in the *relaying* process **plus** `SetForegroundWindow` in the owner. `Window.Activate()` alone is a no-op when another process owns the foreground — exactly this case — and the symptom is a taskbar flash with no panel.

The OS releases the mutex on exit including a kill or crash, so a relaunch after a crash correctly starts fresh. The mutex is `Local\`-scoped, so "one at a time" is per login session (matching the per-user pipe) — a second Windows user or RDP session still gets their own.

### Bug found in passing

`RefreshMicPicker()` set `_micPicker.SelectedItem` while repopulating, which fired `SelectionChanged` and wrote `""` to the saved `MicDeviceId` before the matching item was found. Usually benign — the real ID was written back a moment later — but if the chosen mic was **unplugged** that second write never happened and the saved choice was *permanently erased* instead of just falling back for that session. Guarded with a `_loadingMicPicker` re-entrancy flag; the saved ID now survives an unplug, so re-plugging restores the selection.

## Scope

Client-only. **No server or other stack is touched** — no CloudFormation, Lambda, or transcriber changes. The wire protocol is unchanged. The only non-Windows files are documentation (`docs/audio-capture-app.md` and the in-app help panel `AudioCaptureApp.jsx`).

## Verification

Against the published self-contained build:

- `dotnet build -c Release` — 0 warnings, 0 errors.
- `./build-windows.ps1 -SelfContained` — all 11 SRP known-answer vectors `[PASS]`.
- **Single instance** (UI Automation harness): launch 1 gives one process and no visible window; launches 2, 3 and 4 (two fired back-to-back to race the mutex) each exit 0 with **exactly one** process alive and the panel raised.
- **Mid-recording relaunch:** started with `--lma-start`, then relaunched — same process, same `LMA Audio Capture — Recording` taskbar button, capture still live with Pause/Stop. Stop removes the taskbar button.
- **Crash recovery:** killed the owner, relaunched — new pid, one process; the mutex was correctly released.
- **Grey defaults:** UIA dump of the gear panel reports `strahanr@amazon.com` (mic) and `Other participants` (system) as hint Text elements.
- No `%TEMP%\lma-tray-crash.log` produced in any run.
- `npx prettier --check` clean; `eslint` on `AudioCaptureApp.jsx` matches the `develop` baseline exactly (12 errors, same set — 3 genuine pre-existing, 9 unresolved-import artifacts of the missing `node_modules`).

Still pending, as for the rest of this client: a full live meeting through a native Zoom/Teams client against a deployed stack.
