### PR TITLE
fix(VP/webex): capture chat messages from updated UI

### DIFF
--- a/lma-virtual-participant-stack/backend/src/webex.ts
+++ b/lma-virtual-participant-stack/backend/src/webex.ts
@@ -741,7 +741,7 @@ export default class Webex {
         console.log('Listening for message changes.');
         await frame.evaluate(() => {
                 const targetNode = document.querySelector(
-                    'div[class^="style-chat-box"]'
+                    'div[class^="style-chat-box"], #activity-list > mdc-list'
                 );
 
                 const config = { childList: true, subtree: true };
@@ -751,12 +751,12 @@ export default class Webex {
                     const addedNode = lastMutation.addedNodes[0] as Element;
                     if (addedNode) {
                         const sender = addedNode.querySelector(
-                            'h3[class^="style-chat-label"]'
+                            'h3[class^="style-chat-label"], .sender-name'
                         )?.textContent;
                         const message = addedNode.querySelector(
-                            'span[class^="style-chat-msg"]'
+                            'span[class^="style-chat-msg"], .activity-item-message'
                         )?.textContent;
-                        if (!sender!.startsWith('from LMA')) {
+                        if (!sender!.startsWith('from LMA') && sender !== "You") {
                             (window as any).messageChange(message);
                         }
                     }


### PR DESCRIPTION
Fixes #507 

*Description of changes:*
Added new selectors to support updated webex UI that displays chat box. 
Selectors are extended only to make sure changes are backward-compatible if some variants are still using old UI (tested on free account)