### PR TITLE
fix(vp): pin the audio pipeline to 16 kHz mono to stop 3x resampling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,7 +337,7 @@ test-vp-template: ## Static tests on the VP template + MicroVM client (no AWS)
 	@echo "Running Virtual Participant template + MicroVM client tests..."
 	$(PYTHON) -m pytest $(VP_DIR)/test/test_vp_template.py $(VP_DIR)/test/test_microvm_client.py \
 		$(VP_DIR)/test/test_ai_stack_vnc_alb.py $(VP_DIR)/test/test_microvm_manager.py \
-		$(VP_DIR)/test/test_microvm_vnc_token.py -q
+		$(VP_DIR)/test/test_microvm_vnc_token.py $(VP_DIR)/test/test_audio_sample_rates.py -q
 	@echo -e "$(GREEN)✅ Virtual Participant template tests passed!$(NC)"
 
 test-ui-force: ## Run React UI tests (ignore checksum, always run)

--- a/lma-virtual-participant-stack/backend/Dockerfile
+++ b/lma-virtual-participant-stack/backend/Dockerfile
@@ -81,7 +81,31 @@ EXPOSE 5900 5901 9000
 
 RUN chmod +x /srv/entrypoint.sh
 RUN useradd -m -d /home/appuser -s /bin/bash appuser
-RUN chown -R appuser:appuser /srv /opt/cloakbrowser
+
+# Pin PulseAudio to the pipeline's native format: 16 kHz mono.
+#
+# PulseAudio's compiled default is 48 kHz stereo, and every stage of the VP audio
+# path is 16 kHz mono PCM16 (Nova Sonic in and out, Transcribe, the pacat
+# playback streams). With the default, Nova's voice was resampled 16k->48k into
+# agent_output, again through the loopback into combined_audio, and again through
+# module-remap-source into Chromium's virtual mic — three conversions before the
+# meeting heard it, which made the assistant sound warbly (GitHub #538).
+#
+# resample-method: PulseAudio defaults to speex-float-1, tuned for speed. Any
+# residual conversion should favour quality; speex-float-5 is still cheap.
+# Written as the appuser's own config since the daemon runs as that user.
+RUN mkdir -p /home/appuser/.config/pulse && \
+    printf '%s\n' \
+      'default-sample-rate = 16000' \
+      'alternate-sample-rate = 16000' \
+      'default-sample-channels = 1' \
+      'default-sample-format = s16le' \
+      'resample-method = speex-float-5' \
+      'avoid-resampling = yes' \
+      'flat-volumes = no' \
+      > /home/appuser/.config/pulse/daemon.conf
+
+RUN chown -R appuser:appuser /srv /opt/cloakbrowser /home/appuser/.config
 USER appuser
 
 # Default entrypoint stays entrypoint.sh so ECS (EC2/FARGATE) behaviour is

--- a/lma-virtual-participant-stack/backend/entrypoint.sh
+++ b/lma-virtual-participant-stack/backend/entrypoint.sh
@@ -173,15 +173,18 @@ sleep 2
 echo "Creating PulseAudio audio routing for meeting and agent..."
 
 # Create a null sink for meeting audio (Chromium output)
-MEETING_SINK=$(pactl load-module module-null-sink sink_name=meeting_audio sink_properties=device.description="Meeting_Audio")
+# rate/channels are pinned on every sink: a null sink otherwise adopts the
+# daemon default (48 kHz stereo), and each 16 kHz mono stream would then be
+# resampled on the way in AND on the way out (GitHub #538).
+MEETING_SINK=$(pactl load-module module-null-sink sink_name=meeting_audio rate=16000 channels=1 format=s16le sink_properties=device.description="Meeting_Audio")
 echo "Created meeting_audio sink (module $MEETING_SINK)"
 
 # Create a null sink for agent audio output (Nova/ElevenLabs)
-AGENT_SINK=$(pactl load-module module-null-sink sink_name=agent_output sink_properties=device.description="Agent_Audio_Output")
+AGENT_SINK=$(pactl load-module module-null-sink sink_name=agent_output rate=16000 channels=1 format=s16le sink_properties=device.description="Agent_Audio_Output")
 echo "Created agent_output sink (module $AGENT_SINK)"
 
 # Create a combined sink that mixes meeting + agent audio for transcription
-COMBINED_SINK=$(pactl load-module module-null-sink sink_name=combined_audio sink_properties=device.description="Combined_Audio_For_Transcription")
+COMBINED_SINK=$(pactl load-module module-null-sink sink_name=combined_audio rate=16000 channels=1 format=s16le sink_properties=device.description="Combined_Audio_For_Transcription")
 echo "Created combined_audio sink (module $COMBINED_SINK)"
 
 # 20ms latency: 1ms caused underruns on smaller instances.
@@ -205,6 +208,18 @@ echo "✓ Audio routing configured"
 echo "PulseAudio Devices:"
 echo "--- Sinks ---"
 pactl list short sinks
+
+# Assert the sinks really are 16 kHz mono. `pactl list short sinks` prints the
+# sample spec, so a regression here (e.g. a sink created without rate=) shows up
+# as a loud warning instead of only as degraded voice-assistant audio quality
+# that takes a live meeting to notice (GitHub #538).
+if pactl list short sinks | grep -qE 's16le[[:space:]]+1ch[[:space:]]+16000Hz'; then
+    echo "✓ Audio sinks are 16 kHz mono — no resampling in the Nova/Transcribe path"
+else
+    echo "⚠️  WARNING: audio sinks are NOT 16 kHz mono. Nova audio will be resampled" >&2
+    echo "    (warbly voice assistant). Expected 's16le 1ch 16000Hz'; got:" >&2
+    pactl list short sinks >&2
+fi
 echo "--- Sources ---"
 pactl list short sources
 

--- a/lma-virtual-participant-stack/test/test_audio_sample_rates.py
+++ b/lma-virtual-participant-stack/test/test_audio_sample_rates.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2025 Amazon.com
+# This file is licensed under the MIT License.
+# See the LICENSE file in the project root for full license information.
+"""Static tests that the VP audio path is 16 kHz mono end to end (GitHub #538).
+
+The voice assistant sounded warbly in a live Teams meeting. ffmpeg reported the
+PulseAudio sinks as `48000 Hz, stereo` while every stage of the pipeline — Nova
+Sonic input and output, Transcribe, and the pacat playback streams — is 16 kHz
+mono PCM16. PulseAudio's compiled default is 48 kHz stereo and the null sinks were
+created without a rate, so they inherited it.
+
+Nova's voice was therefore resampled at least three times before the meeting heard
+it:
+
+    Nova 16k -> agent_output (48k)          <- resample 1
+    agent_output.monitor -> combined_audio  <- resample 2 (loopback)
+    agent_output.monitor -> agent_mic       <- resample 3 (remap-source)
+
+Cumulative interpolation on a 3x upsample is audible as warble, with no gaps
+because the timing was never the problem. Transcription was unaffected in quality
+because speech recognition tolerates resampling far better than a human ear.
+
+These assertions are cheap and catch the regression at commit time rather than
+requiring a live meeting and someone listening carefully.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+BACKEND = Path(__file__).resolve().parents[1] / "backend"
+ENTRYPOINT = BACKEND / "entrypoint.sh"
+DOCKERFILE = BACKEND / "Dockerfile"
+
+# The pipeline's native format. Nova Sonic's audioInput/audioOutputConfiguration
+# both declare sampleRateHertz 16000, channelCount 1, sampleSizeBits 16.
+PIPELINE_RATE = "16000"
+
+
+@pytest.fixture(scope="module")
+def entrypoint() -> str:
+    return ENTRYPOINT.read_text()
+
+
+@pytest.fixture(scope="module")
+def dockerfile() -> str:
+    return DOCKERFILE.read_text()
+
+
+def _null_sink_lines(entrypoint: str) -> list[str]:
+    return [
+        line.strip()
+        for line in entrypoint.splitlines()
+        if "module-null-sink" in line and not line.strip().startswith("#")
+    ]
+
+
+def test_all_three_null_sinks_are_created(entrypoint: str) -> None:
+    """meeting_audio, agent_output and combined_audio."""
+    lines = _null_sink_lines(entrypoint)
+    assert len(lines) == 3, f"expected 3 null sinks, found {len(lines)}"
+    names = {re.search(r"sink_name=(\w+)", line).group(1) for line in lines}
+    assert names == {"meeting_audio", "agent_output", "combined_audio"}
+
+
+def test_every_null_sink_pins_rate_and_channels(entrypoint: str) -> None:
+    """A sink without rate= adopts the daemon default (48 kHz stereo).
+
+    That is the specific defect behind #538: the sink format silently disagreed
+    with every producer and consumer attached to it.
+    """
+    for line in _null_sink_lines(entrypoint):
+        name = re.search(r"sink_name=(\w+)", line).group(1)
+        assert f"rate={PIPELINE_RATE}" in line, f"{name} does not pin rate={PIPELINE_RATE}"
+        assert "channels=1" in line, f"{name} does not pin channels=1"
+        assert "format=s16le" in line, f"{name} does not pin format=s16le"
+
+
+def test_daemon_config_pins_the_pipeline_format(dockerfile: str) -> None:
+    """Belt and braces alongside the per-sink settings.
+
+    Pinning the daemon covers anything that creates a stream without an explicit
+    spec — including PulseAudio's own internal paths.
+    """
+    assert f"default-sample-rate = {PIPELINE_RATE}" in dockerfile
+    # alternate-sample-rate is what PulseAudio switches to for streams that do
+    # not match the default; leaving it at 44100 would reintroduce a resample.
+    assert f"alternate-sample-rate = {PIPELINE_RATE}" in dockerfile
+    assert "default-sample-channels = 1" in dockerfile
+
+
+def test_resampler_favours_quality_over_speed(dockerfile: str) -> None:
+    """PulseAudio defaults to speex-float-1, tuned for speed.
+
+    Any residual conversion should not add avoidable artifacts to speech.
+    """
+    # The Dockerfile writes these via printf, so each line is single-quoted.
+    match = re.search(r"resample-method = ([a-z0-9-]+)", dockerfile)
+    assert match, "resample-method should be set explicitly"
+    method = match.group(1)
+    assert method != "speex-float-1", "the speed-tuned default is not appropriate here"
+    assert method.startswith("speex-float-"), f"unexpected resampler {method}"
+    assert int(method.rsplit("-", 1)[1]) >= 3, "quality level should be >= 3"
+
+
+def test_avoid_resampling_is_enabled(dockerfile: str) -> None:
+    """Makes PulseAudio follow the stream's rate instead of converting."""
+    assert "avoid-resampling = yes" in dockerfile
+
+
+def test_daemon_config_is_owned_by_the_running_user(dockerfile: str) -> None:
+    """The daemon runs as appuser, so the config must be readable by it.
+
+    A root-owned file in /home/appuser/.config would be silently ignored and the
+    48 kHz default would come straight back.
+    """
+    assert "/home/appuser/.config/pulse/daemon.conf" in dockerfile
+    chown = re.search(r"chown -R appuser:appuser ([^\n]+)", dockerfile)
+    assert chown, "expected a chown for appuser"
+    assert "/home/appuser/.config" in chown.group(1)
+
+
+def test_entrypoint_warns_if_the_sinks_are_not_16k_mono(entrypoint: str) -> None:
+    """A regression should be loud in the logs, not merely audible.
+
+    Without this, the only symptom is degraded voice-assistant quality that takes
+    a live meeting and attentive listening to notice.
+    """
+    assert "16000Hz" in entrypoint
+    assert "WARNING" in entrypoint
+    # Must write the warning to stderr so it is not lost among routine output.
+    assert re.search(r"WARNING: audio sinks are NOT 16 kHz mono.*>&2", entrypoint)
+
+
+def test_pacat_streams_use_the_pipeline_rate() -> None:
+    """The playback/capture streams either side of the sinks must agree.
+
+    nova-agent.ts plays Nova's output into agent_output and scribe.ts pipes
+    meeting audio into combined_audio; both must match the sink format or the
+    resample simply moves rather than disappears.
+    """
+    nova = (BACKEND / "src" / "nova-agent.ts").read_text()
+    scribe = (BACKEND / "src" / "scribe.ts").read_text()
+    assert f"NOVA_PLAYBACK_RATE || '{PIPELINE_RATE}'" in nova
+    assert f"'--rate={PIPELINE_RATE}'" in scribe or f"--rate=16000" in scribe


### PR DESCRIPTION
Fixes #538.

## The symptom

The Nova Sonic voice assistant sounds **warbly** — metallic and wavering. Crucially, there are **no gaps or stuttering**, which rules out underruns and points at signal degradation rather than timing.

## The cause: three resamples between Nova and the meeting

ffmpeg, reading a live VP's sink:

```
Stream #1:0: Audio: pcm_s16le, 48000 Hz, stereo, s16, 1536 kb/s
```

But every stage of the pipeline is **16 kHz mono PCM16** — Nova Sonic's declared `audioInputConfiguration` and `audioOutputConfiguration`, its `pacat` playback stream, the Transcribe capture ffmpeg, and the meeting→combined `pacat` pipe.

`entrypoint.sh` starts PulseAudio with no configuration, and there is no `daemon.conf` in the image, so the daemon used its compiled default. The three null sinks were created **without a rate**, so they inherited it:

```
Nova 16k -> agent_output (48k)                 <- resample 1 (3x upsample)
agent_output.monitor -> combined_audio         <- resample 2 (loopback)
agent_output.monitor -> agent_mic -> Chromium  <- resample 3 (remap-source)
```

Cumulative interpolation across those conversions is audible as warble. Timing was never affected — hence no gaps.

**Why the transcript looked fine:** Transcribe gets its own downsample back to 16 kHz, and speech recognition tolerates resampling far better than a human ear. The degradation was inaudible in the transcript while being obvious in the assistant's voice.

## Changes

1. **`daemon.conf`** written to `/home/appuser/.config/pulse/`, pinning `default-sample-rate` / `alternate-sample-rate` (16000), `default-sample-channels` (1), `default-sample-format`, `avoid-resampling`, and `resample-method` — `speex-float-5` rather than PulseAudio's speed-tuned `speex-float-1` default. Owned by `appuser`, since the daemon runs as that user; a root-owned file would be silently ignored and the default would come straight back.

2. **All three `module-null-sink` invocations** now pass `rate=16000 channels=1 format=s16le`. The daemon default alone does not guarantee null-sink format.

3. **A startup assertion** in `entrypoint.sh` that prints a loud warning to stderr if the sinks are not 16 kHz mono — so a regression appears in CloudWatch instead of requiring a live meeting and attentive listening to detect.

`module-loopback` and `module-remap-source` need no change: once source and sink share a format they pass through without conversion.

## Verified, not inferred

Built throwaway Debian containers to confirm both the bug and the fix:

| | `pactl list short sinks` |
|---|---|
| **Without** the fix | `agent_output  s16le 2ch 44100Hz` |
| **With** the fix | `agent_output  s16le 1ch 16000Hz` |

## Testing

8 new tests (95 total) covering per-sink pinning, the daemon config values, the resampler choice, `appuser` ownership, and the startup assertion. **Verified they fail** when the `rate=` arguments are removed.

## Scope

This is shared `entrypoint.sh` / `Dockerfile`, so **EC2 and Fargate are affected identically** — the sinks have always run at the daemon default. Not MicroVM-specific.

## One caveat

The diagnosis is measured (48 kHz sinks feeding a 16 kHz pipeline, reproduced in isolation), but I have **not yet confirmed by ear** that this fully resolves the warble. There could be a second contributor — Teams' own WebRTC encoder, or the `remap-source` path. Worth a listen after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
