### PR TITLE
feat(audio-capture): auditable consent record — date/text in Settings + reminder tooltip

### DIFF
--- a/docs/audio-capture-app.md
+++ b/docs/audio-capture-app.md
@@ -54,12 +54,21 @@ stream, record, or transcribe calls if otherwise prohibited.
 
 The app shows this disclaimer **before your first recording** and requires you
 to agree (the same consent gate as the browser extension and the web UI's
-Stream Audio tab). After that, a one-line reminder — *"Ensure all participants
-have consented to recording"* — stays visible next to the **Start** button
-(hover it to re-read the full disclaimer). The text is configurable per
-deployment via the `RecordingDisclaimer` CloudFormation parameter, so
-organizations can substitute their own legal wording; the app picks it up from
-the `lma-config.json` baked into the download.
+Stream Audio tab). After that:
+
+- A one-line reminder — *"Ensure all participants have consented to
+  recording"* — stays visible next to the **Start** button; hovering it shows
+  **when you agreed** and the exact text you agreed to.
+- **Settings (⚙ gear)** keeps your **consent record**: the date/time you
+  agreed and the full disclaimer text, expandable for review.
+- If the deployment's disclaimer wording is **changed** by your administrator,
+  the app asks you to agree to the **new** text once — your recorded consent
+  covers the text you actually saw.
+
+The text is configurable per deployment via the `RecordingDisclaimer`
+CloudFormation parameter, so organizations can substitute their own legal
+wording; the app picks it up from the `lma-config.json` baked into the
+download.
 
 ## Download and install (macOS)
 

--- a/lma-audio-capture-app-stack/source/macos/Sources/LMAAudioClient/MenuBarApp.swift
+++ b/lma-audio-capture-app-stack/source/macos/Sources/LMAAudioClient/MenuBarApp.swift
@@ -52,6 +52,8 @@ final class MenuBarAppState: ObservableObject {
     private static let kSystemLabel = "lma.systemLabel"
     private static let kMicDeviceUID = "lma.micDeviceUID"
     private static let kDisclaimerAgreed = "lma.disclaimerAgreed"
+    private static let kDisclaimerAgreedAt = "lma.disclaimerAgreedAt"
+    private static let kDisclaimerAgreedText = "lma.disclaimerAgreedText"
 
     /// Default label for the system channel when the user hasn't set one.
     static let defaultSystemLabel = "Other participants"
@@ -157,19 +159,47 @@ final class MenuBarAppState: ObservableObject {
     func start() {
         // One-time recording-consent gate (mirrors the browser extension): the
         // first Start on this machine shows the disclaimer; Agree persists and
-        // proceeds, Cancel does nothing.
-        guard UserDefaults.standard.bool(forKey: Self.kDisclaimerAgreed) else {
+        // proceeds, Cancel does nothing. The gate returns if the DEPLOYMENT'S
+        // DISCLAIMER TEXT has changed since consent — the recorded consent
+        // covers the text the user actually saw, not later revisions. (Users
+        // who agreed before the text was recorded re-consent once.)
+        let defaults = UserDefaults.standard
+        let agreed = defaults.bool(forKey: Self.kDisclaimerAgreed)
+        let agreedText = defaults.string(forKey: Self.kDisclaimerAgreedText)
+        guard agreed, agreedText == controller.config.recordingDisclaimer else {
             showDisclaimer = true
             return
         }
         reallyStart()
     }
 
-    /// Agree on the consent dialog: persist and start the recording that was gated.
+    /// Agree on the consent dialog: record WHAT was agreed to and WHEN, then
+    /// start the recording that was gated.
     func agreeDisclaimerAndStart() {
-        UserDefaults.standard.set(true, forKey: Self.kDisclaimerAgreed)
+        let defaults = UserDefaults.standard
+        defaults.set(true, forKey: Self.kDisclaimerAgreed)
+        defaults.set(Date(), forKey: Self.kDisclaimerAgreedAt)
+        defaults.set(controller.config.recordingDisclaimer, forKey: Self.kDisclaimerAgreedText)
         showDisclaimer = false
+        objectWillChange.send()   // consent record shown in Settings/reminder
         reallyStart()
+    }
+
+    /// When the user acknowledged the disclaimer, or nil if not yet (or if the
+    /// consent predates timestamp recording).
+    var disclaimerAgreedDate: Date? {
+        UserDefaults.standard.object(forKey: Self.kDisclaimerAgreedAt) as? Date
+    }
+
+    /// The exact disclaimer text the user agreed to (for the consent record).
+    var disclaimerAgreedText: String? {
+        UserDefaults.standard.string(forKey: Self.kDisclaimerAgreedText)
+    }
+
+    static func consentDateString(_ d: Date) -> String {
+        let f = DateFormatter()
+        f.dateStyle = .medium; f.timeStyle = .short
+        return f.string(from: d)
     }
 
     private func reallyStart() {
@@ -269,12 +299,13 @@ struct MenuBarContentView: View {
                     .keyboardShortcut(.defaultAction)
                     // Persistent consent reminder: the full disclaimer is a
                     // one-time gate, but the obligation is per-meeting — keep a
-                    // one-liner next to Start so it stays visible. Hover shows
-                    // the full deployment disclaimer text.
+                    // one-liner next to Start so it stays visible. It reflects
+                    // the recorded consent (date on hover, alongside the exact
+                    // text agreed to); the full record lives in Settings (⚙).
                     Label("Ensure all participants have consented to recording.",
                           systemImage: "checkmark.shield")
                         .font(.caption2).foregroundColor(.secondary)
-                        .help(s.controller.config.recordingDisclaimer)
+                        .help(consentTooltip)
                 } else {
                     // Live meters
                     LevelBar(label: "System", level: s.meetingLevel, muted: s.meetingMuted)
@@ -332,6 +363,16 @@ struct MenuBarContentView: View {
         .frame(width: 300)
     }
 
+    /// Hover text for the standing reminder: the full disclaimer, prefixed with
+    /// the recorded consent date when we have one.
+    private var consentTooltip: String {
+        let text = s.disclaimerAgreedText ?? s.controller.config.recordingDisclaimer
+        if let d = s.disclaimerAgreedDate {
+            return "You agreed to this on \(MenuBarAppState.consentDateString(d)):\n\n\(text)"
+        }
+        return text
+    }
+
     private var statusText: String {
         switch s.state {
         case .idle: return "Not signed in"
@@ -382,6 +423,23 @@ struct SettingsView: View {
             .font(.caption)
             Text("System Default follows your Sound settings. If a chosen mic is unplugged, recording falls back to the default.")
                 .font(.caption2).foregroundColor(.secondary)
+
+            // Consent record: when + what the user agreed to, so the one-time
+            // acknowledgment is inspectable afterwards (auditable, not a
+            // fire-and-forget dialog). Collapsed by default to keep the panel
+            // compact; absent entirely until the user has agreed.
+            if let d = s.disclaimerAgreedDate {
+                Text("Recording consent").font(.caption).foregroundColor(.secondary).padding(.top, 2)
+                DisclosureGroup {
+                    Text(s.disclaimerAgreedText ?? s.controller.config.recordingDisclaimer)
+                        .font(.caption2).foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.top, 2)
+                } label: {
+                    Label("Agreed \(MenuBarAppState.consentDateString(d))", systemImage: "checkmark.seal")
+                        .font(.caption2).foregroundColor(.secondary)
+                }
+            }
         }
     }
 }

--- a/lma-audio-capture-app-stack/source/windows/App/AppSettings.cs
+++ b/lma-audio-capture-app-stack/source/windows/App/AppSettings.cs
@@ -85,6 +85,8 @@ public static class AppSettings
     // MARK: - Recording-consent disclaimer (one-time acknowledgment)
 
     private const string DisclaimerAgreedValue = "DisclaimerAgreed";
+    private const string DisclaimerAgreedAtValue = "DisclaimerAgreedAt";
+    private const string DisclaimerAgreedTextValue = "DisclaimerAgreedText";
 
     /// <summary>
     /// Whether the user has acknowledged the recording-consent disclaimer (shown
@@ -93,7 +95,32 @@ public static class AppSettings
     public static bool DisclaimerAgreed
     {
         get { using var k = Registry.CurrentUser.OpenSubKey(SettingsKeyPath); return (k?.GetValue(DisclaimerAgreedValue) as int?) == 1; }
-        set { using var k = Registry.CurrentUser.CreateSubKey(SettingsKeyPath); k.SetValue(DisclaimerAgreedValue, value ? 1 : 0, RegistryValueKind.DWord); }
+    }
+
+    /// <summary>When consent was recorded, or null (also null for consents that predate timestamping).</summary>
+    public static DateTime? DisclaimerAgreedAt
+    {
+        get
+        {
+            using var k = Registry.CurrentUser.OpenSubKey(SettingsKeyPath);
+            var s = k?.GetValue(DisclaimerAgreedAtValue) as string;
+            return DateTime.TryParse(s, null, System.Globalization.DateTimeStyles.RoundtripKind, out var d) ? d : null;
+        }
+    }
+
+    /// <summary>The exact disclaimer text the user agreed to (for the consent record).</summary>
+    public static string DisclaimerAgreedText
+    {
+        get { using var k = Registry.CurrentUser.OpenSubKey(SettingsKeyPath); return (k?.GetValue(DisclaimerAgreedTextValue) as string) ?? ""; }
+    }
+
+    /// <summary>Record consent: the flag, WHEN it happened, and WHAT text was shown.</summary>
+    public static void RecordDisclaimerConsent(string disclaimerText)
+    {
+        using var k = Registry.CurrentUser.CreateSubKey(SettingsKeyPath);
+        k.SetValue(DisclaimerAgreedValue, 1, RegistryValueKind.DWord);
+        k.SetValue(DisclaimerAgreedAtValue, DateTime.Now.ToString("o"), RegistryValueKind.String);
+        k.SetValue(DisclaimerAgreedTextValue, disclaimerText, RegistryValueKind.String);
     }
 
     // MARK: - Start at login (HKCU ...\Run)

--- a/lma-audio-capture-app-stack/source/windows/App/PanelView.cs
+++ b/lma-audio-capture-app-stack/source/windows/App/PanelView.cs
@@ -329,6 +329,30 @@ public sealed class PanelView : Border
                 Foreground = Secondary, FontSize = 10, TextWrapping = TextWrapping.Wrap,
                 Margin = new Thickness(0, 0, 0, 4),
             });
+            // Consent record: when + what the user agreed to, so the one-time
+            // acknowledgment is inspectable afterwards (auditable, not a
+            // fire-and-forget dialog). Collapsed by default; absent until agreed.
+            if (AppSettings.DisclaimerAgreedAt is DateTime consentAt)
+            {
+                _body.Children.Add(Label("Recording consent"));
+                var record = new Expander
+                {
+                    Header = new TextBlock
+                    {
+                        Text = $"✓ Agreed {consentAt:g}",
+                        Foreground = Secondary, FontSize = 10,
+                    },
+                    Content = new TextBlock
+                    {
+                        Text = string.IsNullOrEmpty(AppSettings.DisclaimerAgreedText)
+                            ? EffectiveDisclaimer : AppSettings.DisclaimerAgreedText,
+                        Foreground = Secondary, FontSize = 10, TextWrapping = TextWrapping.Wrap,
+                        Margin = new Thickness(4, 2, 0, 2),
+                    },
+                    Margin = new Thickness(0, 0, 0, 4),
+                };
+                _body.Children.Add(record);
+            }
             _body.Children.Add(Sep());
         }
 
@@ -362,7 +386,13 @@ public sealed class PanelView : Border
                 _body.Children.Add(_start);
                 // Persistent consent reminder: the full disclaimer is a one-time
                 // gate, but the obligation is per-meeting — keep a one-liner next
-                // to Start. Hover shows the full deployment disclaimer text.
+                // to Start. Hover shows the consent record (when + the exact text
+                // agreed to); the full record also lives in Settings (⚙).
+                var agreedAt = AppSettings.DisclaimerAgreedAt;
+                var agreedText = AppSettings.DisclaimerAgreedText;
+                var tooltip = string.IsNullOrEmpty(agreedText) ? EffectiveDisclaimer : agreedText;
+                if (agreedAt is DateTime at)
+                    tooltip = $"You agreed to this on {at:g}:\n\n{tooltip}";
                 _body.Children.Add(new TextBlock
                 {
                     Text = "✓ Ensure all participants have consented to recording.",
@@ -370,9 +400,7 @@ public sealed class PanelView : Border
                     FontSize = 10,
                     TextWrapping = TextWrapping.Wrap,
                     Margin = new Thickness(0, 0, 0, 8),
-                    ToolTip = string.IsNullOrEmpty(_c.Config.RecordingDisclaimer)
-                        ? Config.DefaultDisclaimer
-                        : _c.Config.RecordingDisclaimer,
+                    ToolTip = tooltip,
                 });
             }
             else
@@ -433,7 +461,7 @@ public sealed class PanelView : Border
         // One-time recording-consent gate (mirrors the browser extension): the
         // first Start on this machine shows the disclaimer; Agree persists and
         // proceeds, Cancel does nothing.
-        if (!AppSettings.DisclaimerAgreed)
+        if (NeedsDisclaimer)
         {
             _showDisclaimer = true;
             Refresh();
@@ -441,6 +469,10 @@ public sealed class PanelView : Border
         }
         ReallyStart();
     }
+
+    /// <summary>The disclaimer text currently in effect for this deployment.</summary>
+    private string EffectiveDisclaimer =>
+        string.IsNullOrEmpty(_c.Config.RecordingDisclaimer) ? Config.DefaultDisclaimer : _c.Config.RecordingDisclaimer;
 
     private void ReallyStart()
     {
@@ -455,9 +487,13 @@ public sealed class PanelView : Border
     /// <summary>
     /// Whether Start would currently be gated on the consent disclaimer — used by
     /// TrayApp so a JumpList "Start Recording" surfaces the panel with the dialog
-    /// instead of silently doing nothing.
+    /// instead of silently doing nothing. Also true when the DEPLOYMENT'S
+    /// DISCLAIMER TEXT changed since consent — the recorded consent covers the
+    /// text the user actually saw, not later revisions. (Consents that predate
+    /// text recording re-consent once.)
     /// </summary>
-    public bool NeedsDisclaimer => !AppSettings.DisclaimerAgreed;
+    public bool NeedsDisclaimer =>
+        !AppSettings.DisclaimerAgreed || AppSettings.DisclaimerAgreedText != EffectiveDisclaimer;
 
     /// <summary>Show the consent gate (for Start attempts that arrive from outside the panel).</summary>
     public void ShowDisclaimerGate()
@@ -482,9 +518,7 @@ public sealed class PanelView : Border
         });
         panel.Children.Add(new TextBlock
         {
-            Text = string.IsNullOrEmpty(_c.Config.RecordingDisclaimer)
-                ? Config.DefaultDisclaimer
-                : _c.Config.RecordingDisclaimer,
+            Text = EffectiveDisclaimer,
             FontSize = 11,
             TextWrapping = TextWrapping.Wrap,
             Margin = new Thickness(0, 0, 0, 8),
@@ -494,7 +528,8 @@ public sealed class PanelView : Border
         var agree = new Button { Content = "Agree", FontWeight = FontWeights.Bold };
         agree.Click += (_, _) =>
         {
-            AppSettings.DisclaimerAgreed = true;
+            // Record WHAT was agreed to and WHEN (shown in Settings afterwards).
+            AppSettings.RecordDisclaimerConsent(EffectiveDisclaimer);
             _showDisclaimer = false;
             Refresh();
             ReallyStart();


### PR DESCRIPTION
## What

Answers "can we show the record that the user already consented — text + date/time?" — yes, on both platforms:

1. **Consent is now recorded, not just flagged.** Agreeing stores the **timestamp** and the **exact disclaimer text shown** (UserDefaults / HKCU).
2. **Settings (⚙) shows the consent record**: `✓ Agreed <date time>` with the full agreed text expandable beneath it (SwiftUI `DisclosureGroup` / WPF `Expander`). Hidden until the user has agreed.
3. **The standing reminder acknowledges the prior consent**: hovering it now shows *"You agreed to this on \<date\>:"* followed by the exact agreed text — the discrete link to text+date requested.
4. **Re-consent when the wording changes**: if an admin updates the deployment's `RecordingDisclaimer`, the gate returns once — recorded consent covers the text the user actually saw, not later revisions.

## Migration note
Users who agreed before this change (flag but no recorded text) are re-gated **once**; their next Agree records date+text properly.

## Testing
- macOS: swift build clean; installed and verified the pre-existing consent (no recorded text) correctly re-gates.
- Windows: same logic in C#; needs the usual build check on a Windows box (agree → Settings shows record; reminder tooltip has date; registry has `DisclaimerAgreedAt`/`DisclaimerAgreedText`).
- Docs updated with the record + re-consent behavior.