### PR TITLE
fix(vp): stop Chromium processing the synthetic mic, and log the constraints (#543)

### DIFF
--- a/lma-virtual-participant-stack/backend/src/index.ts
+++ b/lma-virtual-participant-stack/backend/src/index.ts
@@ -7,6 +7,7 @@ import Teams from './teams.js';
 import TeamsSdk from './teams-sdk.js';
 import Webex from './webex.js';
 import { details, ExitInfo, formatExitMessage, didJoinMeeting } from './details.js';
+import { installMicConstraintOverride } from './mic-constraints.js';
 import { transcriptionService } from './scribe.js';
 import { VirtualParticipantStatusManager } from './status-manager.js';
 import { recordingService } from './recording.js';
@@ -435,6 +436,13 @@ const main = async (): Promise<void> => {
     const page = await context.newPage();
     page.setDefaultTimeout(20000);
 
+    // Install BEFORE any navigation: addInitScript only runs in documents created
+    // after it is registered, which is why the Simli override (injected later,
+    // once the avatar is ready) never ran on Teams at all. The VP's mic is
+    // synthetic TTS, so Chromium's noise suppression / AGC only damages it
+    // (GitHub #543).
+    await installMicConstraintOverride(page);
+
     // Renderer-crash latch. A renderer OOM crash leaves every page.evaluate
     // hanging on "Target crashed", so meeting.initialize() never returns and
     // the UI stays stuck on JOINING. We race initialize() against this latch
@@ -468,6 +476,10 @@ const main = async (): Promise<void> => {
         if (
             text.includes('[LMA-Simli]') ||
             text.includes('[Simli]') ||
+            // Mic constraint decisions: previously invisible, which is why
+            // Chromium's audio processing went unsuspected while the voice
+            // assistant crackled on Teams (GitHub #543).
+            text.includes('[LMA-Mic]') ||
             type === 'error' ||
             type === 'warning'
         ) {

--- a/lma-virtual-participant-stack/backend/src/mic-constraints.test.ts
+++ b/lma-virtual-participant-stack/backend/src/mic-constraints.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025 Amazon.com
+ * This file is licensed under the MIT License.
+ * See the LICENSE file in the project root for full license information.
+ */
+
+/**
+ * Tests for the mic constraint override (GitHub #543).
+ *
+ * The VP's microphone is a PulseAudio remap of Nova Sonic's synthesised speech —
+ * no room, no echo path, no background noise. Chromium still ran its full WebRTC
+ * audio processing over it because meeting clients ask for echo cancellation,
+ * noise suppression and AGC by default, and noise suppression over steady
+ * synthetic speech gates it audibly.
+ *
+ * Two earlier diagnoses were wrong (sink resampling, then avatar CPU). What ruled
+ * them out: the container's own recording of agent_output is pristine on BOTH
+ * platforms (0 discontinuities, 0 clipped samples), so the damage happens
+ * downstream of the container — between agent_mic and the meeting's encoder, which
+ * is where the audio processing module sits.
+ */
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { applyForcedAudioConstraints, FORCED_AUDIO_CONSTRAINTS } from './mic-constraints.js';
+
+test('all three processing stages are disabled', () => {
+    // Any one left on is enough to damage synthetic speech: the suppressor gates
+    // it, the AGC pumps it, and the echo canceller subtracts against a reference
+    // that does not exist for a virtual mic.
+    assert.deepEqual(FORCED_AUDIO_CONSTRAINTS, {
+        echoCancellation: false,
+        noiseSuppression: false,
+        autoGainControl: false,
+    });
+});
+
+test('audio: true is widened so the flags can be attached', () => {
+    const out = applyForcedAudioConstraints({ audio: true });
+    assert.deepEqual(out, { audio: { ...FORCED_AUDIO_CONSTRAINTS } });
+});
+
+test('caller-requested processing is overridden, not merged permissively', () => {
+    // This is the actual Teams case: it asks for the processing ON.
+    const out = applyForcedAudioConstraints({
+        audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+    });
+    assert.deepEqual(out!.audio, { ...FORCED_AUDIO_CONSTRAINTS });
+});
+
+test('unrelated caller fields are preserved', () => {
+    // The goal is to disable processing, NOT to override device selection — the
+    // meeting client must still get the mic it asked for.
+    const out = applyForcedAudioConstraints({
+        audio: { deviceId: 'agent_mic', sampleRate: 16000, channelCount: 1, noiseSuppression: true },
+    });
+    assert.deepEqual(out!.audio, {
+        deviceId: 'agent_mic',
+        sampleRate: 16000,
+        channelCount: 1,
+        ...FORCED_AUDIO_CONSTRAINTS,
+    });
+});
+
+test('video constraints are left completely untouched', () => {
+    // The Simli avatar override owns video; this must not interfere with it.
+    const video = { width: { exact: 1920 }, height: { exact: 1080 } };
+    const out = applyForcedAudioConstraints({ audio: true, video });
+    assert.deepEqual(out!.video, video);
+});
+
+test('a video-only request is passed through unchanged', () => {
+    const input = { video: true };
+    assert.equal(applyForcedAudioConstraints(input), input);
+});
+
+test('audio: false is respected — we do not force audio on', () => {
+    const input = { audio: false, video: true };
+    assert.equal(applyForcedAudioConstraints(input), input);
+});
+
+test('undefined constraints do not throw', () => {
+    assert.equal(applyForcedAudioConstraints(undefined), undefined);
+});

--- a/lma-virtual-participant-stack/backend/src/mic-constraints.ts
+++ b/lma-virtual-participant-stack/backend/src/mic-constraints.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025 Amazon.com
+ * This file is licensed under the MIT License.
+ * See the LICENSE file in the project root for full license information.
+ */
+
+/**
+ * Force the meeting client's microphone capture to skip browser audio processing.
+ *
+ * The VP's "microphone" is `agent_mic` — a PulseAudio remap-source of
+ * `agent_output`, which carries nothing but Nova Sonic's synthesised speech. It is
+ * a clean, single-source, 16 kHz mono signal with no room, no echo path and no
+ * background noise.
+ *
+ * Chromium nonetheless applies its full WebRTC audio processing module to it,
+ * because meeting clients request `echoCancellation` / `noiseSuppression` /
+ * `autoGainControl` by default (and Teams requests them aggressively). Running
+ * noise suppression and AGC over synthetic TTS is both pointless and harmful: the
+ * suppressor mistakes steady synthetic speech for noise and gates it, and the AGC
+ * pumps the level. The audible result is crackly, uneven speech (GitHub #543).
+ *
+ * Measured evidence that the problem is here and not upstream: the container's own
+ * recording of `agent_output` is pristine on both platforms — 0 sample-level
+ * discontinuities, 0 clipped samples, peak 18245/32767 — yet Teams sounds crackly
+ * and Zoom does not. So the signal leaving the container is clean and the damage
+ * happens between `agent_mic` and the meeting's encoder, which is exactly where
+ * the APM sits. Teams being worse is consistent with it being the heavier client
+ * and requesting more processing.
+ *
+ * Disabling the APM also removes real per-frame CPU work, which matters on the
+ * MicroVM launch type: it is ARM64 with 2 vCPU, whereas the ECS task definition
+ * runs 2 vCPU on x86_64 — and the crackle was not present on Fargate.
+ *
+ * This is installed independently of the Simli avatar override. That override is
+ * only injected once the avatar is ready, by which point the meeting document
+ * already exists — `addInitScript` only applies to documents created afterwards,
+ * so on Teams it never ran at all (zero `[LMA-Simli]` browser lines in a live
+ * session). Audio must not depend on that timing.
+ */
+import type { Page } from 'playwright-core';
+
+/** Audio processing that must be off for a synthetic, single-source mic. */
+export const FORCED_AUDIO_CONSTRAINTS = {
+    echoCancellation: false,
+    noiseSuppression: false,
+    autoGainControl: false,
+} as const;
+
+/**
+ * Merge the forced flags into whatever the meeting client asked for.
+ *
+ * Pure and exported so the merge semantics are unit-testable without a browser.
+ *
+ * `audio: true` is widened to an object so the flags can be attached. `audio:
+ * false`/absent is left alone — the caller genuinely wants no audio. Any other
+ * caller-supplied fields (deviceId, sampleRate, channelCount) are preserved: the
+ * goal is to disable processing, not to override device selection.
+ */
+export function applyForcedAudioConstraints(
+    constraints: MediaStreamConstraints | undefined,
+): MediaStreamConstraints | undefined {
+    if (!constraints || !constraints.audio) return constraints;
+    const existing = constraints.audio === true ? {} : { ...(constraints.audio as object) };
+    return { ...constraints, audio: { ...existing, ...FORCED_AUDIO_CONSTRAINTS } };
+}
+
+/**
+ * Install the override in the page and every frame it later creates.
+ *
+ * MUST be called before the meeting URL is navigated to: `addInitScript` only
+ * runs in documents created after it is registered.
+ *
+ * Also logs the constraints each caller requests. That is deliberately verbose —
+ * these constraints were previously invisible, which is why the APM was not
+ * suspected for two rounds of misdiagnosis.
+ */
+export async function installMicConstraintOverride(page: Page): Promise<void> {
+    await page.addInitScript((forced: Record<string, boolean>) => {
+        const md = navigator.mediaDevices;
+        if (!md || !md.getUserMedia) return;
+        const original = md.getUserMedia.bind(md);
+        md.getUserMedia = function (constraints?: MediaStreamConstraints) {
+            try {
+                if (constraints && constraints.audio) {
+                    const before = JSON.stringify(constraints.audio);
+                    const existing = constraints.audio === true ? {} : { ...(constraints.audio as object) };
+                    const merged = { ...existing, ...forced };
+                    // eslint-disable-next-line no-param-reassign
+                    constraints = { ...constraints, audio: merged };
+                    console.log(
+                        `[LMA-Mic] audio constraints: requested=${before} -> forced=${JSON.stringify(merged)}`,
+                    );
+                }
+            } catch (e) {
+                // Never let the override break capture: a meeting with processed
+                // audio is far better than a meeting with no audio at all.
+                console.log(`[LMA-Mic] constraint override skipped: ${(e as Error)?.message}`);
+            }
+            return original(constraints);
+        };
+        console.log(`[LMA-Mic] mic constraint override installed in frame: ${location.href}`);
+    }, FORCED_AUDIO_CONSTRAINTS as unknown as Record<string, boolean>);
+}


### PR DESCRIPTION
Re-fixes #543. **The fix in #544 did not work**, and the evidence now rules out its premise.

## Why the previous attempt was wrong

Retested on a live Teams meeting after #544 deployed — still crackly.

- Simli reconnects on Teams are now **0** (were 2), so CPU pressure genuinely dropped
- but the avatar rescale path **never activated** in the failing session (no `scaling avatar` log)
- and it still crackled

The path I optimised wasn't running. The optimisation is worth keeping, but it wasn't the cause.

## Measuring instead of theorising

I analysed the recording of `agent_output` — the exact signal Nova produces:

| | Teams | Zoom |
|---|---|---|
| Sample-jump discontinuities >20000 (click signature) | **0** | **0** |
| Clipped samples | **0** | **0** |
| Peak level | 18245 / 32767 | 18346 / 32767 |
| Format | 16 kHz mono | 16 kHz mono |

31 windows of confirmed agent speech, so this measured signal not silence.

**The audio leaving the container is pristine on both platforms.** The damage happens downstream — between `agent_mic` and the meeting client's encoder.

## Root cause

That gap is where Chromium's WebRTC **audio processing module** sits. The VP's mic is a PulseAudio remap of synthesised speech — no room, no echo path, no background noise. But meeting clients request `echoCancellation` / `noiseSuppression` / `autoGainControl` by default, and Chromium honours them. Noise suppression over steady synthetic speech **gates** it; the AGC **pumps** the level. Audibly crackly.

Consistent with the report that this was clean on **Fargate**: the ECS task runs **x86_64**, MicroVM is **ARM64**, so the APM's cost and behaviour differ.

### A second bug, which is why nothing was overriding this already

The Simli avatar's existing `getUserMedia` override is injected only once the avatar is ready — by which point the meeting document already exists. `addInitScript` only applies to documents created **after** registration, so on Teams **it never ran at all**: a live session logged **zero** browser-side `[LMA-Simli]` lines.

## Changes

1. **`installMicConstraintOverride()`** forces the three flags off for every audio `getUserMedia`, preserving any other caller field (`deviceId`, `sampleRate`, `channelCount`) so device selection is untouched. Installed on the page **before any navigation** — asserted against `meeting.initialize()` ordering.

2. **Requested-vs-forced constraints are now logged** and piped to CloudWatch. They were previously invisible, which is why the APM went unsuspected through two rounds of misdiagnosis.

## Testing

8 new tests (**94** container total): the Teams case (client asks for processing ON → forced off), unrelated fields survive, video constraints untouched, `audio: false` respected rather than forced on.

## This is a hypothesis, not a confirmed cure

The supporting evidence is strong — clean source audio, a Teams/Zoom split, an x86→ARM change, and a plausible mechanism — but I have been wrong on this symptom twice. The constraint logging exists precisely so the next live test either confirms it or points elsewhere.

**#543 stays open until a live Teams meeting actually sounds clean.**

If it doesn't fix it, the logging will show exactly what Teams requests, and the next lever is the ARM64/x86 difference — the ECS path runs x86_64 and was reported clean, so a controlled Fargate-vs-MicroVM comparison on the same build would isolate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
