### PR TITLE
fix(windows): build capture client as x64 so ScreenRecorderLib resolves

### DIFF
--- a/lma-desktop-capture-app-stack/source/windows/LMACaptureClient.Windows.csproj
+++ b/lma-desktop-capture-app-stack/source/windows/LMACaptureClient.Windows.csproj
@@ -33,7 +33,21 @@
     <!-- We build the UI in code (no XAML markup) so there is no App.xaml entry
          point; Program.Main is our explicit entry point. -->
     <StartupObject>LMA.Program</StartupObject>
+    <!-- ScreenRecorderLib is a C++/CLI mixed-mode assembly: its .targets refuses
+         to build on 'AnyCPU' and picks the native DLL off $(Platform). Listing
+         x64 in Platforms is NOT enough — that only declares which platforms are
+         legal, while MSBuild still defaults the ACTIVE $(Platform) to AnyCPU
+         (set in Microsoft.Common.props, imported before this PropertyGroup), so
+         a plain `dotnet build/publish` failed with "does not work correctly on
+         'AnyCPU' platform". Set it explicitly, but leave an explicit
+         -p:Platform=... on the command line able to win.
+         AppendPlatformToOutputPath: a non-AnyCPU platform normally inserts an
+         extra "x64\" segment (bin\x64\Release\...); suppress it so the output
+         stays at bin\$(Configuration)\net8.0-windows\win-x64\ where
+         build-windows.ps1 and the README's by-hand instructions expect it. -->
     <Platforms>x64</Platforms>
+    <Platform Condition="'$(Platform)' == '' or '$(Platform)' == 'AnyCPU'">x64</Platform>
+    <AppendPlatformToOutputPath>false</AppendPlatformToOutputPath>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
   </PropertyGroup>


### PR DESCRIPTION
## Problem

Building the downloadable Windows Desktop Capture Client fails immediately:

```
> ./build-windows.ps1 -SelfContained -Install
==> Building LMA Capture Client (LMA-Bob) (Release, self-contained=True)
  LMACaptureClient.Windows net8.0-windows win-x64 failed with 1 error(s)
    ScreenRecorderLib.targets(6,5): error : ScreenRecorderLib does not work
    correctly on 'AnyCPU' platform. You need to specify platform (x86, Win32 or x64).

Build failed with 1 error(s)
Build did not produce ...\win-x64\publish\LMACaptureClient.exe
```

The script then throws at the `Test-Path $exe` gate. This affects every user who
downloads the Windows client from the LMA UI and follows the documented install
steps, so the Windows capture client is currently unbuildable as shipped.

## Root cause

`ScreenRecorderLib` is a C++/CLI mixed-mode assembly. Its `.targets` hard-errors
on `AnyCPU` and picks the native DLL off `$(Platform)`.

`LMACaptureClient.Windows.csproj` set `<Platforms>x64</Platforms>` - but that
property only declares which platforms are **legal**. The **active**
`$(Platform)` still defaulted to `AnyCPU` (set in `Microsoft.Common.props`,
imported before our `PropertyGroup`), so the guard tripped on every plain
`dotnet build` / `dotnet publish`.

`build-windows.ps1` passes `-r win-x64` but never `-p:Platform`, and the
`-r`/RuntimeIdentifier is unrelated to MSBuild's `$(Platform)` - hence the
failure. Notably `tools/compile-check.sh` *does* pass `-p:Platform=x64`, which is
why the off-Windows compile gate stayed green while the real build was broken.

## Fix

Two properties in the csproj:

- `<Platform Condition="'$(Platform)' == '' or '$(Platform)' == 'AnyCPU'">x64</Platform>`
  - sets the active platform, while leaving an explicit `-p:Platform=...` on the
  command line able to win.
- `<AppendPlatformToOutputPath>false</AppendPlatformToOutputPath>` - a non-AnyCPU
  platform otherwise injects an extra `x64\` segment (`bin\x64\Release\...`),
  which would move the exe away from `bin\<Config>\net8.0-windows\win-x64\`
  where `build-windows.ps1` and the README's by-hand instructions look for it.

No source, packaging, or documented path changes - the output layout is
byte-for-byte where it was expected to be all along.

## Verification

On Windows 11, .NET SDK 11.0.100-preview.6:

- Reproduced the failure on `develop` first, then confirmed it fixed.
- `./build-windows.ps1 -SelfContained` ? builds and the **SRP self-test passes
  (11/11 known-answer vectors)**, ending in the expected success banner.
- Publish output stays at `bin\Release\net8.0-windows\win-x64\publish\`;
  `LMACaptureClient.exe` present.
- Bundled `ScreenRecorderLib.dll` SHA256 **matches the package's `build\x64\`
  native DLL** - i.e. the correct architecture is selected, not just a build that
  no longer errors.
- `dotnet build` with no args, `-p:Platform=x64`, and Debug/Release all succeed;
  no configuration grows a stray `x64\` path segment.

Not run: a live capture smoke test against a deployed stack (no meeting audio in
this environment). The change is build-configuration only and the runtime
self-test passes.