### PR TITLE
fix(windows): make screen-video capture actually stream + add picker thumbnails

### DIFF
--- a/docs/desktop-capture-app.md
+++ b/docs/desktop-capture-app.md
@@ -427,10 +427,10 @@ Panel options:
     recording falls back to the default. Changes are saved immediately and
     apply to the **next** recording (the gear is disabled while recording).
   - **Also record screen video** — off by default. When on, choose from a list of
-    your **screens and windows**, each labeled with the monitor's own name (e.g.
-    *DELL U2720Q*) and its **resolution**, so two similar monitors are easy to
-    tell apart. The chosen screen/window is recorded with the meeting and saved
-    as a video in LMA (see
+    your **screens and windows**, each with a **thumbnail preview**, the monitor's
+    own name (e.g. *DELL U2720Q*), and its **resolution**, so two similar monitors
+    are easy to tell apart. The chosen screen/window is recorded with the meeting
+    and saved as a video in LMA (see
     [Optional: record screen video](#optional-record-screen-video)).
 
 The app uses no audio or CPU when idle, so the intended usage is to leave it in

--- a/lma-desktop-capture-app-stack/source/windows/App/PanelView.cs
+++ b/lma-desktop-capture-app-stack/source/windows/App/PanelView.cs
@@ -365,15 +365,17 @@ public sealed class PanelView : Border
     /// <summary>
     /// Repopulate the video source dropdown (displays + titled windows).
     ///
-    /// Each row shows the source name, an icon indicating display vs window, and
-    /// the pixel size — "Display 2" alone doesn't let a user tell two identical
-    /// monitors apart, and recording the wrong screen is a privacy problem.
+    /// Each row shows the source name, an icon indicating display vs window, the
+    /// pixel size, and a live preview thumbnail — "Display 2" alone doesn't let a
+    /// user tell two identical monitors apart, and recording the wrong screen is
+    /// a privacy problem. (Feature parity with the macOS Settings picker.)
     /// The list now supplies its own default entry (the first display, with the
     /// empty id), so this no longer prepends one.
     /// </summary>
     private void RefreshVideoPicker()
     {
         _loadingVideoPicker = true;
+        List<(string Id, Image Slot)> slots = new();
         try
         {
             _videoPicker.Items.Clear();
@@ -382,8 +384,10 @@ public sealed class PanelView : Border
             var sources = VideoCapture.ListSources();
             foreach (var src in sources)
             {
-                var item = new ComboBoxItem { Content = SourceRow(src), Tag = src.Id };
+                var (row, slot) = SourceRow(src);
+                var item = new ComboBoxItem { Content = row, Tag = src.Id };
                 _videoPicker.Items.Add(item);
+                slots.Add((src.Id, slot));
                 if (src.Id.Length == 0) defaultItem ??= item;
                 if (src.Id == selected) _videoPicker.SelectedItem = item;
             }
@@ -392,15 +396,75 @@ public sealed class PanelView : Border
             _videoPicker.SelectedItem ??= defaultItem ?? _videoPicker.Items.Cast<object>().FirstOrDefault();
         }
         finally { _loadingVideoPicker = false; }
+        LoadThumbnails(slots);
     }
 
     /// <summary>
-    /// One picker row: icon + name, with the resolution underneath as the
-    /// distinguishing detail.
+    /// Fill the picker rows' preview slots asynchronously, mirroring the macOS
+    /// loadThumbnails: capped (windows are listed front-to-back, so the first
+    /// ones are the likely picks), sequential (each preview is a real screen
+    /// copy; a dozen at once would stutter a live recording), and generation-
+    /// checked so a refresh abandons a stale pass instead of painting previews
+    /// onto rows that no longer exist. Rows keep their placeholder until (and
+    /// unless) a preview arrives, so the list never jumps.
     /// </summary>
-    private static UIElement SourceRow(VideoCapture.Source src)
+    private int _thumbnailGeneration;
+    private const int MaxThumbnails = 12;
+
+    private void LoadThumbnails(List<(string Id, Image Slot)> slots)
+    {
+        int generation = ++_thumbnailGeneration;
+        var work = slots.Take(MaxThumbnails).ToList();
+        Task.Run(() =>
+        {
+            foreach (var (id, slot) in work)
+            {
+                if (generation != _thumbnailGeneration) return; // list moved on
+                var thumb = VideoCapture.Thumbnail(id);
+                if (thumb is not { } t) continue;
+                // The BitmapSource is created on the UI thread from the raw
+                // pixels — WPF bitmaps have thread affinity unless frozen.
+                Dispatcher.BeginInvoke(() =>
+                {
+                    if (generation != _thumbnailGeneration) return;
+                    slot.Source = System.Windows.Media.Imaging.BitmapSource.Create(
+                        t.Width, t.Height, 96, 96,
+                        // Bgr32, not Bgra32: GDI leaves the alpha byte 0, which
+                        // Bgra32 would render fully transparent.
+                        PixelFormats.Bgr32, null,
+                        t.PixelsBgra, t.Width * 4);
+                });
+            }
+        });
+    }
+
+    /// <summary>
+    /// One picker row: preview thumbnail + icon + name, with the resolution
+    /// underneath as the distinguishing detail. Returns the Image slot the async
+    /// thumbnail loader fills in later (grey placeholder until then, so rows
+    /// have a stable size and a missing preview never blocks choosing).
+    /// </summary>
+    private static (UIElement Row, Image Slot) SourceRow(VideoCapture.Source src)
     {
         var row = new StackPanel { Orientation = Orientation.Horizontal };
+        // 44×28 matches the macOS SourceThumbnail row size.
+        var slot = new Image
+        {
+            Width = 44, Height = 28,
+            Stretch = Stretch.Uniform,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        row.Children.Add(new Border
+        {
+            Child = slot,
+            Width = 44, Height = 28,
+            Background = new SolidColorBrush(Color.FromRgb(0xE4, 0xE4, 0xE4)),
+            BorderBrush = new SolidColorBrush(Color.FromRgb(0xC8, 0xC8, 0xC8)),
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(2),
+            Margin = new Thickness(0, 2, 6, 2),
+            VerticalAlignment = VerticalAlignment.Center,
+        });
         row.Children.Add(new TextBlock
         {
             // Windows ships Segoe MDL2 Assets on Win10+; these two glyphs are
@@ -413,7 +477,7 @@ public sealed class PanelView : Border
             VerticalAlignment = VerticalAlignment.Center,
             Margin = new Thickness(0, 0, 6, 0),
         });
-        var text = new StackPanel();
+        var text = new StackPanel { VerticalAlignment = VerticalAlignment.Center };
         text.Children.Add(new TextBlock
         {
             Text = src.Name,
@@ -430,7 +494,7 @@ public sealed class PanelView : Border
             });
         }
         row.Children.Add(text);
-        return row;
+        return (row, slot);
     }
 
     private string CurrentEmail()

--- a/lma-desktop-capture-app-stack/source/windows/Engine/VideoCapture.cs
+++ b/lma-desktop-capture-app-stack/source/windows/Engine/VideoCapture.cs
@@ -125,6 +125,178 @@ public sealed class VideoCapture
         return outList;
     }
 
+    // MARK: - Thumbnails (Settings picker)
+
+    /// <summary>
+    /// Raw BGRA pixels of a source preview (top-down rows, 4 bytes/pixel). The
+    /// engine stays UI-framework-agnostic, so the App layer converts this to a
+    /// WPF BitmapSource (PixelFormats.Bgr32 — GDI leaves the alpha byte 0, which
+    /// Bgra32 would render fully transparent).
+    /// </summary>
+    public readonly record struct ThumbnailImage(byte[] PixelsBgra, int Width, int Height);
+
+    /// <summary>
+    /// One-shot still of a source, scaled so its longest edge is `maxPixel`, for
+    /// the picker's preview. Mirrors macOS VideoCapture.thumbnail(sourceID:).
+    ///
+    /// Best-effort by design — returns null when the source is gone (window
+    /// closed, display unplugged) or the copy fails; the picker shows the icon
+    /// placeholder instead, so a missing preview never blocks choosing a source.
+    ///
+    /// Plain GDI (CreateDC/StretchBlt for displays, PrintWindow for windows)
+    /// rather than ScreenRecorderLib: a thumbnail must not spin up the capture
+    /// pipeline (encoder session, capture thread) twelve times just to draw a
+    /// dropdown, and GDI needs no permission on Windows. PW_RENDERFULLCONTENT
+    /// makes PrintWindow include DirectComposition surfaces (Chromium, Electron,
+    /// UWP), which plain WM_PRINT misses.
+    /// </summary>
+    public static ThumbnailImage? Thumbnail(string sourceId, int maxPixel = 320)
+    {
+        try
+        {
+            if (sourceId.StartsWith("window:")
+                && long.TryParse(sourceId.AsSpan("window:".Length), out var handle))
+                return WindowThumbnail((IntPtr)handle, maxPixel);
+
+            string device = "";
+            if (sourceId.StartsWith("display:"))
+                device = sourceId.Substring("display:".Length);
+            else if (sourceId.Length == 0)
+            {
+                // Empty id = the picker default = the FIRST display (must agree
+                // with ListSources / ResolveSource).
+                var displays = Recorder.GetDisplays();
+                if (displays.Count > 0) device = displays[0].DeviceName;
+            }
+            if (device.Length == 0) return null;
+            return DisplayThumbnail(device, maxPixel);
+        }
+        catch
+        {
+            return null; // preview is optional; never let it break the picker
+        }
+    }
+
+    private static ThumbnailImage? DisplayThumbnail(string deviceName, int maxPixel)
+    {
+        var (w, h) = DisplayResolution(deviceName);
+        if (w <= 0 || h <= 0) return null;
+        // A DC for THIS display: coordinates start at (0,0) regardless of where
+        // the monitor sits in the virtual desktop (no negative-origin math).
+        var hdcSrc = CreateDC(null, deviceName, null, IntPtr.Zero);
+        if (hdcSrc == IntPtr.Zero) return null;
+        try { return ScaleAndRead(hdcSrc, 0, 0, w, h, maxPixel); }
+        finally { DeleteDC(hdcSrc); }
+    }
+
+    private static ThumbnailImage? WindowThumbnail(IntPtr hwnd, int maxPixel)
+    {
+        if (!GetWindowRect(hwnd, out var r)) return null;
+        int w = r.Right - r.Left, h = r.Bottom - r.Top;
+        if (w <= 0 || h <= 0) return null;
+
+        var hdcScreen = GetDC(IntPtr.Zero);
+        if (hdcScreen == IntPtr.Zero) return null;
+        var hdcFull = CreateCompatibleDC(hdcScreen);
+        var hbmFull = CreateCompatibleBitmap(hdcScreen, w, h);
+        var oldFull = SelectObject(hdcFull, hbmFull);
+        try
+        {
+            // Full-size render first (PrintWindow can't scale), then scale down.
+            if (!PrintWindow(hwnd, hdcFull, PW_RENDERFULLCONTENT)) return null;
+            return ScaleAndRead(hdcFull, 0, 0, w, h, maxPixel);
+        }
+        finally
+        {
+            SelectObject(hdcFull, oldFull);
+            DeleteObject(hbmFull);
+            DeleteDC(hdcFull);
+            ReleaseDC(IntPtr.Zero, hdcScreen);
+        }
+    }
+
+    /// <summary>
+    /// StretchBlt a source DC region into a thumbnail-sized bitmap (HALFTONE for
+    /// legible downscaling) and read the pixels back as top-down 32-bit BGRA.
+    /// </summary>
+    private static ThumbnailImage? ScaleAndRead(
+        IntPtr hdcSrc, int srcX, int srcY, int srcW, int srcH, int maxPixel)
+    {
+        double scale = Math.Min(1.0, (double)maxPixel / Math.Max(srcW, srcH));
+        int tw = Math.Max(1, (int)(srcW * scale));
+        int th = Math.Max(1, (int)(srcH * scale));
+
+        var hdcScreen = GetDC(IntPtr.Zero);
+        if (hdcScreen == IntPtr.Zero) return null;
+        var hdcMem = CreateCompatibleDC(hdcScreen);
+        var hbm = CreateCompatibleBitmap(hdcScreen, tw, th);
+        var old = SelectObject(hdcMem, hbm);
+        try
+        {
+            SetStretchBltMode(hdcMem, HALFTONE);
+            SetBrushOrgEx(hdcMem, 0, 0, IntPtr.Zero);
+            if (!StretchBlt(hdcMem, 0, 0, tw, th, hdcSrc, srcX, srcY, srcW, srcH, SRCCOPY))
+                return null;
+
+            var bmi = new BITMAPINFOHEADER
+            {
+                biSize = Marshal.SizeOf<BITMAPINFOHEADER>(),
+                biWidth = tw,
+                biHeight = -th,   // negative = top-down rows
+                biPlanes = 1,
+                biBitCount = 32,
+                biCompression = 0, // BI_RGB
+            };
+            var pixels = new byte[tw * th * 4];
+            // GetDIBits requires the bitmap to be unselected from its DC.
+            SelectObject(hdcMem, old);
+            if (GetDIBits(hdcMem, hbm, 0, (uint)th, pixels, ref bmi, DIB_RGB_COLORS) == 0)
+                return null;
+            return new ThumbnailImage(pixels, tw, th);
+        }
+        finally
+        {
+            SelectObject(hdcMem, old);
+            DeleteObject(hbm);
+            DeleteDC(hdcMem);
+            ReleaseDC(IntPtr.Zero, hdcScreen);
+        }
+    }
+
+    private const int HALFTONE = 4;
+    private const uint SRCCOPY_RASTER = 0x00CC0020;
+    private const int SRCCOPY = unchecked((int)SRCCOPY_RASTER);
+    private const uint PW_RENDERFULLCONTENT = 0x00000002;
+    private const uint DIB_RGB_COLORS = 0;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct BITMAPINFOHEADER
+    {
+        public int biSize, biWidth, biHeight;
+        public short biPlanes, biBitCount;
+        public int biCompression, biSizeImage, biXPelsPerMeter, biYPelsPerMeter,
+                   biClrUsed, biClrImportant;
+    }
+
+    [DllImport("gdi32.dll", CharSet = CharSet.Unicode)]
+    private static extern IntPtr CreateDC(string? lpszDriver, string lpszDevice, string? lpszOutput, IntPtr lpInitData);
+    [DllImport("gdi32.dll")] private static extern bool DeleteDC(IntPtr hdc);
+    [DllImport("gdi32.dll")] private static extern IntPtr CreateCompatibleDC(IntPtr hdc);
+    [DllImport("gdi32.dll")] private static extern IntPtr CreateCompatibleBitmap(IntPtr hdc, int cx, int cy);
+    [DllImport("gdi32.dll")] private static extern IntPtr SelectObject(IntPtr hdc, IntPtr h);
+    [DllImport("gdi32.dll")] private static extern bool DeleteObject(IntPtr ho);
+    [DllImport("gdi32.dll")] private static extern int SetStretchBltMode(IntPtr hdc, int mode);
+    [DllImport("gdi32.dll")] private static extern bool SetBrushOrgEx(IntPtr hdc, int x, int y, IntPtr lppt);
+    [DllImport("gdi32.dll")]
+    private static extern bool StretchBlt(IntPtr hdcDest, int xDest, int yDest, int wDest, int hDest,
+                                          IntPtr hdcSrc, int xSrc, int ySrc, int wSrc, int hSrc, int rop);
+    [DllImport("gdi32.dll")]
+    private static extern int GetDIBits(IntPtr hdc, IntPtr hbm, uint start, uint cLines,
+                                        byte[] lpvBits, ref BITMAPINFOHEADER lpbmi, uint usage);
+    [DllImport("user32.dll")] private static extern IntPtr GetDC(IntPtr hWnd);
+    [DllImport("user32.dll")] private static extern int ReleaseDC(IntPtr hWnd, IntPtr hDC);
+    [DllImport("user32.dll")] private static extern bool PrintWindow(IntPtr hwnd, IntPtr hDC, uint nFlags);
+
     // MARK: - Display/window metadata (Win32)
     //
     // These use plain user32 P/Invoke rather than ScreenRecorderLib properties so
@@ -326,7 +498,11 @@ public sealed class VideoCapture
         catch { /* best effort */ }
         finally
         {
-            try { rec.Dispose(); } catch { }
+            // Dispose on a worker: a recorder whose session never completed can
+            // BLOCK inside Dispose, and this method's caller (StopVideo) still
+            // has END_VIDEO to send — a hang here silently loses the recording
+            // server-side even though every byte was already delivered.
+            _ = Task.Run(() => { try { rec.Dispose(); } catch { } });
             _stream?.Dispose();
             _stream = null;
         }
@@ -380,35 +556,72 @@ public sealed class VideoCapture
 }
 
 /// <summary>
-/// A write-only Stream that forwards every write to a callback (the video
-/// socket send). ScreenRecorderLib writes fragmented-MP4 bytes here as they are
-/// encoded, so nothing is staged to disk on the client. Reads/seeks are not
-/// supported (the encoder only writes).
+/// A Stream that forwards appended bytes to a callback (the video socket send).
+/// ScreenRecorderLib writes fragmented-MP4 bytes here as they are encoded, so
+/// nothing is staged to disk on the client.
+///
+/// MUST claim CanSeek: the Media Foundation MPEG4 sink underneath
+/// ScreenRecorderLib checks the target stream's capabilities and, given a
+/// non-seekable stream, silently produces NOTHING — Record() reports
+/// Recording→Finishing with zero writes and no OnRecordingFailed, and the
+/// recorder never completes (Dispose then wedges, which also blocked the
+/// END_VIDEO send). Verified against ScreenRecorderLib 6.2.0.
+///
+/// Seekability creates one wrinkle: at Stop the sink seeks BACK once into the
+/// already-written header to patch the mvhd duration, then seeks forward again.
+/// Bytes already sent over the socket can't be rewritten, so only writes that
+/// extend past the high-water mark are forwarded (the tail of a partially
+/// overlapping write). Dropping the patch is safe for fragmented MP4: players
+/// take timing from the moof fragments, and a zero header duration is exactly
+/// what live fMP4 streams (including the macOS client's) look like.
 /// </summary>
 internal sealed class CallbackStream : Stream
 {
     private readonly Action<byte[]> _onWrite;
     private long _position;
+    private long _length;      // high-water mark = bytes forwarded so far
 
     public CallbackStream(Action<byte[]> onWrite) { _onWrite = onWrite; }
 
     public override bool CanRead => false;
-    public override bool CanSeek => false;
+    public override bool CanSeek => true;
     public override bool CanWrite => true;
-    public override long Length => _position;
-    public override long Position { get => _position; set { } }
+    public override long Length => _length;
+    public override long Position { get => _position; set => _position = value; }
 
     public override void Write(byte[] buffer, int offset, int count)
     {
         if (count <= 0) return;
-        var chunk = new byte[count];
-        Buffer.BlockCopy(buffer, offset, chunk, 0, count);
-        _position += count;
-        _onWrite(chunk);
+        long end = _position + count;
+        if (end > _length)
+        {
+            // Forward only the portion beyond what has already been sent. For
+            // normal appends (_position == _length) that is the whole write.
+            // Clamped: a (never-observed) seek PAST the end would make the raw
+            // difference negative and over-read the buffer.
+            int skip = (int)Math.Clamp(_length - _position, 0, count);
+            var chunk = new byte[count - skip];
+            Buffer.BlockCopy(buffer, offset + skip, chunk, 0, chunk.Length);
+            _onWrite(chunk);
+            _length = end;
+        }
+        // else: entirely inside already-sent bytes (the stop-time header patch)
+        // — drop it; the socket stream is append-only.
+        _position = end;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        _position = origin switch
+        {
+            SeekOrigin.Begin => offset,
+            SeekOrigin.Current => _position + offset,
+            _ => _length + offset,
+        };
+        return _position;
     }
 
     public override void Flush() { }
     public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
-    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
-    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void SetLength(long value) { /* sink pre-sizing hint — nothing to allocate */ }
 }


### PR DESCRIPTION
## Problem 1: screen video recorded nothing (Windows)

A Windows recording with **"Also record screen video"** enabled produced a meeting with audio but **no video**. The transcriber logs for the failing call show the shape of the failure precisely:

```
21:58:09 [START_VIDEO]: [test windows - ...] - Video recording started (offsetMs=0)
22:00:28 [VIDEO]: - Audio ended 120000ms ago and END_VIDEO never arrived; finalizing video now.
22:00:28 [END_VIDEO]: - Video session ended with no recorded data; cleaning up.
```

START_VIDEO arrived, **zero video bytes** followed, and **END_VIDEO never came**. (A macOS session in the same log streamed 263 MB and muxed fine -- server side is healthy.)

### Root cause

Isolated with a standalone ScreenRecorderLib 6.2.0 harness, one recorder configuration per fresh process: the **Media Foundation MPEG4 sink checks the target stream's capabilities, and given a non-seekable stream it silently produces nothing** -- `Record()` reports `Recording->Finishing`, zero writes, **no `OnRecordingFailed`**, and the session never completes (`Dispose` then wedges -- which is also what swallowed END_VIDEO, since `StopVideo` awaits `StopAsync` before sending it).

Our `CallbackStream` declared `CanSeek=false` and threw from `Seek()`. The matrix:

| Target stream | Result |
|---|---|
| File path | OK - bytes |
| `MemoryStream` | OK - bytes |
| Non-seekable stream (**shipped code**) -- any combo of frame size / hw / sw encoder / fragmented / low-latency | **0 bytes, no error** |
| Same stream claiming `CanSeek=true` | OK - bytes |

Only the stream-to-socket path was dead -- exactly the LMA symptom.

### Fix

`CallbackStream` now claims `CanSeek` with bookkeeping-only `Seek`/`Position`. Instrumentation shows the sink seeks **backward exactly once, at Stop**, to patch the `mvhd` duration in the already-written header; those bytes are long gone over the websocket, so overlapping writes are clipped to the portion past the high-water mark and pure-rewrite writes are dropped. Safe for fragmented MP4: players take timing from the `moof` fragments, and a zero header duration is what every live fMP4 stream (including the macOS client's) looks like.

Also moved `Recorder.Dispose` off the stop path onto a worker so a wedged recorder can never again block the END_VIDEO send (defense in depth).

**Verified** with a harness replicating the exact production options + the fixed `CallbackStream`: 80 chunks / 10,877 bytes forwarded, `ftyp` first box, 25 `moof`+`mdat` pairs, exactly 1 dropped header-patch write, `OnRecordingComplete` fires.

## Problem 2: no thumbnails in the source picker (macOS parity)

The macOS client's video source picker shows a live preview of each screen/window; the Windows picker showed only a glyph + name + resolution. Per the macOS code's own rationale: with two identical monitors a name alone can't distinguish them, and recording the wrong screen is a privacy problem.

### Implementation

- `VideoCapture.Thumbnail(sourceId)` (engine): one-shot preview via plain GDI -- `CreateDC`/`StretchBlt` for displays, `PrintWindow(PW_RENDERFULLCONTENT)` for windows so Chromium/Electron/UWP surfaces render. GDI rather than ScreenRecorderLib because a dropdown must not spin up 12 encoder sessions, and GDI needs no permission on Windows. Returns raw BGRA so the engine stays UI-agnostic.
- `PanelView` (app): converts to a **Bgr32** `BitmapSource` (GDI leaves alpha 0 -- Bgra32 would render invisible) and fills each row's 44x28 preview slot **asynchronously, sequentially, capped at 12, generation-checked** -- mirroring the macOS `loadThumbnails` design. Grey placeholder until a preview lands; a missing preview never blocks choosing a source.

**Verified** by driving the real `ListSources`+`Thumbnail` on a live desktop: 11/11 sources produced correct previews (PNGs visually inspected -- display wallpaper, Chrome window content, etc.).

## Testing

- `dotnet build` clean (0 warnings / 0 errors); `./build-windows.ps1 -SelfContained` passes the SRP self-test (11/11 KATs).
- Both fixes validated with standalone harnesses as above.
- **Not run:** a full end-to-end meeting against a live stack from this exact build -- the prior E2E failure was reproduced and root-caused offline with the same library, options, and stream implementation. Recommend one Windows smoke recording with video after merge/redeploy.

## Docs

`docs/desktop-capture-app.md` Windows settings section updated to mention thumbnail previews.