### PR TITLE
chore(deps): bump browser-extension deps with a consistent lockfile (fixes #517, #523)

### DIFF
--- a/lma-browser-extension-stack/package-lock.json
+++ b/lma-browser-extension-stack/package-lock.json
@@ -8,25 +8,25 @@
       "name": "lma-extension",
       "version": "<VERSION_TOKEN>",
       "dependencies": {
-        "@cloudscape-design/components": "^3.0.1333",
-        "@cloudscape-design/global-styles": "^1.0.62",
+        "@cloudscape-design/components": "^3.0.1340",
+        "@cloudscape-design/global-styles": "^1.0.65",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^30.0.0",
-        "@types/node": "^26.1.1",
-        "@types/react": "^19.2.17",
-        "@types/react-dom": "^19.2.3",
+        "@types/node": "^26.1.2",
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.4",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-scripts": "5.0.1",
         "react-use-websocket": "^4.13.0",
         "typescript": "^4.9.5",
-        "web-vitals": "^6.0.0"
+        "web-vitals": "^6.0.1"
       },
       "devDependencies": {
-        "@types/chrome": "^0.2.2",
+        "@types/chrome": "^0.2.5",
         "eslint": "^8.57.0",
         "eslint-plugin-react": "^7.37.5",
         "typescript-eslint": "^8.65.0"
@@ -2114,9 +2114,9 @@
       "license": "MIT"
     },
     "node_modules/@cloudscape-design/components": {
-      "version": "3.0.1333",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.1333.tgz",
-      "integrity": "sha512-cYk6ByAEccDjkeMGeuP8HHDxeHoLQ0tpL7bt0JClxbpL7eYEHBmG+ZQ3MN7bZVD12qVLqQJdgc21D+VzKTMgjw==",
+      "version": "3.0.1340",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.1340.tgz",
+      "integrity": "sha512-u8IZb/zI4lSQ+9+DFXZEXkuJgNGo8lMiBdtRRwxXbY3zWDyrRwsTansA+Nn6jdCjUJv9riM4B4DKPr5KSESBWw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cloudscape-design/collection-hooks": "^1.0.0",
@@ -2142,9 +2142,9 @@
       }
     },
     "node_modules/@cloudscape-design/global-styles": {
-      "version": "1.0.62",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/global-styles/-/global-styles-1.0.62.tgz",
-      "integrity": "sha512-8ll8m/Z2/nwHNBhGtEj/pqkBb08OkboyXoKef+D73HmUFgAOhhXCKUaqtF2SVOsvjHm5IffEQRvKK3/CQUeR1g==",
+      "version": "1.0.65",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/global-styles/-/global-styles-1.0.65.tgz",
+      "integrity": "sha512-T4EbXK8a1tAp0XHohkGktV6mcYGyMMuCKoICEbCqkunu7pUpJA6SkZD5vV7ZcLtbqEMzalO08uyQ3TJ3Inxy8g==",
       "license": "Apache-2.0"
     },
     "node_modules/@cloudscape-design/test-utils-core": {
@@ -4412,9 +4412,9 @@
       }
     },
     "node_modules/@types/chrome": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.2.2.tgz",
-      "integrity": "sha512-8rSMZ4cvo2xmaSyQg0sN5yRL7oiDkntLoiHxUhfwQnv1mvnkrdoZ25SlNrKWmYKaeP50WvrfWj1pmc02+U9KKw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.2.5.tgz",
+      "integrity": "sha512-DwLFgwj3D0zjxRBhQ3610RBso2g+yI1cakq/JdIGopZ9Bc5UhQluyfcLGZwivFE4t2h4b2QZYZhPV7KylExSbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4627,9 +4627,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -4675,18 +4675,18 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -18417,23 +18417,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/tapable": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
@@ -19522,9 +19505,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.0.0.tgz",
-      "integrity": "sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.0.1.tgz",
+      "integrity": "sha512-iF3+kno3Anlqi5fPVTQk9gYLfsCiL8P69Hof+AmZyVVx00E3e/BiGVvu+EsOy6jvTLqTKuiaRloPyw0JtdKbSw==",
       "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {

--- a/lma-browser-extension-stack/package-lock.json
+++ b/lma-browser-extension-stack/package-lock.json
@@ -6329,9 +6329,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -9104,9 +9104,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -18417,6 +18417,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
@@ -19144,9 +19161,9 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/lma-browser-extension-stack/package.json
+++ b/lma-browser-extension-stack/package.json
@@ -3,22 +3,22 @@
   "version": "<VERSION_TOKEN>",
   "private": true,
   "dependencies": {
-    "@cloudscape-design/components": "^3.0.1333",
-    "@cloudscape-design/global-styles": "^1.0.62",
+    "@cloudscape-design/components": "^3.0.1340",
+    "@cloudscape-design/global-styles": "^1.0.65",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^30.0.0",
-    "@types/node": "^26.1.1",
-    "@types/react": "^19.2.17",
-    "@types/react-dom": "^19.2.3",
+    "@types/node": "^26.1.2",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-scripts": "5.0.1",
     "react-use-websocket": "^4.13.0",
     "typescript": "^4.9.5",
-    "web-vitals": "^6.0.0"
+    "web-vitals": "^6.0.1"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -45,7 +45,7 @@
     ]
   },
   "devDependencies": {
-    "@types/chrome": "^0.2.2",
+    "@types/chrome": "^0.2.5",
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.37.5",
     "typescript-eslint": "^8.65.0"

--- a/lma-browser-extension-stack/package.json
+++ b/lma-browser-extension-stack/package.json
@@ -65,11 +65,13 @@
     "glob@10": "^10.5.0",
     "picomatch@2": "^2.3.2",
     "form-data@3": "^3.0.4",
-    "brace-expansion@1": "^1.1.13",
+    "brace-expansion@1": "^1.1.18",
     "svgo@2": "^2.8.1",
     "cross-spawn": "^7.0.6",
     "lodash": "^4.18.0",
     "http-proxy-middleware@2": "^2.0.7",
-    "shell-quote": "^1.10.0"
+    "shell-quote": "^1.10.0",
+    "brace-expansion@2": "^2.1.4",
+    "brace-expansion@5": "^5.0.9"
   }
 }


### PR DESCRIPTION
Supersedes #517 and #523. Both targeted `lma-browser-extension-stack/package-lock.json` and **each left it unusable on its own**, so they are combined here to avoid re-conflicting.

## The bug
Both PRs dropped the `tailwindcss/node_modules/yaml@2.9.0` entry while leaving the dependency that resolves to it in place, so `npm ci` aborted:

```
npm error code EUSAGE
npm error Missing: yaml@2.9.0 from lock file
```

`yaml` is an *optional peer* of tailwindcss. Regenerating with `npm install --package-lock-only` restores it.

`brace-expansion` is governed by the `overrides` block, so its bumps needed the override floors raised — editing the lockfile directly fails with `EOVERRIDE`.

## Changes
- `@cloudscape-design/components` 3.0.1333 → 3.0.1340, `global-styles` 1.0.62 → 1.0.65
- `@types/node` 26.1.1 → 26.1.2, `@types/react` 19.2.17 → 19.2.18, `@types/react-dom` 19.2.3 → 19.2.4, `@types/chrome` 0.2.2 → 0.2.5
- `web-vitals` 6.0.0 → 6.0.1
- `brace-expansion` 1.1.16 → 1.1.18, 2.1.2 → 2.1.4, 5.0.8 → 5.0.9

## Verification
- `npm ci` installs cleanly (1526 packages) — previously failed
- `react-scripts build` compiles
- `npm audit` total drops 23 → 22 (one high resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)