### PR TITLE
feat(audio-capture): standing consent reminder next to Start

### DIFF
--- a/docs/audio-capture-app.md
+++ b/docs/audio-capture-app.md
@@ -54,10 +54,12 @@ stream, record, or transcribe calls if otherwise prohibited.
 
 The app shows this disclaimer **before your first recording** and requires you
 to agree (the same consent gate as the browser extension and the web UI's
-Stream Audio tab). The text is configurable per deployment via the
-`RecordingDisclaimer` CloudFormation parameter, so organizations can substitute
-their own legal wording; the app picks it up from the `lma-config.json` baked
-into the download.
+Stream Audio tab). After that, a one-line reminder — *"Ensure all participants
+have consented to recording"* — stays visible next to the **Start** button
+(hover it to re-read the full disclaimer). The text is configurable per
+deployment via the `RecordingDisclaimer` CloudFormation parameter, so
+organizations can substitute their own legal wording; the app picks it up from
+the `lma-config.json` baked into the download.
 
 ## Download and install (macOS)
 

--- a/lma-ai-stack/source/ui/src/components/audio-capture-app-layout/AudioCaptureApp.jsx
+++ b/lma-ai-stack/source/ui/src/components/audio-capture-app-layout/AudioCaptureApp.jsx
@@ -704,7 +704,8 @@ const AudioCaptureApp = () => {
           <Alert type="warning" header="Recording consent">
             You are responsible for complying with the legal, corporate, and ethical restrictions that apply to
             recording meetings and calls &mdash; in many places <strong>all participants must consent</strong> to being
-            recorded. The app asks you to acknowledge this before your first recording.
+            recorded. The app asks you to acknowledge this before your first recording, and shows a standing reminder
+            next to the Start button.
           </Alert>
         </SpaceBetween>
       </Container>

--- a/lma-audio-capture-app-stack/source/macos/Sources/LMAAudioClient/MenuBarApp.swift
+++ b/lma-audio-capture-app-stack/source/macos/Sources/LMAAudioClient/MenuBarApp.swift
@@ -267,6 +267,14 @@ struct MenuBarContentView: View {
                     }
                     .disabled(s.isBusy)
                     .keyboardShortcut(.defaultAction)
+                    // Persistent consent reminder: the full disclaimer is a
+                    // one-time gate, but the obligation is per-meeting — keep a
+                    // one-liner next to Start so it stays visible. Hover shows
+                    // the full deployment disclaimer text.
+                    Label("Ensure all participants have consented to recording.",
+                          systemImage: "checkmark.shield")
+                        .font(.caption2).foregroundColor(.secondary)
+                        .help(s.controller.config.recordingDisclaimer)
                 } else {
                     // Live meters
                     LevelBar(label: "System", level: s.meetingLevel, muted: s.meetingMuted)

--- a/lma-audio-capture-app-stack/source/windows/App/PanelView.cs
+++ b/lma-audio-capture-app-stack/source/windows/App/PanelView.cs
@@ -358,8 +358,22 @@ public sealed class PanelView : Border
             {
                 _body.Children.Add(Label("Meeting name (optional)"));
                 _body.Children.Add(_meetingName);
-                _start.Margin = new Thickness(0, 4, 0, 8);
+                _start.Margin = new Thickness(0, 4, 0, 4);
                 _body.Children.Add(_start);
+                // Persistent consent reminder: the full disclaimer is a one-time
+                // gate, but the obligation is per-meeting — keep a one-liner next
+                // to Start. Hover shows the full deployment disclaimer text.
+                _body.Children.Add(new TextBlock
+                {
+                    Text = "✓ Ensure all participants have consented to recording.",
+                    Foreground = Secondary,
+                    FontSize = 10,
+                    TextWrapping = TextWrapping.Wrap,
+                    Margin = new Thickness(0, 0, 0, 8),
+                    ToolTip = string.IsNullOrEmpty(_c.Config.RecordingDisclaimer)
+                        ? Config.DefaultDisclaimer
+                        : _c.Config.RecordingDisclaimer,
+                });
             }
             else
             {


### PR DESCRIPTION
## What

Follow-up to #474. The consent disclaimer is a **one-time** gate, but the obligation to have participant consent is **per-meeting** — this adds the planned standing reminder so the responsibility stays visible after the initial acknowledgment:

- One-line caption under the **Start Recording** button on both platforms: *"✓ Ensure all participants have consented to recording."*
- Hovering it shows the **full deployment disclaimer text** (macOS `.help` tooltip / WPF `ToolTip`), so the complete wording is always one hover away.
- Subtle styling (caption size, secondary color) — a reminder, not a nag.

Docs (`docs/audio-capture-app.md`) and the UI download page updated to mention the standing reminder.

## Testing
- macOS: `swift build` clean; built, installed, and verified live — the reminder renders under Start with the tooltip.
- Windows C#: same panel pattern as existing captions; needs the usual build check on a Windows box.
- UI: eslint matches develop baseline (3 pre-existing, none new).