### PR TITLE
fix(vp): detect Teams meeting end instead of running to the 8-hour ceiling

### DIFF
--- a/lma-virtual-participant-stack/backend/src/teams-meeting-end.test.ts
+++ b/lma-virtual-participant-stack/backend/src/teams-meeting-end.test.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2025 Amazon.com
+ * This file is licensed under the MIT License.
+ * See the LICENSE file in the project root for full license information.
+ */
+
+/**
+ * Regression tests for GitHub #540 — and guards against re-breaking #317/#318.
+ *
+ * A Teams VP kept running after the user ended the meeting: 135 video segments
+ * (~630 MB) uploaded to S3 after everyone had left, a live Nova Sonic session,
+ * and a MicroVM that would have run to its 8-hour ceiling. It logged
+ * "attendee badge missing/empty — treating as unknown (not leaving)" every 20
+ * seconds, forever.
+ *
+ * Teams removes the roster badge when the meeting ends, so the badge is absent in
+ * exactly the case the watchdog exists to detect. The old code returned
+ * unconditionally on a missing badge, so NO number of missing reads could ever end
+ * the meeting.
+ *
+ * The tension these tests pin: #317/#318 were the opposite failure — a single
+ * transient misread ended live meetings mid-sentence. Both directions must hold,
+ * so every "ends" test has a matching "does not end too early" test.
+ */
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import {
+    decideAttendeeAction,
+    POLLS_BEFORE_END,
+    type AttendeeReading,
+    type AttendeeWatchdogState,
+} from './teams.js';
+
+const fresh = (): AttendeeWatchdogState => ({ consecutiveLonely: 0, consecutiveMissing: 0 });
+const MISSING: AttendeeReading = { state: 'BADGE_MISSING' };
+const busy: AttendeeReading = { state: 'OK', count: 3 };
+const alone: AttendeeReading = { state: 'OK', count: 1 };
+
+test('a sustained missing badge ends the meeting — the #540 fix', () => {
+    const state = fresh();
+    for (let i = 1; i < POLLS_BEFORE_END; i += 1) {
+        assert.equal(
+            decideAttendeeAction(MISSING, state).action,
+            'continue',
+            `poll ${i} must not end the meeting yet`,
+        );
+    }
+    const decision = decideAttendeeAction(MISSING, state);
+    assert.equal(decision.action, 'end');
+    assert.equal(decision.action === 'end' && decision.reason, 'removed-from-meeting');
+    assert.equal(decision.action === 'end' && decision.trigger, 'attendee-badge-missing');
+});
+
+test('the missing-badge path is BOUNDED — it cannot loop forever', () => {
+    // The literal defect: the old code returned unconditionally, so this loop
+    // would have produced 'continue' 50 times (and forever after).
+    const state = fresh();
+    const actions = new Set<string>();
+    for (let i = 0; i < 50; i += 1) actions.add(decideAttendeeAction(MISSING, state).action);
+    assert.ok(actions.has('end'), 'a missing badge must eventually end the meeting');
+});
+
+test('ONE transient missing badge does not end a live meeting (#317/#318)', () => {
+    // The badge legitimately disappears on a collapsed roster, content share or
+    // re-layout. Reacting to a single misread is what ended live meetings
+    // mid-sentence, so this must stay non-fatal.
+    const state = fresh();
+    assert.equal(decideAttendeeAction(MISSING, state).action, 'continue');
+});
+
+test('a recovered badge resets the missing counter', () => {
+    // Flapping must not accumulate toward an exit: content-share toggling on and
+    // off should never end a meeting that still has people in it.
+    const state = fresh();
+    for (let cycle = 0; cycle < 10; cycle += 1) {
+        for (let i = 0; i < POLLS_BEFORE_END - 1; i += 1) {
+            assert.equal(decideAttendeeAction(MISSING, state).action, 'continue');
+        }
+        assert.equal(decideAttendeeAction(busy, state).action, 'continue');
+        assert.equal(state.consecutiveMissing, 0, 'a good reading must reset the counter');
+    }
+});
+
+test('sustained alone still ends the meeting, unchanged', () => {
+    const state = fresh();
+    for (let i = 1; i < POLLS_BEFORE_END; i += 1) {
+        assert.equal(decideAttendeeAction(alone, state).action, 'continue');
+    }
+    const decision = decideAttendeeAction(alone, state);
+    assert.equal(decision.action, 'end');
+    assert.equal(decision.action === 'end' && decision.reason, 'alone-in-meeting');
+    assert.equal(decision.action === 'end' && decision.trigger, 'attendees-left');
+});
+
+test('a count of 0 is treated as alone, not as unknown', () => {
+    // parseInt failures map to 0 upstream; 0 attendees means the VP is by itself.
+    const state = fresh();
+    for (let i = 1; i < POLLS_BEFORE_END; i += 1) {
+        decideAttendeeAction({ state: 'OK', count: 0 }, state);
+    }
+    assert.equal(decideAttendeeAction({ state: 'OK', count: 0 }, state).action, 'end');
+});
+
+test('others present resets the lonely counter', () => {
+    const state = fresh();
+    for (let i = 0; i < POLLS_BEFORE_END - 1; i += 1) decideAttendeeAction(alone, state);
+    decideAttendeeAction(busy, state);
+    assert.equal(state.consecutiveLonely, 0);
+    // ...and the next lone reading starts counting from scratch.
+    assert.equal(decideAttendeeAction(alone, state).action, 'continue');
+});
+
+test('the two counters do not contaminate each other', () => {
+    // A reading is either a genuine count or a miss, never both. Interleaving
+    // them must never reach an exit, or a flapping badge on a busy meeting would
+    // eject the VP.
+    const state = fresh();
+    for (let i = 0; i < 30; i += 1) {
+        const reading: AttendeeReading = i % 2 === 0 ? MISSING : busy;
+        assert.equal(
+            decideAttendeeAction(reading, state).action,
+            'continue',
+            `alternating readings must not end the meeting (poll ${i})`,
+        );
+    }
+});
+
+test('the grace period is ~60s, matching the Zoom watchdog', () => {
+    // 3 polls x 20s. Long enough to absorb re-renders, short enough that an
+    // abandoned meeting is not billed for long.
+    assert.equal(POLLS_BEFORE_END, 3);
+});
+
+test('a caller can shorten the debounce for testing without touching prod', () => {
+    const state = fresh();
+    assert.equal(decideAttendeeAction(MISSING, state, 1).action, 'end');
+});

--- a/lma-virtual-participant-stack/backend/src/teams.ts
+++ b/lma-virtual-participant-stack/backend/src/teams.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Page } from 'playwright-core';
 
-import { details, matchesEndCommand, exitMessagesFor, ExitInfo, MeetingInitOptions } from "./details.js";
+import { details, matchesEndCommand, exitMessagesFor, ExitInfo, ExitReasonCode, MeetingInitOptions } from "./details.js";
 import { transcriptionService } from "./scribe.js";
 import { createStatusManager } from "./status-manager.js";
 import { voiceAssistant } from './voice-assistant.js';
@@ -10,6 +10,84 @@ import { agentSpeakingDetector } from './agent-speaking-detector.js';
 import { findElementWithFallback, classifyJoinState, isResolverEnabled } from './ai-dom-resolver.js';
 import { startDialogWatchdog } from './dialog-watchdog.js';
 import { humanClick, humanType } from './prejoin-actions.js';
+
+/** Polls before a sustained condition is believed. 3 x 20s poll = ~60s grace. */
+export const POLLS_BEFORE_END = 3;
+
+/** What one poll of the Teams roster badge told us. */
+export type AttendeeReading = { state: 'OK'; count: number } | { state: 'BADGE_MISSING' };
+
+/** Debounced counters carried across polls. */
+export interface AttendeeWatchdogState {
+    consecutiveLonely: number;
+    consecutiveMissing: number;
+}
+
+export type AttendeeDecision =
+    | { action: 'continue' }
+    | { action: 'end'; reason: ExitReasonCode; trigger: string; detail: string };
+
+/**
+ * Decide whether the meeting has ended, from one badge reading plus the running
+ * counters.
+ *
+ * Extracted from the watchdog's setInterval so the decision is unit-testable —
+ * the bug this fixes lived in a closure that no test could reach.
+ *
+ * BADGE_MISSING is the important case. Teams removes the roster badge when the
+ * host ends the meeting, so a missing badge is the *expected* state for the very
+ * event we need to detect. It was previously treated as "unknown, never leave"
+ * with an unconditional early return, which meant no number of missing reads
+ * could ever end the meeting: the VP kept recording video and holding a voice
+ * session until the 8-hour MicroVM ceiling (GitHub #540).
+ *
+ * It cannot simply be treated as "alone" either — the badge legitimately
+ * disappears on a collapsed roster, content share, or re-layout, and reacting to
+ * a single misread ended live meetings mid-sentence (GitHub #317, #318).
+ *
+ * So it gets its OWN debounced counter, exactly as zoom.ts already does: a
+ * transient miss is absorbed, but a sustained one is bounded and ends the
+ * meeting. Note the two counters are mutually exclusive — a reading is either a
+ * genuine count or a miss, never both — so each resets the other.
+ */
+export function decideAttendeeAction(
+    reading: AttendeeReading,
+    state: AttendeeWatchdogState,
+    pollsBeforeEnd: number = POLLS_BEFORE_END,
+): AttendeeDecision {
+    if (reading.state !== 'OK') {
+        state.consecutiveMissing += 1;
+        state.consecutiveLonely = 0;
+        if (state.consecutiveMissing >= pollsBeforeEnd) {
+            return {
+                action: 'end',
+                reason: 'removed-from-meeting',
+                trigger: 'attendee-badge-missing',
+                detail:
+                    `attendee badge absent for ${state.consecutiveMissing} consecutive polls — ` +
+                    'the meeting has ended or the VP was removed',
+            };
+        }
+        return { action: 'continue' };
+    }
+
+    state.consecutiveMissing = 0;
+    if (reading.count > 1) {
+        state.consecutiveLonely = 0;
+        return { action: 'continue' };
+    }
+
+    state.consecutiveLonely += 1;
+    if (state.consecutiveLonely >= pollsBeforeEnd) {
+        return {
+            action: 'end',
+            reason: 'alone-in-meeting',
+            trigger: 'attendees-left',
+            detail: `count<=1 for ${state.consecutiveLonely} consecutive polls`,
+        };
+    }
+    return { action: 'continue' };
+}
 
 export default class Teams {
     private endRequested: Promise<ExitInfo>;
@@ -854,51 +932,91 @@ export default class Teams {
         // document reviews are real meetings).
         console.log("Listening for attendee changes.");
         const POLL_MS = 20_000;
-        const POLLS_BEFORE_END = 3; // ~60s of sustained "alone" before leaving
-        let consecutiveLonely = 0;
+        const watchdogState: AttendeeWatchdogState = {
+            consecutiveLonely: 0,
+            consecutiveMissing: 0,
+        };
         const attendeeWatchdog = setInterval(async () => {
             if (page.isClosed()) {
                 clearInterval(attendeeWatchdog);
                 return;
             }
-            let result: { state: string; count?: number };
+
+            // Strongest signal first: Teams renders an unmistakable post-meeting
+            // screen ("You left the meeting" / "The meeting has ended", or a
+            // /postmeeting-style URL). Checking this before the roster badge means
+            // a genuinely-ended meeting is detected in ONE poll instead of waiting
+            // out the badge debounce (GitHub #540).
+            let ended: { ended: boolean; how?: string } = { ended: false };
             try {
-                result = await page.evaluate(() => {
+                ended = await page.evaluate(() => {
+                    const url = window.location.href;
+                    if (/\/postmeeting|\/meetingended|calling\/end/i.test(url)) {
+                        return { ended: true, how: `url:${url.slice(0, 120)}` };
+                    }
+                    const text = (document.body?.innerText || '').slice(0, 4000);
+                    const phrases = [
+                        /you (?:have )?left the meeting/i,
+                        /the meeting (?:has )?ended/i,
+                        /this meeting has ended/i,
+                        /you(?:'|’)?ve been removed from (?:the|this) meeting/i,
+                        /the call (?:has )?ended/i,
+                    ];
+                    for (const re of phrases) {
+                        const m = text.match(re);
+                        if (m) return { ended: true, how: `text:${m[0]}` };
+                    }
+                    return { ended: false };
+                });
+            } catch {
+                // Page closed/navigated or CDP error — fall through to the badge
+                // reading, which handles unknown state with its own debounce.
+                ended = { ended: false };
+            }
+
+            if (ended.ended) {
+                console.log(`Teams meeting has ended (${ended.how}) — leaving.`);
+                clearInterval(attendeeWatchdog);
+                details.start = false;
+                this.requestEnd({ reason: 'host-ended', trigger: 'post-meeting-screen' });
+                return;
+            }
+
+            let reading: AttendeeReading;
+            try {
+                reading = await page.evaluate(() => {
                     const badgeElement = document.querySelector('span[data-tid="toolbar-item-badge"]');
-                    if (!badgeElement) return { state: 'BADGE_MISSING' };
+                    if (!badgeElement) return { state: 'BADGE_MISSING' as const };
                     const text = (badgeElement.textContent || '').trim();
-                    if (text === '') return { state: 'BADGE_MISSING' };
+                    if (text === '') return { state: 'BADGE_MISSING' as const };
                     const n = parseInt(text, 10);
-                    return { state: 'OK', count: Number.isFinite(n) ? n : 0 };
+                    return { state: 'OK' as const, count: Number.isFinite(n) ? n : 0 };
                 });
             } catch {
                 // page.evaluate threw — page closed/navigated or CDP error.
-                // Treat as unknown, not a leave signal.
-                result = { state: 'BADGE_MISSING' };
+                reading = { state: 'BADGE_MISSING' };
             }
 
-            if (result.state !== 'OK') {
-                // Badge missing/empty is a normal transient on Teams (collapsed
-                // roster, content-share, re-layout) — do NOT treat as alone.
-                console.log('DEBUG: Teams attendee badge missing/empty — treating as unknown (not leaving).');
-                consecutiveLonely = 0;
-                return;
+            const decision = decideAttendeeAction(reading, watchdogState);
+            if (reading.state === 'OK') {
+                console.log(
+                    `DEBUG: Teams attendee count: ${reading.count}, ` +
+                        `hasOthers: ${reading.count > 1}, ` +
+                        `consecutiveLonely: ${watchdogState.consecutiveLonely}/${POLLS_BEFORE_END}`,
+                );
+            } else {
+                console.log(
+                    'DEBUG: Teams attendee badge missing/empty — ' +
+                        `${watchdogState.consecutiveMissing}/${POLLS_BEFORE_END} consecutive ` +
+                        '(the badge also disappears when the meeting ends, so this is now bounded)',
+                );
             }
 
-            const count = result.count ?? 0;
-            const hasOthers = count > 1;
-            console.log(`DEBUG: Teams attendee count: ${count}, hasOthers: ${hasOthers}, consecutiveLonely: ${hasOthers ? 0 : consecutiveLonely + 1}/${POLLS_BEFORE_END}`);
-            if (hasOthers) {
-                consecutiveLonely = 0;
-                return;
-            }
-
-            consecutiveLonely += 1;
-            if (consecutiveLonely >= POLLS_BEFORE_END) {
-                console.log(`LMA Virtual Participant got lonely and left (count<=1 for ${consecutiveLonely} consecutive polls).`);
+            if (decision.action === 'end') {
+                console.log(`LMA Virtual Participant is leaving: ${decision.detail}`);
                 clearInterval(attendeeWatchdog);
                 details.start = false;
-                this.requestEnd({ reason: 'alone-in-meeting', trigger: 'attendees-left' });
+                this.requestEnd({ reason: decision.reason, trigger: decision.trigger });
             }
         }, POLL_MS);
         page.once('close', () => clearInterval(attendeeWatchdog));


### PR DESCRIPTION
Fixes #540.

## The failure

A Teams VP kept running after the user ended the meeting. It logged this every 20 seconds, indefinitely:

```
DEBUG: Teams attendee badge missing/empty — treating as unknown (not leaving).
```

Meanwhile it uploaded **135 video segments (~630 MB)** to S3 after everyone had left, held a live Nova Sonic session, and would have run to the 8-hour MicroVM ceiling. It had to be terminated by hand.

## Root cause

Teams removes the roster badge when the host ends the meeting — so **the badge is absent in exactly the case the watchdog exists to detect.** The old code returned unconditionally:

```ts
if (result.state !== 'OK') {
    consecutiveLonely = 0;
    return;          // ← no number of missing reads could EVER end the meeting
}
```

`teams.ts` had only **two** `requestEnd()` call sites — the chat end-command and this watchdog — so with the badge gone, nothing could end the meeting.

**The original reasoning was sound**, which is why this was easy to miss. That unconditional return was added to fix #317/#318, where a *single* transient misread ended live meetings mid-sentence. It cured a false positive by making the false negative unbounded.

## Changes

**1. The missing badge gets its own debounced counter**, mirroring what `zoom.ts` already does (`consecutiveMissingCounter` → `removed-from-meeting`). A transient miss is still absorbed — the badge legitimately disappears on a collapsed roster, content share or re-layout — but a sustained one is **bounded** and ends the meeting after ~60s.

`zoom.ts` has 8 exit paths to Teams' 2. This file's own comment said it set out to *"mirror the debounced participants-watchdog already proven on Zoom"* — it just omitted the missing-counter half.

**2. A stronger primary signal**, checked before the badge. Teams renders an unmistakable post-meeting state ("You left the meeting", "The meeting has ended", a `/postmeeting`-style URL). That ends the meeting in **one poll** with `reason: 'host-ended'`, rather than waiting out the badge debounce. The badge path stays as the fallback.

The decision logic is extracted into `decideAttendeeAction()`, a pure function — the bug lived inside a `setInterval` closure that no test could reach.

## Testing

10 new tests (86 total, up from 76).

Because #540 and #317/#318 are **opposite failures**, every "ends the meeting" test has a matching "does not end too early" test:

- a sustained missing badge **ends** the meeting → but one transient miss does **not**
- a flapping badge must never accumulate toward an exit
- interleaved good/missing readings must never eject the VP from a busy meeting
- sustained "alone" still ends the meeting, unchanged

One test asserts the missing-badge path is **bounded** by polling it 50 times — the literal defect.

**Verified the tests fail against the original code:** restoring the unconditional return produces 3 failures; the fix returns 86/86.

## Scope

Shared `teams.ts`, so **EC2 and Fargate are affected identically** — not MicroVM-specific. The MicroVM just makes the cost of not exiting more visible, since it bills per meeting.

## Caveat

The post-meeting phrase/URL patterns are inferred from Teams' behaviour, not captured from a live post-meeting DOM — I diagnosed this from the badge-missing logs, and the VP had already been terminated. If Teams words it differently, the badge debounce still catches it within ~60s, so the fallback carries the fix either way. Worth confirming which of the two signals fires on the next live test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
