### PR TITLE
feat(audio-capture): recording-consent disclaimer before first recording (macOS + Windows)

### DIFF
--- a/docs/audio-capture-app.md
+++ b/docs/audio-capture-app.md
@@ -45,6 +45,20 @@ https://github.com/user-attachments/assets/4663740b-a0b3-45a1-b1f3-dc5461f12d18
 > **no special permission** — there is no equivalent of the macOS Screen
 > Recording prompt. The only OS gate is the microphone privacy setting.
 
+## Recording consent
+
+You are responsible for complying with the legal, corporate, and ethical
+restrictions that apply to recording meetings and calls — in many jurisdictions
+**all participants must consent** to being recorded. Do not use this app to
+stream, record, or transcribe calls if otherwise prohibited.
+
+The app shows this disclaimer **before your first recording** and requires you
+to agree (the same consent gate as the browser extension and the web UI's
+Stream Audio tab). The text is configurable per deployment via the
+`RecordingDisclaimer` CloudFormation parameter, so organizations can substitute
+their own legal wording; the app picks it up from the `lma-config.json` baked
+into the download.
+
 ## Download and install (macOS)
 
 1. In the LMA web app, open **Meeting Assistant ▸ Sources ▸ Audio Capture App

--- a/lma-ai-stack/source/ui/src/components/audio-capture-app-layout/AudioCaptureApp.jsx
+++ b/lma-ai-stack/source/ui/src/components/audio-capture-app-layout/AudioCaptureApp.jsx
@@ -701,6 +701,11 @@ const AudioCaptureApp = () => {
               )}
             </li>
           </ul>
+          <Alert type="warning" header="Recording consent">
+            You are responsible for complying with the legal, corporate, and ethical restrictions that apply to
+            recording meetings and calls &mdash; in many places <strong>all participants must consent</strong> to being
+            recorded. The app asks you to acknowledge this before your first recording.
+          </Alert>
         </SpaceBetween>
       </Container>
 

--- a/lma-audio-capture-app-stack/source/macos/Sources/LMAAudioClient/Config.swift
+++ b/lma-audio-capture-app-stack/source/macos/Sources/LMAAudioClient/Config.swift
@@ -42,6 +42,16 @@ struct Config {
     /// DIFFERENT CloudFront distribution than the WebSocket endpoint, so it must
     /// be configured explicitly rather than derived from `endpoint`.
     var webEndpoint: String
+    /// Recording-consent disclaimer shown before the first recording. Baked into
+    /// lma-config.json from the deployment's RecordingDisclaimer parameter (same
+    /// text the browser extension shows); falls back to the standard wording.
+    var recordingDisclaimer: String
+
+    /// Fallback consent text when the deployment config predates the setting.
+    static let defaultDisclaimer =
+        "Important: You are responsible for complying with legal, corporate, and ethical "
+        + "restrictions that apply to recording meetings and calls. Do not use this solution "
+        + "to stream, record, or transcribe calls if otherwise prohibited."
 
     static func parse() -> Config {
         let env = ProcessInfo.processInfo.environment
@@ -83,7 +93,9 @@ struct Config {
             userPoolId: value("user-pool-id", "LMA_USER_POOL_ID", "userPoolId"),
             clientId: value("client-id", "LMA_CLIENT_ID", "clientId"),
             region: value("region", "LMA_REGION", "region"),
-            webEndpoint: value("web-endpoint", "LMA_WEB_ENDPOINT", "webEndpoint")
+            webEndpoint: value("web-endpoint", "LMA_WEB_ENDPOINT", "webEndpoint"),
+            recordingDisclaimer: value("disclaimer", "LMA_RECORDING_DISCLAIMER", "recordingDisclaimer",
+                                       Config.defaultDisclaimer)
         )
     }
 

--- a/lma-audio-capture-app-stack/source/macos/Sources/LMAAudioClient/MenuBarApp.swift
+++ b/lma-audio-capture-app-stack/source/macos/Sources/LMAAudioClient/MenuBarApp.swift
@@ -38,6 +38,11 @@ final class MenuBarAppState: ObservableObject {
     @Published var micDeviceUID = ""            // "" = System Default
     @Published var micDevices: [MicDevices.Device] = []
 
+    // Recording-consent disclaimer: shown once, before the FIRST recording ever
+    // starts on this machine (same pattern as the browser extension's popup).
+    // Agreement is persisted; Cancel just doesn't start.
+    @Published var showDisclaimer = false
+
     let controller: CaptureController
     // UserDefaults keys for the optional "remember login id" feature. Only the
     // username (email) is stored — never the password, which stays in memory.
@@ -46,6 +51,7 @@ final class MenuBarAppState: ObservableObject {
     private static let kMicLabel = "lma.micLabel"
     private static let kSystemLabel = "lma.systemLabel"
     private static let kMicDeviceUID = "lma.micDeviceUID"
+    private static let kDisclaimerAgreed = "lma.disclaimerAgreed"
 
     /// Default label for the system channel when the user hasn't set one.
     static let defaultSystemLabel = "Other participants"
@@ -149,6 +155,24 @@ final class MenuBarAppState: ObservableObject {
         }
     }
     func start() {
+        // One-time recording-consent gate (mirrors the browser extension): the
+        // first Start on this machine shows the disclaimer; Agree persists and
+        // proceeds, Cancel does nothing.
+        guard UserDefaults.standard.bool(forKey: Self.kDisclaimerAgreed) else {
+            showDisclaimer = true
+            return
+        }
+        reallyStart()
+    }
+
+    /// Agree on the consent dialog: persist and start the recording that was gated.
+    func agreeDisclaimerAndStart() {
+        UserDefaults.standard.set(true, forKey: Self.kDisclaimerAgreed)
+        showDisclaimer = false
+        reallyStart()
+    }
+
+    private func reallyStart() {
         // Push current settings (labels may depend on the signed-in email).
         pushSettingsToController()
         let name = meetingName.isEmpty ? "" : "\(meetingName) - \(Self.timestamp())"
@@ -217,7 +241,26 @@ struct MenuBarContentView: View {
                 }
             } else {
                 // Streaming controls
-                if !s.isStreaming {
+                if s.showDisclaimer {
+                    // One-time recording-consent gate (same text and Agree/Cancel
+                    // shape as the browser extension's popup). Shown in place of
+                    // the Start controls so it can't be missed or clicked past.
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label("Important", systemImage: "exclamationmark.triangle.fill")
+                            .font(.headline).foregroundColor(.orange)
+                        Text(s.controller.config.recordingDisclaimer)
+                            .font(.caption)
+                            .fixedSize(horizontal: false, vertical: true)
+                        HStack {
+                            Spacer()
+                            Button("Cancel") { s.showDisclaimer = false }
+                            Button("Agree") { s.agreeDisclaimerAndStart() }
+                                .keyboardShortcut(.defaultAction)
+                        }
+                    }
+                    .padding(10)
+                    .background(RoundedRectangle(cornerRadius: 8).fill(Color.orange.opacity(0.08)))
+                } else if !s.isStreaming {
                     TextField("Meeting name (optional)", text: $s.meetingName).textFieldStyle(.roundedBorder)
                     Button(action: s.start) {
                         Label("Start Recording", systemImage: "record.circle").frame(maxWidth: .infinity)
@@ -460,7 +503,12 @@ final class MenuBarController: NSObject, NSApplicationDelegate {
 
     @objc private func dockTogglePause() { state.togglePause() }
     @objc private func dockStop() { state.stop() }
-    @objc private func dockStart() { state.start() }
+    @objc private func dockStart() {
+        state.start()
+        // First-ever recording: start() gates on the consent disclaimer instead
+        // of starting. Surface the panel so the dialog is actually visible.
+        if state.showDisclaimer { showPanelWindow() }
+    }
     @objc private func dockOpenPanel() { showPanelWindow() }
 
     /// The same SwiftUI content as the popover, hosted in a small titled window

--- a/lma-audio-capture-app-stack/source/windows/App/AppSettings.cs
+++ b/lma-audio-capture-app-stack/source/windows/App/AppSettings.cs
@@ -82,6 +82,20 @@ public static class AppSettings
         set { using var k = Registry.CurrentUser.CreateSubKey(SettingsKeyPath); k.SetValue(MicDeviceValue, value, RegistryValueKind.String); }
     }
 
+    // MARK: - Recording-consent disclaimer (one-time acknowledgment)
+
+    private const string DisclaimerAgreedValue = "DisclaimerAgreed";
+
+    /// <summary>
+    /// Whether the user has acknowledged the recording-consent disclaimer (shown
+    /// once before the first recording, same pattern as the browser extension).
+    /// </summary>
+    public static bool DisclaimerAgreed
+    {
+        get { using var k = Registry.CurrentUser.OpenSubKey(SettingsKeyPath); return (k?.GetValue(DisclaimerAgreedValue) as int?) == 1; }
+        set { using var k = Registry.CurrentUser.CreateSubKey(SettingsKeyPath); k.SetValue(DisclaimerAgreedValue, value ? 1 : 0, RegistryValueKind.DWord); }
+    }
+
     // MARK: - Start at login (HKCU ...\Run)
 
     /// <summary>

--- a/lma-audio-capture-app-stack/source/windows/App/PanelView.cs
+++ b/lma-audio-capture-app-stack/source/windows/App/PanelView.cs
@@ -347,7 +347,14 @@ public sealed class PanelView : Border
         else
         {
             bool streaming = _c.CurrentState.Kind == CaptureController.StateKind.Streaming;
-            if (!streaming)
+            if (_showDisclaimer && !streaming)
+            {
+                // One-time recording-consent gate (same text and Agree/Cancel shape
+                // as the browser extension's popup). Rendered in place of the Start
+                // controls so it can't be missed or clicked past.
+                _body.Children.Add(BuildDisclaimerBlock());
+            }
+            else if (!streaming)
             {
                 _body.Children.Add(Label("Meeting name (optional)"));
                 _body.Children.Add(_meetingName);
@@ -409,12 +416,86 @@ public sealed class PanelView : Border
 
     private void DoStart()
     {
+        // One-time recording-consent gate (mirrors the browser extension): the
+        // first Start on this machine shows the disclaimer; Agree persists and
+        // proceeds, Cancel does nothing.
+        if (!AppSettings.DisclaimerAgreed)
+        {
+            _showDisclaimer = true;
+            Refresh();
+            return;
+        }
+        ReallyStart();
+    }
+
+    private void ReallyStart()
+    {
         // Push current settings (the mic label may depend on the signed-in email).
         PushSettingsToController();
         var name = string.IsNullOrEmpty(_meetingName.Text)
             ? null
             : $"{_meetingName.Text} - {DateTime.Now:yyyy-MM-dd HH:mm}";
         _c.Start(name);
+    }
+
+    /// <summary>
+    /// Whether Start would currently be gated on the consent disclaimer — used by
+    /// TrayApp so a JumpList "Start Recording" surfaces the panel with the dialog
+    /// instead of silently doing nothing.
+    /// </summary>
+    public bool NeedsDisclaimer => !AppSettings.DisclaimerAgreed;
+
+    /// <summary>Show the consent gate (for Start attempts that arrive from outside the panel).</summary>
+    public void ShowDisclaimerGate()
+    {
+        _showDisclaimer = true;
+        Refresh();
+    }
+
+    // Consent-gate UI state + block. Built fresh each Refresh (cheap, and avoids
+    // the shared-parent pitfalls of persistent controls).
+    private bool _showDisclaimer;
+
+    private Border BuildDisclaimerBlock()
+    {
+        var panel = new StackPanel();
+        panel.Children.Add(new TextBlock
+        {
+            Text = "⚠ Important",
+            FontWeight = FontWeights.Bold,
+            Foreground = new SolidColorBrush(Color.FromRgb(0xB0, 0x6A, 0x00)),
+            Margin = new Thickness(0, 0, 0, 4),
+        });
+        panel.Children.Add(new TextBlock
+        {
+            Text = string.IsNullOrEmpty(_c.Config.RecordingDisclaimer)
+                ? Config.DefaultDisclaimer
+                : _c.Config.RecordingDisclaimer,
+            FontSize = 11,
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Thickness(0, 0, 0, 8),
+        });
+        var cancel = new Button { Content = "Cancel" };
+        cancel.Click += (_, _) => { _showDisclaimer = false; Refresh(); };
+        var agree = new Button { Content = "Agree", FontWeight = FontWeights.Bold };
+        agree.Click += (_, _) =>
+        {
+            AppSettings.DisclaimerAgreed = true;
+            _showDisclaimer = false;
+            Refresh();
+            ReallyStart();
+        };
+        panel.Children.Add(Row(cancel, agree));
+        return new Border
+        {
+            Background = new SolidColorBrush(Color.FromArgb(0x14, 0xE0, 0x91, 0x00)),
+            BorderBrush = new SolidColorBrush(Color.FromRgb(0xE0, 0x91, 0x00)),
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(6),
+            Padding = new Thickness(10),
+            Margin = new Thickness(0, 2, 0, 8),
+            Child = panel,
+        };
     }
 
     private void OpenLma()

--- a/lma-audio-capture-app-stack/source/windows/App/TrayApp.cs
+++ b/lma-audio-capture-app-stack/source/windows/App/TrayApp.cs
@@ -435,6 +435,14 @@ public sealed class TrayApp
                 if (_controller.IsAuthenticated &&
                     _controller.CurrentState.Kind != CaptureController.StateKind.Streaming)
                 {
+                    // First-ever recording: gate on the consent disclaimer — show
+                    // the panel with the dialog instead of silently starting.
+                    if (_panel.NeedsDisclaimer)
+                    {
+                        _panel.ShowDisclaimerGate();
+                        ShowControlPanel();
+                        return;
+                    }
                     // Same settings path as the panel's Start button, so
                     // JumpList-started recordings get the right speaker labels.
                     _panel.PushSettingsToController();

--- a/lma-audio-capture-app-stack/source/windows/Engine/Config.cs
+++ b/lma-audio-capture-app-stack/source/windows/Engine/Config.cs
@@ -42,6 +42,19 @@ public sealed class Config
     /// </summary>
     public string WebEndpoint = "";
 
+    /// <summary>
+    /// Recording-consent disclaimer shown before the first recording. Baked into
+    /// lma-config.json from the deployment's RecordingDisclaimer parameter (same
+    /// text the browser extension shows); falls back to the standard wording.
+    /// </summary>
+    public string RecordingDisclaimer = "";
+
+    /// <summary>Fallback consent text when the deployment config predates the setting.</summary>
+    public const string DefaultDisclaimer =
+        "Important: You are responsible for complying with legal, corporate, and ethical " +
+        "restrictions that apply to recording meetings and calls. Do not use this solution " +
+        "to stream, record, or transcribe calls if otherwise prohibited.";
+
     public static Config Parse(string[] argv)
     {
         var env = Environment.GetEnvironmentVariables();
@@ -92,6 +105,8 @@ public sealed class Config
             ClientId = Value("client-id", "LMA_CLIENT_ID", "clientId"),
             Region = Value("region", "LMA_REGION", "region"),
             WebEndpoint = Value("web-endpoint", "LMA_WEB_ENDPOINT", "webEndpoint"),
+            RecordingDisclaimer = Value("disclaimer", "LMA_RECORDING_DISCLAIMER", "recordingDisclaimer",
+                                        DefaultDisclaimer),
         };
     }
 

--- a/lma-audio-capture-app-stack/source/windows/README.md
+++ b/lma-audio-capture-app-stack/source/windows/README.md
@@ -253,6 +253,13 @@ Panel options:
   correct even if changed elsewhere.
 - Meeting name gets a `" - yyyy-MM-dd HH:mm"` timestamp suffix when you Start,
   matching macOS.
+- **Recording-consent gate** — the first Start on a machine shows the
+  deployment's `recordingDisclaimer` (from `lma-config.json`; same text as the
+  browser extension's popup) with Agree/Cancel, rendered in place of the Start
+  controls. Agree persists (`HKCU\...\DisclaimerAgreed`) so it's one-time;
+  Cancel doesn't start. The JumpList "Start Recording" path routes through the
+  same gate (`NeedsDisclaimer` / `ShowDisclaimerGate`), surfacing the panel so
+  the dialog is visible.
 
 ### Headless CLI mode (dev + debugging)
 

--- a/lma-audio-capture-app-stack/template.yaml
+++ b/lma-audio-capture-app-stack/template.yaml
@@ -56,6 +56,14 @@ Parameters:
     Type: String
     Description: S3 location (bucket/key) of the audio-capture app source zip
 
+  RecordingDisclaimer:
+    Type: String
+    Description: Disclaimer shown by the app before the first recording (same default as the browser extension)
+    Default: >-
+      Important: You are responsible for complying with legal, corporate, and ethical
+      restrictions that apply to recording meetings and calls. Do not use this solution
+      to stream, record, or transcribe calls if otherwise prohibited.
+
   CloudWatchLogsExpirationInDays:
     Type: Number
     Default: 14
@@ -161,6 +169,8 @@ Resources:
           Value: !Ref WebAppBucket
         - Name: CLOUDFRONT_DISTRIBUTION_ID
           Value: !Ref WebAppCloudFrontDistribution
+        - Name: RECORDING_DISCLAIMER
+          Value: !Ref RecordingDisclaimer
       Source:
         Location: !Sub "arn:aws:s3:::${SourceCodeLocation}"
         Type: S3
@@ -181,8 +191,10 @@ Resources:
                   MAC_DIR=.
                   if [ -d ./source/macos ]; then MAC_DIR=./source/macos; fi
                   if [ -d ./macos ]; then MAC_DIR=./macos; fi
-                  printf '{\n  "wssEndpoint": "%s",\n  "webEndpoint": "%s",\n  "userPoolId": "%s",\n  "clientId": "%s",\n  "region": "%s"\n}\n' \
-                    "$WEBSOCKET_ENDPOINT" "$WEB_ENDPOINT" "$COGNITO_USER_POOL_ID" "$COGNITO_CLIENT_ID" "$COGNITO_REGION" > "$MAC_DIR/lma-config.json"
+                  # JSON-escape the disclaimer (free text — may contain quotes/newlines).
+                  DISCLAIMER_JSON=$(python3 -c 'import json,os; print(json.dumps(os.environ.get("RECORDING_DISCLAIMER","")))')
+                  printf '{\n  "wssEndpoint": "%s",\n  "webEndpoint": "%s",\n  "userPoolId": "%s",\n  "clientId": "%s",\n  "region": "%s",\n  "recordingDisclaimer": %s\n}\n' \
+                    "$WEBSOCKET_ENDPOINT" "$WEB_ENDPOINT" "$COGNITO_USER_POOL_ID" "$COGNITO_CLIENT_ID" "$COGNITO_REGION" "$DISCLAIMER_JSON" > "$MAC_DIR/lma-config.json"
                   cat "$MAC_DIR/lma-config.json"
                   # Zip the preconfigured macOS source tree (source + install
                   # scripts + baked config), excluding any build artifacts.
@@ -202,8 +214,9 @@ Resources:
                   if [ -d ./source/windows ]; then WIN_DIR=./source/windows; fi
                   if [ -d ./windows ]; then WIN_DIR=./windows; fi
                   if [ -n "$WIN_DIR" ]; then
-                    printf '{\n  "wssEndpoint": "%s",\n  "webEndpoint": "%s",\n  "userPoolId": "%s",\n  "clientId": "%s",\n  "region": "%s"\n}\n' \
-                      "$WEBSOCKET_ENDPOINT" "$WEB_ENDPOINT" "$COGNITO_USER_POOL_ID" "$COGNITO_CLIENT_ID" "$COGNITO_REGION" > "$WIN_DIR/lma-config.json"
+                    DISCLAIMER_JSON=$(python3 -c 'import json,os; print(json.dumps(os.environ.get("RECORDING_DISCLAIMER","")))')
+                    printf '{\n  "wssEndpoint": "%s",\n  "webEndpoint": "%s",\n  "userPoolId": "%s",\n  "clientId": "%s",\n  "region": "%s",\n  "recordingDisclaimer": %s\n}\n' \
+                      "$WEBSOCKET_ENDPOINT" "$WEB_ENDPOINT" "$COGNITO_USER_POOL_ID" "$COGNITO_CLIENT_ID" "$COGNITO_REGION" "$DISCLAIMER_JSON" > "$WIN_DIR/lma-config.json"
                     cat "$WIN_DIR/lma-config.json"
                     winzip=lma-audio-capture-app-windows-v<VERSION_TOKEN>.zip
                     (cd "$WIN_DIR" && rm -rf bin obj && zip -r "$OLDPWD/../${winzip}" . -x '*/bin/*' -x '*/obj/*')


### PR DESCRIPTION
## Why

The native audio-capture apps were the **only LMA capture surface with no recording-consent warning**:

| Surface | Consent warning |
|---|---|
| Browser extension | ✅ Modal with Agree/Cancel, deployment-configurable text |
| Web UI Stream Audio / embed | ✅ confirm() dialog, same text |
| Virtual Participant | ✅ Implicit — visible in participant list + platform consent banners |
| **Native macOS/Windows apps** | ❌ **Nothing** — and they're the most discreet capture method |

Many jurisdictions require all-party consent to record; this closes that gap consistently with the rest of the solution.

## What

**Both apps** now show the disclaimer **before the first recording on a machine** (mirroring the extension's pattern):
- An "Important" panel with the disclaimer text and **Agree / Cancel**, rendered in place of the Start controls so it can't be clicked past.
- **Agree persists** (UserDefaults on macOS, HKCU on Windows) — one-time, not per-meeting. **Cancel** simply doesn't start.
- The **macOS Dock menu** and **Windows JumpList** "Start Recording" paths route through the same gate and surface the panel so the dialog is visible (instead of silently no-oping).

**Deployment-configurable text**, matching the other surfaces:
- New `RecordingDisclaimer` parameter on `lma-audio-capture-app-stack/template.yaml` (default = the extension's exact wording).
- CodeBuild bakes it into each platform's `lma-config.json` as `recordingDisclaimer` (JSON-escaped via python3, since it's free text that may contain quotes).
- Both app Configs read it with a hardcoded fallback, so **zips built by older deployments still show the standard disclaimer**.

## Docs
- `docs/audio-capture-app.md`: new **Recording consent** section (incl. the CloudFormation parameter).
- UI download page: consent Alert in "How it works".
- Windows README: implementation note.

## Testing
- macOS: `swift build` clean; app installed and launched; config parse smoke-tested with a custom disclaimer value.
- `cfn-lint`: clean (pre-existing W2001 only).
- UI: `vite build` passes; eslint matches develop baseline (3 pre-existing errors, none introduced).
- Windows C#: needs a build + manual check on a Windows box (first Start shows the gate; Agree persists; JumpList start surfaces the panel).