### PR TITLE
fix(vp): cap Transcribe audio frames and retry framing errors

### DIFF
--- a/lma-virtual-participant-stack/backend/src/scribe-audio-framing.test.ts
+++ b/lma-virtual-participant-stack/backend/src/scribe-audio-framing.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2025 Amazon.com
+ * This file is licensed under the MIT License.
+ * See the LICENSE file in the project root for full license information.
+ */
+
+/**
+ * Regression tests for GitHub #536.
+ *
+ * A live Zoom meeting stopped transcribing 75 seconds in and never recovered.
+ * ffmpeg handed over an audio buffer larger than Amazon Transcribe accepts, and
+ * the resulting BadRequestException matched the "non-retryable configuration
+ * error" predicate — so the retry loop broke out permanently while the VP stayed
+ * ACTIVE, showing no sign of trouble in the UI.
+ */
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import {
+    frameAudioChunk,
+    isTransientFramingError,
+    MAX_AUDIO_CHUNK_BYTES,
+} from './scribe.js';
+
+test('the frame cap is well under the service limit but still a useful size', () => {
+    // 16 KB = 512 ms at 16 kHz mono PCM16. Small enough to be safely accepted,
+    // large enough that per-frame overhead stays negligible.
+    assert.equal(MAX_AUDIO_CHUNK_BYTES, 16 * 1024);
+});
+
+test('a buffer within the limit is passed through unchanged and uncopied', () => {
+    // The common case must cost nothing: same object identity, not a copy.
+    const chunk = Buffer.alloc(1024, 7);
+    const frames = frameAudioChunk(chunk);
+    assert.equal(frames.length, 1);
+    assert.equal(frames[0], chunk);
+});
+
+test('a buffer exactly at the limit is not split', () => {
+    const chunk = Buffer.alloc(MAX_AUDIO_CHUNK_BYTES, 1);
+    assert.equal(frameAudioChunk(chunk).length, 1);
+});
+
+test('an oversized buffer is split into frames within the limit', () => {
+    const chunk = Buffer.alloc(MAX_AUDIO_CHUNK_BYTES * 3 + 123, 9);
+    const frames = frameAudioChunk(chunk);
+    assert.equal(frames.length, 4);
+    for (const frame of frames) {
+        assert.ok(
+            frame.length <= MAX_AUDIO_CHUNK_BYTES,
+            `frame of ${frame.length} exceeds the cap`,
+        );
+    }
+});
+
+test('splitting loses no audio and preserves byte order', () => {
+    // This is the property that matters: dropping the overflow would silently
+    // lose speech, and reordering would corrupt the transcript.
+    const chunk = Buffer.alloc(MAX_AUDIO_CHUNK_BYTES * 2 + 500);
+    for (let i = 0; i < chunk.length; i += 1) chunk[i] = i % 251;
+    const rejoined = Buffer.concat(frameAudioChunk(chunk));
+    assert.equal(rejoined.length, chunk.length, 'no bytes may be dropped');
+    assert.ok(rejoined.equals(chunk), 'bytes must be forwarded in order');
+});
+
+test('an empty buffer yields a single empty frame rather than nothing', () => {
+    assert.deepEqual(frameAudioChunk(Buffer.alloc(0)).length, 1);
+});
+
+test('the exact Transcribe message from the incident is treated as transient', () => {
+    // Verbatim from the failing meeting's logs.
+    assert.equal(
+        isTransientFramingError({
+            message: 'Your stream is too big. Reduce the frame size and try your request again.',
+        }),
+        true,
+    );
+});
+
+test('framing-error detection is case-insensitive and matches either phrase', () => {
+    assert.equal(isTransientFramingError({ message: 'STREAM IS TOO BIG' }), true);
+    assert.equal(isTransientFramingError({ message: 'please Reduce The Frame Size' }), true);
+});
+
+test('genuine configuration errors are NOT treated as transient', () => {
+    // These must keep aborting: retrying a bad language configuration would spin
+    // for the whole meeting without ever succeeding.
+    for (const message of [
+        'The language code provided is not valid',
+        'LanguageOptions must contain at least two languages',
+        'validation error detected: Value null at LanguageCode failed to satisfy constraint',
+        '',
+    ]) {
+        assert.equal(
+            isTransientFramingError({ message }),
+            false,
+            `"${message}" must not be classified as transient`,
+        );
+    }
+});
+
+test('a missing or malformed error object does not throw', () => {
+    assert.equal(isTransientFramingError({}), false);
+    assert.equal(isTransientFramingError(undefined as unknown as { message: string }), false);
+});

--- a/lma-virtual-participant-stack/backend/src/scribe.ts
+++ b/lma-virtual-participant-stack/backend/src/scribe.ts
@@ -16,6 +16,57 @@ let currentSpeaker = "none";
 // Local testing mode - skip AWS services
 const isLocalTest = process.env.LOCAL_TEST === 'true';
 
+/**
+ * Maximum bytes per Transcribe `AudioChunk`.
+ *
+ * ffmpeg's stdout is consumed with `for await`, so the buffer size is whatever
+ * Node's opportunistic read happens to return — not a fixed frame. When the read
+ * loop stalls briefly (CPU pressure from Chromium + avatar + video recording) a
+ * burst of audio accumulates and the next read can exceed Transcribe's per-frame
+ * limit. The request is then rejected with "Your stream is too big. Reduce the
+ * frame size and try your request again." and, before this fix, transcription
+ * aborted for the rest of the meeting (GitHub #536).
+ *
+ * 16 KB = 512 ms at 16 kHz mono PCM16 (16000 * 2 bytes/s). Comfortably under the
+ * service limit while keeping frames large enough not to add per-frame overhead.
+ */
+export const MAX_AUDIO_CHUNK_BYTES = 16 * 1024;
+
+/**
+ * Split a PCM buffer into frames no larger than `maxBytes`.
+ *
+ * Slices rather than drops: every byte is forwarded, in order, so no audio is
+ * lost. Buffers already within the limit are passed through as-is (no copy), so
+ * the common case costs nothing.
+ */
+export function frameAudioChunk(
+    chunk: Buffer,
+    maxBytes: number = MAX_AUDIO_CHUNK_BYTES,
+): Buffer[] {
+    if (chunk.length <= maxBytes) return [chunk];
+    const frames: Buffer[] = [];
+    for (let offset = 0; offset < chunk.length; offset += maxBytes) {
+        frames.push(chunk.subarray(offset, Math.min(offset + maxBytes, chunk.length)));
+    }
+    return frames;
+}
+
+/**
+ * True when a Transcribe error is a transient framing/throughput complaint
+ * rather than a permanent misconfiguration.
+ *
+ * "Your stream is too big" arrives as a BadRequestException, which the
+ * non-retryable predicate would otherwise treat as a fatal configuration error —
+ * aborting the meeting's transcription and logging a message about
+ * TRANSCRIBE_LANGUAGE_CODE that has nothing to do with the actual failure.
+ * Reconnecting is both correct and safe: the retry path already preserves the
+ * transcript timeline via transcribeTimeOffsetSeconds (GitHub #292).
+ */
+export function isTransientFramingError(error: { message?: string }): boolean {
+    const message = error?.message || '';
+    return /stream is too big|reduce the frame size/i.test(message);
+}
+
 // True when a Transcribe streaming error indicates the SessionId we tried to
 // resume is no longer valid (expired / closed / unknown), so the next attempt
 // must start a fresh session rather than reuse the stale id. Kept in sync with
@@ -134,12 +185,17 @@ export class TranscriptionService {
 
         try {
             for await (const chunk of this.process.stdout!) {
-                if (!details.start) {
-                    yield {
-                        AudioEvent: { AudioChunk: Buffer.alloc(chunk.length) },
-                    };
-                } else {
-                    yield { AudioEvent: { AudioChunk: chunk } };
+                // Cap the frame size (see MAX_AUDIO_CHUNK_BYTES). ffmpeg can hand
+                // over a buffer larger than Transcribe accepts, which used to
+                // abort transcription for the rest of the meeting (GitHub #536).
+                for (const frame of frameAudioChunk(chunk)) {
+                    if (!details.start) {
+                        // Before the meeting starts, send silence of the same
+                        // length so the stream stays open without capturing audio.
+                        yield { AudioEvent: { AudioChunk: Buffer.alloc(frame.length) } };
+                    } else {
+                        yield { AudioEvent: { AudioChunk: frame } };
+                    }
                 }
                 if (!this.startTime) {
                     this.startTime = Date.now();
@@ -373,13 +429,19 @@ export class TranscriptionService {
                 // nosemgrep: javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring -- ECMAScript template literals do not interpret util.format specifiers
                 console.error(`Transcription error (consecutive failure ${consecutiveFailures + 1}/${maxRetries}):`, error.message);
 
+                // A framing/throughput complaint is transient, so it must be
+                // checked FIRST: "Your stream is too big" is a
+                // BadRequestException with httpStatusCode 400 and would otherwise
+                // match every clause below, aborting the meeting's transcription
+                // and blaming the language configuration (GitHub #536).
                 const isNonRetryable =
-                    error.name === 'BadRequestException' ||
-                    error.name === 'ValidationException' ||
-                    error.name === 'InvalidParameterException' ||
-                    error.$metadata?.httpStatusCode === 400 ||
-                    error.message?.includes('validation error') ||
-                    error.message?.includes('non-retryable streaming request');
+                    !isTransientFramingError(error) &&
+                    (error.name === 'BadRequestException' ||
+                        error.name === 'ValidationException' ||
+                        error.name === 'InvalidParameterException' ||
+                        error.$metadata?.httpStatusCode === 400 ||
+                        error.message?.includes('validation error') ||
+                        error.message?.includes('non-retryable streaming request'));
 
                 // If the resumed SessionId is no longer valid (expired / closed /
                 // not found / invalid), clear it so the next retry starts a FRESH
@@ -405,9 +467,19 @@ export class TranscriptionService {
                 this.teardownSessionProcesses();
 
                 if (isNonRetryable) {
+                    // Only mention the language settings when the error is
+                    // plausibly about them. Pointing at TRANSCRIBE_LANGUAGE_* for
+                    // every 400 sent a real investigation down the wrong path
+                    // (GitHub #536): the failing request was an oversized audio
+                    // frame and the language configuration was correct.
+                    const looksLanguageRelated = /language|vocabulary|LanguageCode|LanguageOptions/i.test(
+                        error.message || '',
+                    );
                     console.error(
-                        'Non-retryable Transcribe configuration error — aborting without further retries. ' +
-                        'Check TRANSCRIBE_LANGUAGE_CODE / TRANSCRIBE_LANGUAGE_OPTIONS / TRANSCRIBE_PREFERRED_LANGUAGE.',
+                        `Non-retryable Transcribe error — aborting without further retries: ${error.message}` +
+                            (looksLanguageRelated
+                                ? ' Check TRANSCRIBE_LANGUAGE_CODE / TRANSCRIBE_LANGUAGE_OPTIONS / TRANSCRIBE_PREFERRED_LANGUAGE.'
+                                : ''),
                     );
                     break;
                 }


### PR DESCRIPTION
Fixes #536.

## The failure

A live Zoom meeting stopped transcribing 75 seconds in and never recovered. The VP stayed `ACTIVE` and kept recording video, so nothing surfaced in the UI — the user assumed their headset was at fault.

```
13:17:28Z  Starting new transcription session with language: en-US
13:17      [13:17] Speaker changed to: Bob Strahan        <- audio WAS working
13:18:43Z  Handle transcript events error (retryable): Your stream is too big.
           Reduce the frame size and try your request again.
13:18:43Z  Non-retryable Transcribe configuration error — aborting without further
           retries. Check TRANSCRIBE_LANGUAGE_CODE / TRANSCRIBE_LANGUAGE_OPTIONS / ...
```

Note the contradiction: line 1 classifies the error `(retryable)`, then it aborts as non-retryable.

## Two bugs, both in shared `scribe.ts`

**1. No cap on `AudioChunk` size.** ffmpeg's stdout was consumed with `for await` and forwarded verbatim, so the frame size was whatever Node's opportunistic read returned — not a fixed frame. When the read loop stalls briefly, a burst of audio accumulates and the next read can exceed Transcribe's per-frame limit.

`frameAudioChunk()` slices oversized buffers into ≤16 KB frames (512 ms at 16 kHz mono PCM16). It **slices rather than drops**, so no audio is lost and byte order is preserved. Buffers already within the limit pass through with no copy, so the common case costs nothing.

**2. The error was misclassified as fatal.** `"Your stream is too big"` arrives as a `BadRequestException` with `httpStatusCode: 400` — matching *every* clause of the `isNonRetryable` predicate. It hit the `break` and skipped the entire retry path below it. The message then blamed `TRANSCRIBE_LANGUAGE_CODE`, which is actively misleading: the language configuration was correct and irrelevant.

`isTransientFramingError()` is now checked **first** and short-circuits the predicate, so the error flows into the existing reconnect path.

## No new timestamp logic was needed

The reconnect machinery from #292 already preserves the transcript timeline:

- `transcribeTimeOffsetSeconds` is advanced exactly once per session inside a `finally`, so it is **already correct on the error path**
- `handleTranscriptEvents` adds it to every word timestamp, so segments continue the meeting timeline instead of restarting at 0
- `consecutiveFailures` counts only *consecutive* failures, so a long meeting is not aborted by transient reconnects spread across it

Reclassifying the error is therefore sufficient for correct recovery.

## Also

The abort message now includes the actual error text and only mentions the language settings when the error is plausibly language-related.

## Testing

10 new tests (76 total, up from 66):

- the **verbatim** message from the incident is classified transient
- splitting loses no bytes and preserves order (the property that matters — dropping the overflow would silently lose speech)
- a buffer within the limit is passed through **uncopied** (same object identity)
- genuine language-configuration errors still abort rather than spinning for the whole meeting

**Verified the tests fail against the original code:** reverting both fixes produces 3 failures, and restoring them returns 76/76.

## Scope note

This is shared code, so all three launch types are affected. It may be easier to trigger on `MICROVM`, where a 2-vCPU VM runs Chromium + avatar + video recording concurrently and is more likely to stall the read loop — but I have **not** confirmed that against ECS, so I'm not claiming it as MicroVM-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
