### PR TITLE
chore(deps): finish remaining boto3/botocore/phonenumbers bumps

### DIFF
--- a/lma-ai-stack/requirements/requirements-dev.txt
+++ b/lma-ai-stack/requirements/requirements-dev.txt
@@ -10,9 +10,9 @@ toml>=0.10.2
 yamllint~=1.38.0
 
 # runtime and typing dependencies included to hint IDEs and make it easier to test/debug locally
-boto3~=1.43.58
-boto3-stubs[comprehend,codebuild,dynamodb,lambda,lexv2-runtime,s3,sqs,sns]~=1.43.54
+boto3~=1.43.62
+boto3-stubs[comprehend,codebuild,dynamodb,lambda,lexv2-runtime,s3,sqs,sns]~=1.43.62
 gql[botocore,aiohttp,requests]~=3.5.3
 aws-lambda-powertools~=3.31.1
-phonenumbers~=9.0.35
+phonenumbers~=9.0.36
 crhelper~=2.0.12

--- a/lma-ai-stack/source/lambda_functions/mcp_analytics/requirements.txt
+++ b/lma-ai-stack/source/lambda_functions/mcp_analytics/requirements.txt
@@ -1,3 +1,3 @@
 boto3>=1.43.62
-botocore>=1.43.54
+botocore>=1.43.62
 requests>=2.34.2

--- a/lma-ai-stack/source/lambda_functions/meeting_invitation_parser/requirements.txt
+++ b/lma-ai-stack/source/lambda_functions/meeting_invitation_parser/requirements.txt
@@ -1,2 +1,2 @@
 boto3>=1.43.62
-botocore>=1.43.54
+botocore>=1.43.62

--- a/lma-ai-stack/source/lambda_functions/virtual_participant_manager/requirements.txt
+++ b/lma-ai-stack/source/lambda_functions/virtual_participant_manager/requirements.txt
@@ -1,3 +1,3 @@
 # Virtual Participant Manager Lambda Dependencies
 boto3>=1.43.62
-botocore>=1.43.54
+botocore>=1.43.62

--- a/lma-ai-stack/source/lambda_layers/transcript_enrichment_layer/requirements.txt
+++ b/lma-ai-stack/source/lambda_layers/transcript_enrichment_layer/requirements.txt
@@ -1,7 +1,7 @@
 # keep in sync with local dev dependencies in requirements-dev.txt
-boto3~=1.43.58
+boto3~=1.43.62
 gql[botocore,aiohttp,requests]~=3.5.3
 aws-lambda-powertools~=3.31.1
-phonenumbers~=9.0.35
+phonenumbers~=9.0.36
 pyjwt
 cryptography


### PR DESCRIPTION
Completes the dependency bumps from dependabot PRs #491, #492, #500 and #501. Those were closed before merge and their branches deleted, so they could not be reopened — this re-applies their content directly.

## Changes
Brings stragglers up to the versions already on develop after #519 / #490 / #503:

| Dependency | From | To | Files |
|---|---|---|---|
| `botocore` | `>=1.43.54` | `>=1.43.62` | mcp_analytics, meeting_invitation_parser, virtual_participant_manager |
| `boto3` | `~=1.43.58` | `~=1.43.62` | transcript_enrichment_layer, requirements-dev |
| `phonenumbers` | `~=9.0.35` | `~=9.0.36` | transcript_enrichment_layer, requirements-dev |
| `boto3-stubs` | `~=1.43.54` | `~=1.43.62` | requirements-dev |

This also removes a pre-existing skew where `boto3>=1.43.62` sat alongside `botocore>=1.43.54` in the same files.

## Verification
- `requirements-dev.txt` installs cleanly in a fresh venv; `pip check` reports no broken requirements
- All 91 Lambda unit tests pass across 6 test directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)