### PR TITLE
fix(vp): audio-path fixes for #569/#543 — sole combined_audio writer, recording source, idempotent audio graph

### DIFF
--- a/lma-virtual-participant-stack/backend/Dockerfile
+++ b/lma-virtual-participant-stack/backend/Dockerfile
@@ -94,6 +94,19 @@ RUN useradd -m -d /home/appuser -s /bin/bash appuser
 # resample-method: PulseAudio defaults to speex-float-1, tuned for speed. Any
 # residual conversion should favour quality; speex-float-5 is still cheap.
 # Written as the appuser's own config since the daemon runs as that user.
+#
+# NOTE: `avoid-resampling = yes` is deliberately NOT set. It makes PulseAudio
+# RECONFIGURE a device to a client's rate instead of resampling for it, which
+# does nothing here — every sink already carries an explicit
+# `rate=16000 channels=1 format=s16le` (entrypoint.sh), and that pinning is what
+# actually removed the triple resample. What it can do is harm: Teams opens the
+# agent_mic remap source TWICE with conflicting formats (one mono capture with
+# echoCancellation/AGC on, one stereo capture with them off — both observed live
+# via the audio diagnostics), so two clients demand incompatible formats from one
+# monitor source. Zoom opens it once, and Zoom is the platform that sounds fine.
+# Device re-negotiation glitches audio without dropping an RTP packet, which
+# matches every measurement taken for #543: the container-side recording is
+# clean, packet counters are clean, and only the meeting listener hears garble.
 RUN mkdir -p /home/appuser/.config/pulse && \
     printf '%s\n' \
       'default-sample-rate = 16000' \
@@ -101,7 +114,6 @@ RUN mkdir -p /home/appuser/.config/pulse && \
       'default-sample-channels = 1' \
       'default-sample-format = s16le' \
       'resample-method = speex-float-5' \
-      'avoid-resampling = yes' \
       'flat-volumes = no' \
       > /home/appuser/.config/pulse/daemon.conf
 

--- a/lma-virtual-participant-stack/backend/entrypoint.sh
+++ b/lma-virtual-participant-stack/backend/entrypoint.sh
@@ -172,20 +172,58 @@ sleep 2
 
 echo "Creating PulseAudio audio routing for meeting and agent..."
 
+# EVERY load-module below must be idempotent.
+#
+# Under MICROVM this script is run by bootStack() from the /ready hook, and
+# Lambda RETRIES /ready whenever it returns 503 (observed ~3 retries on a cold
+# ARM boot, and bootStack reports failure if the VNC ports take longer than its
+# timeout). Each retry re-ran this section, and pactl silently renames a
+# colliding sink rather than failing -- so a live MicroVM was observed with the
+# entire graph duplicated:
+#
+#   sinks:   meeting_audio agent_output combined_audio
+#            meeting_audio.2 agent_output.2 combined_audio.2
+#   sources: ... agent_mic agent_mic.2
+#
+# The dangerous one is not the spare sinks, which nothing writes to. It is the
+# module-loopback below: a second copy mixes the agent's voice into
+# combined_audio TWICE at two independent latencies, which is precisely the
+# double-writer this file warns about for meeting audio (#542) -- every agent
+# utterance reaching Transcribe twice. And because /ready runs at IMAGE BUILD
+# time, the duplicate graph is captured in the snapshot and every launch inherits
+# it.
+pa_sink_exists() { pactl list short sinks | cut -f2 | grep -qx "$1"; }
+pa_source_exists() { pactl list short sources | cut -f2 | grep -qx "$1"; }
+pa_loopback_exists() {
+    pactl list short modules | grep -q "module-loopback.*source=$1.*sink=$2"
+}
+
 # Create a null sink for meeting audio (Chromium output)
 # rate/channels are pinned on every sink: a null sink otherwise adopts the
 # daemon default (48 kHz stereo), and each 16 kHz mono stream would then be
 # resampled on the way in AND on the way out (GitHub #538).
-MEETING_SINK=$(pactl load-module module-null-sink sink_name=meeting_audio rate=16000 channels=1 format=s16le sink_properties=device.description="Meeting_Audio")
-echo "Created meeting_audio sink (module $MEETING_SINK)"
+if pa_sink_exists meeting_audio; then
+    echo "meeting_audio sink already exists — not creating a duplicate"
+else
+    MEETING_SINK=$(pactl load-module module-null-sink sink_name=meeting_audio rate=16000 channels=1 format=s16le sink_properties=device.description="Meeting_Audio")
+    echo "Created meeting_audio sink (module $MEETING_SINK)"
+fi
 
 # Create a null sink for agent audio output (Nova/ElevenLabs)
-AGENT_SINK=$(pactl load-module module-null-sink sink_name=agent_output rate=16000 channels=1 format=s16le sink_properties=device.description="Agent_Audio_Output")
-echo "Created agent_output sink (module $AGENT_SINK)"
+if pa_sink_exists agent_output; then
+    echo "agent_output sink already exists — not creating a duplicate"
+else
+    AGENT_SINK=$(pactl load-module module-null-sink sink_name=agent_output rate=16000 channels=1 format=s16le sink_properties=device.description="Agent_Audio_Output")
+    echo "Created agent_output sink (module $AGENT_SINK)"
+fi
 
 # Create a combined sink that mixes meeting + agent audio for transcription
-COMBINED_SINK=$(pactl load-module module-null-sink sink_name=combined_audio rate=16000 channels=1 format=s16le sink_properties=device.description="Combined_Audio_For_Transcription")
-echo "Created combined_audio sink (module $COMBINED_SINK)"
+if pa_sink_exists combined_audio; then
+    echo "combined_audio sink already exists — not creating a duplicate"
+else
+    COMBINED_SINK=$(pactl load-module module-null-sink sink_name=combined_audio rate=16000 channels=1 format=s16le sink_properties=device.description="Combined_Audio_For_Transcription")
+    echo "Created combined_audio sink (module $COMBINED_SINK)"
+fi
 
 # 80ms latency: 1ms caused underruns on smaller instances, and 20ms still
 # underran on a 2-vCPU MicroVM once Chromium, the avatar rescale, video recording
@@ -207,16 +245,34 @@ echo "Created combined_audio sink (module $COMBINED_SINK)"
 # utterance to Transcribe (#542).
 
 # Route agent_output.monitor to combined_audio sink
-pactl load-module module-loopback source=agent_output.monitor sink=combined_audio latency_msec=80
-echo "Routed agent audio to combined sink"
+if pa_loopback_exists agent_output.monitor combined_audio; then
+    echo "agent_output→combined_audio loopback already exists — not adding a second writer"
+else
+    pactl load-module module-loopback source=agent_output.monitor sink=combined_audio latency_msec=80
+    echo "Routed agent audio to combined sink"
+fi
 
 # Create a virtual microphone source from agent_output for Chromium
-pactl load-module module-remap-source source_name=agent_mic master=agent_output.monitor source_properties=device.description="Agent_Virtual_Microphone"
-echo "Created agent_mic source for Chromium"
+if pa_source_exists agent_mic; then
+    echo "agent_mic source already exists — not creating a duplicate"
+else
+    pactl load-module module-remap-source source_name=agent_mic master=agent_output.monitor source_properties=device.description="Agent_Virtual_Microphone"
+    echo "Created agent_mic source for Chromium"
+fi
 
 # Set meeting_audio as the default sink (Chromium will output here)
 pactl set-default-sink meeting_audio
 echo "Set meeting_audio as default sink"
+
+# ...and agent_mic as the default SOURCE. This was previously unset, which left
+# the choice of capture device entirely to PulseAudio: a live Teams call was
+# observed capturing with deviceId "default" rather than an explicit device, so
+# whatever PulseAudio happened to rank first became the meeting's microphone.
+# Every other reader in the app names its device explicitly (the ffmpegs, the
+# pacat streams, the speaking detector), so nothing depends on the previous
+# default and making this deterministic can only remove a variable.
+pactl set-default-source agent_mic
+echo "Set agent_mic as default source"
 
 echo "✓ Audio routing configured"
 

--- a/lma-virtual-participant-stack/backend/entrypoint.sh
+++ b/lma-virtual-participant-stack/backend/entrypoint.sh
@@ -197,8 +197,14 @@ echo "Created combined_audio sink (module $COMBINED_SINK)"
 # Transcribe twice at two different latencies -- Transcribe then transcribed both
 # ("Jack and Jill, Jack and Jill went up ...", GitHub #542). Do not re-add a
 # second writer here or in the app.
-pactl load-module module-loopback source=meeting_audio.monitor sink=combined_audio latency_msec=80
-echo "Routed meeting audio to combined sink"
+# NOTE: meeting_audio is NOT loopback-routed to combined_audio. A module-loopback
+# into a null sink does not keep that sink out of PulseAudio's idle/suspend
+# state, so this route went digitally silent -- a live Zoom session recorded 50s
+# of combined_audio with peak amplitude 0 while meeting_audio itself had audio
+# (GitHub #569). The app instead holds an ACTIVE pacat playback stream on
+# combined_audio (scribe.ts), which both delivers the audio and keeps the sink
+# running. Exactly ONE writer -- adding this loopback back would duplicate every
+# utterance to Transcribe (#542).
 
 # Route agent_output.monitor to combined_audio sink
 pactl load-module module-loopback source=agent_output.monitor sink=combined_audio latency_msec=80

--- a/lma-virtual-participant-stack/backend/src/audio-diagnostics.test.ts
+++ b/lma-virtual-participant-stack/backend/src/audio-diagnostics.test.ts
@@ -7,82 +7,140 @@
 /**
  * Tests for the outbound-audio classifier used to diagnose GitHub #543.
  *
- * These assert the thresholds that decide whether a live session's audio is
- * leaving cleanly. That matters because three previous fixes were shipped on
- * reasoning rather than measurement, and one of them broke transcription — so the
- * next change must be justified by what these numbers say.
+ * These pin the thresholds that decide whether a live session's audio is leaving
+ * cleanly. That matters twice over: three previous fixes were shipped on reasoning
+ * rather than measurement (one of them broke transcription), and then the FIRST
+ * version of this classifier produced false alarms that would have justified a
+ * fourth wrong fix. The numbers in these tests are taken verbatim from the live
+ * Teams capture so that specific misreading cannot come back.
  */
 import { strict as assert } from 'node:assert';
 import { test } from 'node:test';
 import {
-    classifyOutboundAudio,
+    classifyAudioWindow,
     EXPECTED_PACKETS_PER_SECOND,
+    MIN_CAPTURE_RATIO,
+    SPEECH_ENERGY_THRESHOLD,
     STATS_INTERVAL_MS,
 } from './audio-diagnostics.js';
 
+/** A window with no audio energy: the sender is deliberately silent. */
+const silent = { seconds: 1, packets: 5, captureRatio: 1.0, energyDelta: 0 };
+/** A window mid-utterance on a healthy sender. */
+const speaking = { seconds: 1, packets: 50, captureRatio: 1.0, energyDelta: 0.02 };
+
 test('the expected cadence matches Opus at a 20ms frame', () => {
-    // 1000ms / 20ms = 50 packets per second. If the meeting client negotiates a
-    // different ptime this constant must change, or every sample reads IRREGULAR.
+    // 1000ms / 20ms = 50 packets per second.
     assert.equal(EXPECTED_PACKETS_PER_SECOND, 50);
 });
 
-test('a steady sender is reported healthy', () => {
-    const v = classifyOutboundAudio({ packetsPerSecond: 50, sendDelayPerPacketMs: 1 });
-    assert.equal(v.healthy, true);
-    assert.match(v.reason, /steady/);
+test('DTX comfort noise during silence is NOT a problem', () => {
+    // Regression for the false alarm that filled the first live capture: 4.8
+    // packets/s for ten minutes, every line reported "encoder or capture starving".
+    // A DTX sender that has nothing to say is healthy, and drowning the log in
+    // this hid whether anything real was happening.
+    for (const packets of [4, 5, 6]) {
+        const v = classifyAudioWindow({ ...silent, packets });
+        assert.equal(v.state, 'idle', `${packets} pkt/s of comfort noise should read idle`);
+        assert.match(v.reason, /silent/);
+    }
 });
 
-test('normal sampling drift is tolerated', () => {
-    // The sampling window is not frame-aligned, so a healthy sender still varies.
-    // Flagging that would bury the real signal in noise.
-    for (const pps of [41, 45, 50, 55, 59]) {
-        assert.equal(
-            classifyOutboundAudio({ packetsPerSecond: pps }).healthy,
-            true,
-            `${pps}/s should be treated as healthy drift`,
+test('a short utterance averaged over a long window is not misread as frame loss', () => {
+    // The other artefact: sampling every 5s, a ~2.5s utterance at a perfect 50/s
+    // reads as ~25/s. The old code called that "capture starving" — indistinguishable
+    // from genuinely dropping half the frames, which was the question being asked.
+    // At a 1s window the same sender is judged on capture continuity instead.
+    const v = classifyAudioWindow({ seconds: 5, packets: 125, captureRatio: 1.0, energyDelta: 0.02 });
+    assert.notEqual(v.state, 'problem');
+});
+
+test('capture starvation is flagged from the capture ratio alone', () => {
+    // The signature actually being hunted: Chromium losing audio before the encoder
+    // sees it. Independent of speech, DTX and window alignment.
+    const v = classifyAudioWindow({ ...speaking, captureRatio: 0.6 });
+    assert.equal(v.state, 'problem');
+    assert.match(v.reason, /capture starving/);
+});
+
+test('capture starvation is flagged even while silent', () => {
+    // Capture runs whether or not the agent is speaking, so a gap during silence is
+    // still a real fault — and it is the cheapest window in which to notice one.
+    const v = classifyAudioWindow({ ...silent, captureRatio: 0.5 });
+    assert.equal(v.state, 'problem');
+    assert.match(v.reason, /capture starving/);
+});
+
+test('a healthy capture ratio is accepted with its normal jitter', () => {
+    // The stat is a float differenced across an unaligned window, so it will never
+    // read exactly 1.0; a tight bound here would recreate the false-alarm problem.
+    for (const ratio of [MIN_CAPTURE_RATIO, 0.99, 1.0, 1.01]) {
+        assert.notEqual(
+            classifyAudioWindow({ ...speaking, captureRatio: ratio }).state,
+            'problem',
+            `${ratio} should be treated as healthy`,
         );
     }
 });
 
-test('a starved encoder is flagged', () => {
-    // The signature we are hunting: audio being produced too slowly, which is
-    // what a CPU-starved capture or encode looks like from the sender side.
-    const v = classifyOutboundAudio({ packetsPerSecond: 30 });
-    assert.equal(v.healthy, false);
-    assert.match(v.reason, /below the expected/);
+test('far-end packet loss is reported as a wire fault, not a capture fault', () => {
+    // Crackle from loss on the wire and crackle from a starved encoder need
+    // opposite fixes, so the two must never collapse into one message.
+    const v = classifyAudioWindow({ ...speaking, remotePacketsLost: 3 });
+    assert.equal(v.state, 'problem');
+    assert.match(v.reason, /wire/);
 });
 
-test('bursting after a stall is flagged', () => {
-    // The other half of a stall: the queue drains faster than realtime once the
-    // CPU frees up. Crackle can come from either side of that.
-    const v = classifyOutboundAudio({ packetsPerSecond: 90 });
-    assert.equal(v.healthy, false);
-    assert.match(v.reason, /exceeds the expected/);
-});
-
-test('silence is distinguished from an irregular cadence', () => {
-    // "No audio at all" and "audio arriving unevenly" need different fixes, so
-    // they must not collapse into one message.
-    const v = classifyOutboundAudio({ packetsPerSecond: 0 });
-    assert.equal(v.healthy, false);
-    assert.match(v.reason, /no audio packets/);
+test('capture starvation outranks far-end loss', () => {
+    // If capture is already losing frames, the far end will also report loss; the
+    // upstream cause is the actionable one.
+    const v = classifyAudioWindow({ ...speaking, captureRatio: 0.4, remotePacketsLost: 3 });
+    assert.match(v.reason, /capture starving/);
 });
 
 test('queueing is flagged even when the cadence looks right', () => {
-    // A sender can hit ~50/s while still adding latency per packet; that is a
-    // stall being absorbed by a buffer rather than a clean path.
-    const v = classifyOutboundAudio({ packetsPerSecond: 50, sendDelayPerPacketMs: 45 });
-    assert.equal(v.healthy, false);
+    const v = classifyAudioWindow({ ...speaking, sendDelayPerPacketMs: 45 });
+    assert.equal(v.state, 'problem');
     assert.match(v.reason, /send delay/);
 });
 
-test('a missing send-delay stat does not produce a false alarm', () => {
-    // Not every browser reports totalPacketSendDelay; absence must not read as 0
-    // problems OR as a failure.
-    assert.equal(classifyOutboundAudio({ packetsPerSecond: 50 }).healthy, true);
+test('a starved cadence during speech is flagged', () => {
+    const v = classifyAudioWindow({ ...speaking, packets: 20 });
+    assert.equal(v.state, 'problem');
+    assert.match(v.reason, /only 20\.0 pkt\/s/);
 });
 
-test('the sampling interval is frequent enough to catch a short meeting', () => {
-    assert.ok(STATS_INTERVAL_MS <= 10000, 'should sample at least every 10s');
-    assert.ok(STATS_INTERVAL_MS >= 1000, 'but not so often that it adds load');
+test('audio energy with no packets at all is flagged', () => {
+    // Distinct from silence: the agent is producing sound and none of it is leaving.
+    const v = classifyAudioWindow({ ...speaking, packets: 0 });
+    assert.equal(v.state, 'problem');
+    assert.match(v.reason, /no packets sent/);
+});
+
+test('a high cadence at the start of an utterance is not flagged', () => {
+    // A DTX sender resuming mid-window legitimately overshoots 50/s. The first
+    // version called this "bursting after a stall" and it was just speech onset.
+    assert.equal(classifyAudioWindow({ ...speaking, packets: 62 }).state, 'ok');
+});
+
+test('missing optional stats do not produce a false alarm', () => {
+    // Not every stat is present on every browser or before the first RTCP report.
+    // Absence must read as "unknown", never as a fault.
+    const v = classifyAudioWindow({ seconds: 1, packets: 50, energyDelta: 0.02 });
+    assert.equal(v.state, 'ok');
+});
+
+test('the speech threshold sits above a silent null sink and below real speech', () => {
+    // Energy is summed squared amplitude; the observed values differ by orders of
+    // magnitude, so this only has to land between them.
+    assert.ok(SPEECH_ENERGY_THRESHOLD > 0);
+    assert.equal(classifyAudioWindow({ ...silent, energyDelta: SPEECH_ENERGY_THRESHOLD }).state, 'idle');
+    assert.equal(classifyAudioWindow({ ...speaking, energyDelta: 0.01 }).state, 'ok');
+});
+
+test('the sampling interval can resolve a single utterance', () => {
+    // A typical assistant reply is a few seconds. At 5s the utterance and the
+    // silence around it landed in one window and the rate became meaningless.
+    assert.ok(STATS_INTERVAL_MS <= 1000, 'must be <= 1s to separate speech from silence');
+    assert.ok(STATS_INTERVAL_MS >= 1000, 'but not so often that polling adds load');
 });

--- a/lma-virtual-participant-stack/backend/src/audio-diagnostics.test.ts
+++ b/lma-virtual-participant-stack/backend/src/audio-diagnostics.test.ts
@@ -19,7 +19,10 @@ import { test } from 'node:test';
 import {
     classifyAudioWindow,
     formatDeviceSpecs,
+    formatCaptureStreams,
     parsePactlDefaults,
+    parsePactlIndexToName,
+    parsePactlSourceOutputs,
     parsePactlShort,
     EXPECTED_PACKETS_PER_SECOND,
     MIN_CAPTURE_RATIO,
@@ -270,4 +273,109 @@ test('a default that fell through to a duplicate or a monitor is visible', () =>
 
 test('missing pactl info fields read as undefined, not as a crash', () => {
     assert.deepEqual(parsePactlDefaults(''), { sink: undefined, source: undefined });
+});
+
+/**
+ * Resolving capture streams to device NAMES and owning applications.
+ *
+ * The question these answer: is the meeting's microphone the device we intended?
+ * A live session logged four sources occupying indices 1-4 with capture streams on
+ * 1, 3 and 4 — and because the short listing identifies a device only by index,
+ * there was no way to tell whether Chromium was reading agent_mic or
+ * combined_audio.monitor. The latter would mean Teams is being fed the meeting's
+ * own audio mixed back in, which is a complete explanation of garbled playback
+ * that leaves every packet counter clean.
+ */
+const SOURCES_SHORT = [
+    '1\tmeeting_audio.monitor\tmodule-null-sink.c\ts16le 1ch 16000Hz\tIDLE',
+    '2\tagent_output.monitor\tmodule-null-sink.c\ts16le 1ch 16000Hz\tRUNNING',
+    '3\tcombined_audio.monitor\tmodule-null-sink.c\ts16le 1ch 16000Hz\tRUNNING',
+    '4\tagent_mic\tmodule-remap-source.c\ts16le 1ch 16000Hz\tRUNNING',
+].join('\n');
+
+test('device indices are mapped to names rather than to listing positions', () => {
+    // The indices in the live capture started at 1, so "the third line" is not
+    // source 3. Position-based mapping would silently mislabel every stream.
+    const map = parsePactlIndexToName(SOURCES_SHORT);
+    assert.equal(map.get('1'), 'meeting_audio.monitor');
+    assert.equal(map.get('4'), 'agent_mic');
+    assert.equal(map.size, 4);
+});
+
+test('a capture stream is resolved to its application and device name', () => {
+    const streams = parsePactlSourceOutputs(
+        [
+            'Source Output #3',
+            '\tDriver: protocol-native.c',
+            '\tClient: 12',
+            '\tSource: 4',
+            '\tSample Specification: s16le 2ch 48000Hz',
+            '\tProperties:',
+            '\t\tapplication.name = "Chromium"',
+        ].join('\n'),
+    );
+    assert.equal(streams.length, 1);
+    assert.deepEqual(streams[0], {
+        index: '3',
+        sourceIndex: '4',
+        spec: 's16le 2ch 48000Hz',
+        app: 'Chromium',
+    });
+    assert.equal(
+        formatCaptureStreams(streams, parsePactlIndexToName(SOURCES_SHORT)),
+        'Chromium<-agent_mic[s16le 2ch 48000Hz]',
+    );
+});
+
+test('the failure mode this exists to catch is legible in one line', () => {
+    // Chromium capturing combined_audio.monitor: the meeting would hear itself.
+    const streams = parsePactlSourceOutputs(
+        [
+            'Source Output #5',
+            '\tSource: 3',
+            '\tSample Specification: s16le 2ch 48000Hz',
+            '\tProperties:',
+            '\t\tapplication.name = "Chromium"',
+        ].join('\n'),
+    );
+    assert.equal(
+        formatCaptureStreams(streams, parsePactlIndexToName(SOURCES_SHORT)),
+        'Chromium<-combined_audio.monitor[s16le 2ch 48000Hz]',
+    );
+});
+
+test('several capture streams are parsed from one listing', () => {
+    const streams = parsePactlSourceOutputs(
+        [
+            'Source Output #0',
+            '\tSource: 2',
+            '\tSample Specification: s16le 1ch 16000Hz',
+            '\tProperties:',
+            '\t\tmedia.name = "Loopback to Combined_Audio"',
+            'Source Output #3',
+            '\tSource: 4',
+            '\tSample Specification: s16le 2ch 48000Hz',
+            '\tProperties:',
+            '\t\tapplication.name = "Chromium"',
+        ].join('\n'),
+    );
+    assert.equal(streams.length, 2);
+    // A loopback has no application.name; media.name keeps it identifiable rather
+    // than collapsing every anonymous stream into one indistinguishable label.
+    assert.equal(streams[0].app, 'Loopback to Combined_Audio');
+    assert.equal(streams[1].app, 'Chromium');
+});
+
+test('a stream on an unknown source index is labelled, not dropped', () => {
+    // If the map is stale, showing "source#9" is far better than hiding a capture.
+    const streams = parsePactlSourceOutputs(
+        ['Source Output #1', '\tSource: 9', '\tSample Specification: s16le 1ch 16000Hz'].join('\n'),
+    );
+    assert.match(formatCaptureStreams(streams, new Map()), /source#9/);
+    assert.equal(streams[0].app, 'unknown');
+});
+
+test('an empty listing yields no streams', () => {
+    assert.deepEqual(parsePactlSourceOutputs(''), []);
+    assert.equal(formatCaptureStreams([], new Map()), '');
 });

--- a/lma-virtual-participant-stack/backend/src/audio-diagnostics.test.ts
+++ b/lma-virtual-participant-stack/backend/src/audio-diagnostics.test.ts
@@ -19,6 +19,7 @@ import { test } from 'node:test';
 import {
     classifyAudioWindow,
     formatDeviceSpecs,
+    parsePactlDefaults,
     parsePactlShort,
     EXPECTED_PACKETS_PER_SECOND,
     MIN_CAPTURE_RATIO,
@@ -242,4 +243,31 @@ test('formatting is stable so unchanged devices produce no log line', () => {
 
 test('an empty listing formats to something falsy, not the string "undefined"', () => {
     assert.equal(formatDeviceSpecs([]), '');
+});
+
+test('the default sink and source are extracted from pactl info', () => {
+    // A live Teams call captured with deviceId "default", so which source the
+    // meeting's microphone actually is was left to PulseAudio. entrypoint.sh now
+    // pins it; this is how the pin is confirmed to have held.
+    const info = [
+        'Server String: /run/user/1000/pulse/native',
+        'Default Sink: meeting_audio',
+        'Default Source: agent_mic',
+        'Cookie: 1234:5678',
+    ].join('\n');
+    assert.deepEqual(parsePactlDefaults(info), { sink: 'meeting_audio', source: 'agent_mic' });
+});
+
+test('a default that fell through to a duplicate or a monitor is visible', () => {
+    // The two outcomes worth catching: the ".2" copy of a duplicated graph, and
+    // combined_audio.monitor — which would feed the meeting its own mixed audio.
+    assert.equal(parsePactlDefaults('Default Source: agent_mic.2').source, 'agent_mic.2');
+    assert.equal(
+        parsePactlDefaults('Default Source: combined_audio.monitor').source,
+        'combined_audio.monitor',
+    );
+});
+
+test('missing pactl info fields read as undefined, not as a crash', () => {
+    assert.deepEqual(parsePactlDefaults(''), { sink: undefined, source: undefined });
 });

--- a/lma-virtual-participant-stack/backend/src/audio-diagnostics.test.ts
+++ b/lma-virtual-participant-stack/backend/src/audio-diagnostics.test.ts
@@ -18,6 +18,8 @@ import { strict as assert } from 'node:assert';
 import { test } from 'node:test';
 import {
     classifyAudioWindow,
+    formatDeviceSpecs,
+    parsePactlShort,
     EXPECTED_PACKETS_PER_SECOND,
     MIN_CAPTURE_RATIO,
     MIN_MEASURE_SECONDS,
@@ -180,4 +182,64 @@ test('the sampling interval can resolve a single utterance', () => {
     // silence around it landed in one window and the rate became meaningless.
     assert.ok(STATS_INTERVAL_MS <= 1000, 'must be <= 1s to separate speech from silence');
     assert.ok(STATS_INTERVAL_MS >= 1000, 'but not so often that polling adds load');
+});
+
+/**
+ * The PulseAudio device-format probe. Its job is to show whether the virtual mic's
+ * format flaps while Teams holds two captures on it with conflicting channel
+ * counts — the one mechanism that fits every measurement taken so far (clean
+ * container-side recording, clean packet counters, garbled listener audio).
+ */
+test('sink and source listings are parsed into name/format pairs', () => {
+    // Verbatim shape of `pactl list short sinks` after #538 pinned the sinks.
+    const out = parsePactlShort(
+        [
+            '0\tmeeting_audio\tmodule-null-sink.c\ts16le 1ch 16000Hz\tSUSPENDED',
+            '1\tagent_output\tmodule-null-sink.c\ts16le 1ch 16000Hz\tRUNNING',
+            '2\tcombined_audio\tmodule-null-sink.c\ts16le 1ch 16000Hz\tRUNNING',
+        ].join('\n'),
+    );
+    assert.deepEqual(
+        out.map((e) => e.name),
+        ['meeting_audio', 'agent_output', 'combined_audio'],
+    );
+    assert.ok(out.every((e) => e.spec === 's16le 1ch 16000Hz'));
+});
+
+test('a device running at a DIFFERENT format is reported as-is', () => {
+    // The failure being hunted: something on the capture leg pulling the pipeline
+    // off 16 kHz mono. If the parser normalised this away the probe would be blind.
+    const out = parsePactlShort('1\tagent_output\tmodule-null-sink.c\tfloat32le 2ch 48000Hz\tRUNNING');
+    assert.equal(out[0].spec, 'float32le 2ch 48000Hz');
+});
+
+test('source-outputs are labelled even though their second column is numeric', () => {
+    // This listing is the direct evidence of Teams holding two captures at once:
+    // a numeric source id sits where sinks put a name, so a naive index would
+    // label every client the same and the two would be indistinguishable.
+    const out = parsePactlShort(
+        ['0\t3\t12\tprotocol-native.c\ts16le 1ch 16000Hz', '1\t3\t12\tprotocol-native.c\ts16le 2ch 48000Hz'].join(
+            '\n',
+        ),
+    );
+    assert.equal(out.length, 2);
+    assert.notEqual(out[0].name, out[1].name, 'two concurrent captures must be distinguishable');
+    assert.equal(out[1].spec, 's16le 2ch 48000Hz');
+});
+
+test('blank lines and headers are ignored', () => {
+    assert.deepEqual(parsePactlShort('\n\n'), []);
+    assert.deepEqual(parsePactlShort('no sample spec here\n'), []);
+});
+
+test('formatting is stable so unchanged devices produce no log line', () => {
+    // The probe logs only on change; an unstable rendering would emit a line every
+    // tick and bury the flap it exists to catch.
+    const entries = [{ name: 'agent_output', spec: 's16le 1ch 16000Hz' }];
+    assert.equal(formatDeviceSpecs(entries), formatDeviceSpecs([...entries]));
+    assert.match(formatDeviceSpecs(entries), /agent_output=\[s16le 1ch 16000Hz\]/);
+});
+
+test('an empty listing formats to something falsy, not the string "undefined"', () => {
+    assert.equal(formatDeviceSpecs([]), '');
 });

--- a/lma-virtual-participant-stack/backend/src/audio-diagnostics.test.ts
+++ b/lma-virtual-participant-stack/backend/src/audio-diagnostics.test.ts
@@ -20,14 +20,17 @@ import {
     classifyAudioWindow,
     EXPECTED_PACKETS_PER_SECOND,
     MIN_CAPTURE_RATIO,
+    MIN_MEASURE_SECONDS,
     SPEECH_ENERGY_THRESHOLD,
     STATS_INTERVAL_MS,
 } from './audio-diagnostics.js';
 
+/** Long enough that cumulative capture is judged rather than skipped. */
+const measured = { elapsedSeconds: 60, cumulativeCaptureRatio: 1.0 };
 /** A window with no audio energy: the sender is deliberately silent. */
-const silent = { seconds: 1, packets: 5, captureRatio: 1.0, energyDelta: 0 };
+const silent = { seconds: 1, packets: 5, captureRatio: 1.0, energyDelta: 0, ...measured };
 /** A window mid-utterance on a healthy sender. */
-const speaking = { seconds: 1, packets: 50, captureRatio: 1.0, energyDelta: 0.02 };
+const speaking = { seconds: 1, packets: 50, captureRatio: 1.0, energyDelta: 0.02, ...measured };
 
 test('the expected cadence matches Opus at a 20ms frame', () => {
     // 1000ms / 20ms = 50 packets per second.
@@ -55,10 +58,10 @@ test('a short utterance averaged over a long window is not misread as frame loss
     assert.notEqual(v.state, 'problem');
 });
 
-test('capture starvation is flagged from the capture ratio alone', () => {
+test('capture starvation is flagged from the cumulative ratio', () => {
     // The signature actually being hunted: Chromium losing audio before the encoder
     // sees it. Independent of speech, DTX and window alignment.
-    const v = classifyAudioWindow({ ...speaking, captureRatio: 0.6 });
+    const v = classifyAudioWindow({ ...speaking, cumulativeCaptureRatio: 0.6 });
     assert.equal(v.state, 'problem');
     assert.match(v.reason, /capture starving/);
 });
@@ -66,21 +69,55 @@ test('capture starvation is flagged from the capture ratio alone', () => {
 test('capture starvation is flagged even while silent', () => {
     // Capture runs whether or not the agent is speaking, so a gap during silence is
     // still a real fault — and it is the cheapest window in which to notice one.
-    const v = classifyAudioWindow({ ...silent, captureRatio: 0.5 });
+    const v = classifyAudioWindow({ ...silent, cumulativeCaptureRatio: 0.5 });
     assert.equal(v.state, 'problem');
     assert.match(v.reason, /capture starving/);
 });
 
-test('a healthy capture ratio is accepted with its normal jitter', () => {
-    // The stat is a float differenced across an unaligned window, so it will never
-    // read exactly 1.0; a tight bound here would recreate the false-alarm problem.
-    for (const ratio of [MIN_CAPTURE_RATIO, 0.99, 1.0, 1.01]) {
+test('the per-window ratio never produces a verdict on its own', () => {
+    // Verbatim from the live capture: the per-window ratio alternated between these
+    // two values on a sender whose cumulative ratio was 1.008. The first version
+    // flagged every low-phase window as "capture starving". Four bogus PROBLEM
+    // lines came from exactly these numbers.
+    for (const ratio of [0.954, 0.959, 0.947, 0.949, 1.049, 1.061]) {
         assert.notEqual(
             classifyAudioWindow({ ...speaking, captureRatio: ratio }).state,
+            'problem',
+            `per-window ${ratio} must not be a verdict`,
+        );
+    }
+});
+
+test('cumulative capture is not judged before there is enough of it', () => {
+    // Early on, the cumulative ratio carries the same quantisation as one window,
+    // so judging it would just move the false alarms to the start of the meeting.
+    const v = classifyAudioWindow({
+        ...speaking,
+        elapsedSeconds: MIN_MEASURE_SECONDS - 1,
+        cumulativeCaptureRatio: 0.5,
+    });
+    assert.notEqual(v.state, 'problem');
+});
+
+test('a healthy cumulative ratio is accepted at the threshold', () => {
+    for (const ratio of [MIN_CAPTURE_RATIO, 0.99, 1.0, 1.008, 1.01]) {
+        assert.notEqual(
+            classifyAudioWindow({ ...speaking, cumulativeCaptureRatio: ratio }).state,
             'problem',
             `${ratio} should be treated as healthy`,
         );
     }
+});
+
+test('the starvation message quantifies how much audio was lost', () => {
+    // "0.90 vs 0.95" is not actionable; "6000ms of audio never captured" is.
+    const v = classifyAudioWindow({
+        ...speaking,
+        elapsedSeconds: 60,
+        cumulativeCaptureRatio: 0.95 - 0.05,
+    });
+    assert.equal(v.state, 'problem');
+    assert.match(v.reason, /6000ms of audio never captured/);
 });
 
 test('far-end packet loss is reported as a wire fault, not a capture fault', () => {
@@ -94,7 +131,7 @@ test('far-end packet loss is reported as a wire fault, not a capture fault', () 
 test('capture starvation outranks far-end loss', () => {
     // If capture is already losing frames, the far end will also report loss; the
     // upstream cause is the actionable one.
-    const v = classifyAudioWindow({ ...speaking, captureRatio: 0.4, remotePacketsLost: 3 });
+    const v = classifyAudioWindow({ ...speaking, cumulativeCaptureRatio: 0.4, remotePacketsLost: 3 });
     assert.match(v.reason, /capture starving/);
 });
 

--- a/lma-virtual-participant-stack/backend/src/audio-diagnostics.ts
+++ b/lma-virtual-participant-stack/backend/src/audio-diagnostics.ts
@@ -255,6 +255,76 @@ export function formatDeviceSpecs(entries: Array<{ name: string; spec: string }>
 }
 
 /**
+ * Map device index -> name from `pactl list short sinks|sources`.
+ *
+ * Needed because `pactl list short source-outputs` identifies a stream's device
+ * by INDEX, and indices are not positions in the listing: a live session showed
+ * four sources occupying indices 1-4, so "the third line" is not source 3. Without
+ * this map, "which device is Chromium capturing" is unanswerable — and that is
+ * precisely the question, because if the meeting's microphone were
+ * combined_audio.monitor rather than agent_mic, Teams would be receiving the
+ * meeting's own audio mixed back in.
+ */
+export function parsePactlIndexToName(stdout: string): Map<string, string> {
+    const map = new Map<string, string>();
+    for (const line of stdout.split('\n')) {
+        const cols = line.split('\t');
+        if (cols.length < 2) continue;
+        if (!/^\d+$/.test(cols[0].trim())) continue;
+        map.set(cols[0].trim(), cols[1].trim());
+    }
+    return map;
+}
+
+/** One capturing stream, resolved to a device name and an owning application. */
+export interface CaptureStream {
+    index: string;
+    sourceIndex: string;
+    spec: string;
+    app: string;
+}
+
+/**
+ * Parse the LONG form of `pactl list source-outputs`.
+ *
+ * The short form omits the one field that matters most — `application.name` —
+ * so there is no way to tell Chromium's capture apart from ffmpeg's or a
+ * loopback's. With it, a single log line answers whether the meeting's microphone
+ * is the device we intended.
+ */
+export function parsePactlSourceOutputs(stdout: string): CaptureStream[] {
+    const out: CaptureStream[] = [];
+    // Blocks are separated by the "Source Output #N" header.
+    for (const block of stdout.split(/Source Output #/).slice(1)) {
+        const index = (/^(\d+)/.exec(block) ?? [])[1] ?? '?';
+        const sourceIndex = (/^\s*Source:\s*(\d+)\s*$/m.exec(block) ?? [])[1] ?? '?';
+        const spec = (/^\s*Sample Specification:\s*(.+)$/m.exec(block) ?? [])[1]?.trim() ?? '?';
+        // application.name is quoted; media.name is the fallback label when a
+        // stream has no application (module-loopback, for instance).
+        const app =
+            (/application\.name = "([^"]*)"/.exec(block) ?? [])[1] ??
+            (/media\.name = "([^"]*)"/.exec(block) ?? [])[1] ??
+            'unknown';
+        out.push({ index, sourceIndex, spec, app });
+    }
+    return out;
+}
+
+/** Render capture streams with their device names resolved. */
+export function formatCaptureStreams(
+    streams: CaptureStream[],
+    sourceNames: Map<string, string>,
+): string {
+    return streams
+        .map(
+            (s) =>
+                `${s.app}<-${sourceNames.get(s.sourceIndex) ?? `source#${s.sourceIndex}`}` +
+                `[${s.spec}]`,
+        )
+        .join(' ');
+}
+
+/**
  * Pull the default sink and source out of `pactl info`.
  *
  * Worth logging because a live Teams call was seen capturing with
@@ -282,26 +352,51 @@ export function parsePactlDefaults(stdout: string): { sink?: string; source?: st
  */
 export function startAudioDeviceSpecPolling(intervalMs = DEVICE_SPEC_INTERVAL_MS): () => void {
     const last = new Map<string, string>();
-    const kinds = ['sinks', 'sources', 'source-outputs'];
+    const kinds = ['sinks', 'sources'];
+    /** Latest source index -> name, so capture streams can be resolved by name. */
+    let sourceNames = new Map<string, string>();
+
+    const run = (cmd: string): Promise<string | null> =>
+        new Promise((resolve) => {
+            exec(cmd, { timeout: 4000 }, (err, stdout) => resolve(err ? null : stdout));
+        });
 
     const sample = () => {
-        exec('pactl info', { timeout: 4000 }, (err, stdout) => {
-            if (err) return;
-            const d = parsePactlDefaults(stdout);
-            const line = `sink=${d.sink ?? '?'} source=${d.source ?? '?'}`;
-            if (last.get('defaults') === line) return;
-            last.set('defaults', line);
-            console.log(`[LMA-Audio] pulse defaults: ${line}`);
-        });
-        for (const kind of kinds) {
-            exec(`pactl list short ${kind}`, { timeout: 4000 }, (err, stdout) => {
-                if (err) return; // pulse not up yet, or tearing down
+        void (async () => {
+            const info = await run('pactl info');
+            if (info) {
+                const d = parsePactlDefaults(info);
+                const line = `sink=${d.sink ?? '?'} source=${d.source ?? '?'}`;
+                if (last.get('defaults') !== line) {
+                    last.set('defaults', line);
+                    console.log(`[LMA-Audio] pulse defaults: ${line}`);
+                }
+            }
+
+            for (const kind of kinds) {
+                const stdout = await run(`pactl list short ${kind}`);
+                if (!stdout) continue; // pulse not up yet, or tearing down
+                if (kind === 'sources') sourceNames = parsePactlIndexToName(stdout);
                 const line = formatDeviceSpecs(parsePactlShort(stdout));
-                if (last.get(kind) === line) return;
+                if (last.get(kind) === line) continue;
                 last.set(kind, line);
                 console.log(`[LMA-Audio] pulse ${kind}: ${line || '(none)'}`);
-            });
-        }
+            }
+
+            // Capture streams last, so the index->name map is current. The LONG
+            // form is required: the short form omits application.name, which is
+            // the only way to tell Chromium's capture from ffmpeg's or a
+            // loopback's — and therefore the only way to confirm the meeting's
+            // microphone is the device we intended.
+            const outputs = await run('pactl list source-outputs');
+            if (outputs) {
+                const line = formatCaptureStreams(parsePactlSourceOutputs(outputs), sourceNames);
+                if (last.get('captures') !== line) {
+                    last.set('captures', line);
+                    console.log(`[LMA-Audio] pulse captures: ${line || '(none)'}`);
+                }
+            }
+        })();
     };
 
     sample();

--- a/lma-virtual-participant-stack/backend/src/audio-diagnostics.ts
+++ b/lma-virtual-participant-stack/backend/src/audio-diagnostics.ts
@@ -16,81 +16,159 @@
  *        Simli reconnects went 2 -> 0, but the rescale path was not even active in
  *        the failing session and it still crackled.
  *   #545 forced echoCancellation/noiseSuppression/autoGainControl off — this BROKE
- *        Teams transcription outright and was reverted.
+ *        Teams transcription outright and was reverted. The first live capture from
+ *        this module then showed WHY it could never have helped: Teams already
+ *        requests all three off, and the track confirms them off.
  *
- * What IS established, by measuring the container's own recording of
- * `agent_output`: the signal leaving the container is pristine on both platforms
- * (0 sample-level discontinuities above the click threshold, 0 clipped samples,
- * peak 18245/32767). So the damage happens after the audio leaves PulseAudio, in
- * Chromium's capture / processing / Opus encode — a segment never instrumented.
+ * What IS established: the container's own recording of `agent_output` is pristine
+ * on both platforms (0 sample-level discontinuities above the click threshold, 0
+ * clipped samples, peak 18245/32767). The damage happens after the audio leaves
+ * PulseAudio — in Chromium's capture / encode / send, or on the wire.
  *
- * WHY THIS DOES NOT LOG FROM THE PAGE
- * -----------------------------------
- * A first version of this file logged from inside the page with console.log and
- * produced NOTHING across three live sessions. Counting the captured console lines
- * by type explains why:
+ * WHAT THE FIRST VERSION OF THIS FILE GOT WRONG
+ * ---------------------------------------------
+ * It sampled `packetsSent` every 5s and compared the rate against Opus' 50/s. On a
+ * live Teams call that produced a wall of PROBLEM verdicts at ~4.8 packets/s during
+ * silence and ~25/s around speech. Both were artefacts:
  *
- *     Browser log:       0
- *     Browser warning:   6
- *     Browser error:     4
+ *   - 4.8/s is DTX comfort noise. A sender that is deliberately silent is healthy,
+ *     so flagging it buried any real signal in false alarms.
+ *   - ~25/s came from averaging a ~2.5s utterance over a 5s window. A perfectly
+ *     healthy 50/s sender that speaks for half the window reads as exactly 25/s.
+ *     The metric could not distinguish "half the frames dropped" from "spoke half
+ *     the time", which is precisely the question being asked.
  *
- * `page.on('console')` in index.ts is working, but plain `console.log` from the
- * page never arrives under cloakbrowser — only warnings and errors do. The Simli
- * override's own init-script logs were silent for the same reason, which is why
- * the audio processing module went unsuspected for so long.
+ * So packet rate alone cannot answer this. This version measures quantities that
+ * are independent of how much the agent happened to say:
  *
- * So the page side only ACCUMULATES observations onto `window.__lmaAudio`, and
- * Node drains and prints them on an interval with its own console.log, which
- * demonstrably reaches CloudWatch. No dependency on console forwarding.
+ *   captureRatio  ΔtotalSamplesDuration / Δwall-clock. Seconds of audio Chromium
+ *                 actually captured per second of real time. ~1.0 on a healthy
+ *                 path REGARDLESS of silence or speech; below that means capture is
+ *                 losing audio before the encoder ever sees it. This is the direct
+ *                 test of the starvation theory.
+ *   energyDelta   ΔtotalAudioEnergy, used only to tell speech windows from silent
+ *                 ones so cadence is judged when it is meaningful.
+ *   codec/bitrate what Teams actually negotiated. A low negotiated Opus bitrate, a
+ *                 narrowband codec, or a bandwidth estimator collapsing the target
+ *                 all sound exactly like crackle, and Teams and Zoom negotiate
+ *                 independently — an obvious candidate the old metric was blind to.
+ *   remote loss   packetsLost / jitter as reported BY THE FAR END over RTCP. This
+ *                 splits "we sent bad audio" from "the network broke good audio",
+ *                 which no sender-side counter can do.
  *
  * EVERYTHING HERE IS OBSERVATIONAL. Nothing mutates constraints, tracks or
  * streams; getUserMedia returns the original stream object unchanged. #545 proved
  * that touching this path can silently kill transcription.
+ *
+ * WHY THE PAGE DOES NOT LOG
+ * -------------------------
+ * An earlier version logged from inside the page and produced nothing across three
+ * live sessions. Counting captured console lines by type explains it:
+ *
+ *     Browser log: 0    Browser warning: 6    Browser error: 4
+ *
+ * `page.on('console')` works, but plain `console.log` from the page never arrives
+ * under cloakbrowser. So the page side only ACCUMULATES onto `window.__lmaAudio`
+ * and Node drains it with its own console.log, which demonstrably reaches
+ * CloudWatch.
  */
 import type { Page } from 'playwright-core';
 
-/** How often Node drains the page-side buffer and samples sender stats. */
-export const STATS_INTERVAL_MS = 5000;
+/**
+ * Sampling period. 1s so a single utterance spans several windows — the 5s window
+ * used first could not resolve speech from silence, which is what made its packet
+ * rates meaningless.
+ */
+export const STATS_INTERVAL_MS = 1000;
 
 /** Opus at the standard 20 ms frame duration. */
 export const EXPECTED_PACKETS_PER_SECOND = 50;
 
-/** One sampled window of outbound audio sender stats. */
-export interface OutboundAudioSample {
-    packetsPerSecond: number;
-    sendDelayPerPacketMs?: number;
-}
+/**
+ * ΔtotalAudioEnergy above which a window counts as containing speech. Energy is
+ * the sum of squared sample amplitudes over duration, so silence is not exactly
+ * zero — the null sink's own noise floor lands well below this.
+ */
+export const SPEECH_ENERGY_THRESHOLD = 1e-4;
+
+/** Seconds of captured audio per second of wall clock below which capture is losing frames. */
+export const MIN_CAPTURE_RATIO = 0.95;
 
 /**
- * Classify a sample against the expected Opus cadence. Pure, so the thresholds
- * are testable without a browser.
+ * Longest window over which packet cadence still means anything. Beyond this, a
+ * window mixes speech and silence and the average is uninterpretable — the exact
+ * mistake that made the first live capture read as 50% frame loss when it was a
+ * 2.5s utterance in a 5s window.
  */
-export function classifyOutboundAudio(sample: OutboundAudioSample): {
-    healthy: boolean;
-    reason: string;
-} {
-    const pps = sample.packetsPerSecond;
-    if (pps <= 0) return { healthy: false, reason: 'no audio packets being sent' };
-    // +/-20%: the sampling window is not frame-aligned, so a healthy sender drifts.
-    if (pps < EXPECTED_PACKETS_PER_SECOND * 0.8) {
+export const MAX_CADENCE_WINDOW_SECONDS = 2;
+
+/** One sampled window of outbound audio, already differenced against the previous. */
+export interface AudioWindow {
+    /** Wall-clock length of the window, seconds. */
+    seconds: number;
+    /** Packets sent during the window. */
+    packets: number;
+    /** ΔtotalSamplesDuration / seconds, if the media-source stat was available. */
+    captureRatio?: number;
+    /** ΔtotalAudioEnergy, used to detect whether the agent was speaking. */
+    energyDelta?: number;
+    /** Mean added latency per packet, milliseconds. */
+    sendDelayPerPacketMs?: number;
+    /** Packets the FAR END reported lost during the window. */
+    remotePacketsLost?: number;
+}
+
+export type AudioState = 'idle' | 'ok' | 'problem';
+
+/**
+ * Classify one window. Pure, so the thresholds are testable without a browser —
+ * and so the DTX false-alarm class that made the first version unusable stays
+ * fixed.
+ */
+export function classifyAudioWindow(w: AudioWindow): { state: AudioState; reason: string } {
+    const pps = w.seconds > 0 ? w.packets / w.seconds : 0;
+
+    // Capture continuity first: it is independent of speech, of DTX and of the
+    // sampling window, so it is the only metric here that can stand alone.
+    if (w.captureRatio !== undefined && w.captureRatio < MIN_CAPTURE_RATIO) {
         return {
-            healthy: false,
-            reason: `cadence ${pps.toFixed(1)}/s is below the expected ~${EXPECTED_PACKETS_PER_SECOND}/s — encoder or capture starving`,
+            state: 'problem',
+            reason:
+                `capture starving: ${w.captureRatio.toFixed(3)}s of audio captured per second of wall clock ` +
+                `(need >= ${MIN_CAPTURE_RATIO}) — frames lost before the encoder`,
         };
     }
-    if (pps > EXPECTED_PACKETS_PER_SECOND * 1.2) {
+    if ((w.remotePacketsLost ?? 0) > 0) {
         return {
-            healthy: false,
-            reason: `cadence ${pps.toFixed(1)}/s exceeds the expected ~${EXPECTED_PACKETS_PER_SECOND}/s — bursting after a stall`,
+            state: 'problem',
+            reason: `far end reported ${w.remotePacketsLost} lost packet(s) — damage on the wire, not in capture`,
         };
     }
-    if ((sample.sendDelayPerPacketMs ?? 0) > 20) {
+    if ((w.sendDelayPerPacketMs ?? 0) > 20) {
         return {
-            healthy: false,
-            reason: `send delay ${sample.sendDelayPerPacketMs!.toFixed(1)}ms/packet indicates queueing`,
+            state: 'problem',
+            reason: `send delay ${w.sendDelayPerPacketMs!.toFixed(1)}ms/packet indicates queueing`,
         };
     }
-    return { healthy: true, reason: `steady ${pps.toFixed(1)} packets/s` };
+
+    // Silent windows are healthy: a DTX sender emits ~5 packets/s of comfort noise
+    // by design. Judging cadence here is what produced the earlier false alarms.
+    const speaking = (w.energyDelta ?? 0) > SPEECH_ENERGY_THRESHOLD;
+    if (!speaking) {
+        return { state: 'idle', reason: `silent (${pps.toFixed(1)} pkt/s comfort noise)` };
+    }
+
+    if (pps <= 0) return { state: 'problem', reason: 'audio present but no packets sent' };
+    // Only a LOW cadence during speech is meaningful, and only over a window short
+    // enough that the whole window WAS speech. A high cadence is expected: the
+    // window boundary is not frame-aligned and a DTX sender resumes mid-window.
+    if (w.seconds <= MAX_CADENCE_WINDOW_SECONDS && pps < EXPECTED_PACKETS_PER_SECOND * 0.7) {
+        return {
+            state: 'problem',
+            reason: `speaking but only ${pps.toFixed(1)} pkt/s vs ~${EXPECTED_PACKETS_PER_SECOND}/s expected`,
+        };
+    }
+    return { state: 'ok', reason: `speaking, ${pps.toFixed(1)} pkt/s` };
 }
 
 /**
@@ -155,6 +233,21 @@ export async function installAudioDiagnostics(page: Page): Promise<void> {
 
 /* c8 ignore start - needs a live page; exercised by the container e2e test */
 
+/** Raw per-sender snapshot pulled out of getStats(). */
+interface SenderSnapshot {
+    id: string;
+    packets: number;
+    bytes: number;
+    delay: number;
+    ts: number;
+    samplesDuration?: number;
+    energy?: number;
+    remoteLost?: number;
+    jitterMs?: number;
+    targetBitrate?: number;
+    codec?: string;
+}
+
 /**
  * Start Node-side draining. Logs with Node's console.log, which reaches
  * CloudWatch — unlike page console.log (see the module docstring).
@@ -162,11 +255,18 @@ export async function installAudioDiagnostics(page: Page): Promise<void> {
  * Returns a stop function so the caller can clear the timer on teardown.
  */
 export function startAudioDiagnosticsPolling(page: Page): () => void {
-    const prev = new Map<string, { packets: number; delay: number; ts: number }>();
+    const prev = new Map<string, SenderSnapshot>();
+    /** Codecs already reported, so the negotiated parameters are logged once each. */
+    const reportedCodecs = new Set<string>();
+    /** Consecutive problem windows per sender, so a burst collapses into one line. */
+    const problemRun = new Map<string, number>();
+    let ticks = 0;
 
     const timer = setInterval(() => {
         void (async () => {
             try {
+                ticks += 1;
+
                 // 1. Drain page-side observations.
                 const lines: string[] = await page.evaluate(() => {
                     const w = window as unknown as Record<string, unknown>;
@@ -176,50 +276,110 @@ export function startAudioDiagnosticsPolling(page: Page): () => void {
                 });
                 for (const line of lines) console.log(`[LMA-Audio] ${line}`);
 
-                // 2. Sample outbound audio sender stats from every peer connection.
-                const samples: Array<{ id: string; packets: number; bytes: number; delay: number; ts: number }> =
-                    await page.evaluate(async () => {
-                        const w = window as unknown as Record<string, unknown>;
-                        const pcs = (w.__lmaPCs as RTCPeerConnection[]) || [];
-                        const out: Array<{ id: string; packets: number; bytes: number; delay: number; ts: number }> = [];
-                        for (const pc of pcs) {
-                            if (pc.connectionState === 'closed') continue;
-                            try {
-                                const report = await pc.getStats();
-                                report.forEach((s: Record<string, unknown>) => {
-                                    if (s.type !== 'outbound-rtp' || s.kind !== 'audio') return;
-                                    out.push({
-                                        id: String(s.id),
-                                        packets: Number(s.packetsSent ?? 0),
-                                        bytes: Number(s.bytesSent ?? 0),
-                                        delay: Number(s.totalPacketSendDelay ?? 0),
-                                        ts: Number(s.timestamp ?? 0),
-                                    });
+                // 2. Snapshot every outbound audio sender, joined to its media
+                //    source, negotiated codec and the far end's RTCP report.
+                const snaps: SenderSnapshot[] = await page.evaluate(async () => {
+                    const w = window as unknown as Record<string, unknown>;
+                    const pcs = (w.__lmaPCs as RTCPeerConnection[]) || [];
+                    const out: SenderSnapshot[] = [];
+                    for (const pc of pcs) {
+                        if (pc.connectionState === 'closed') continue;
+                        try {
+                            const report = await pc.getStats();
+                            const byId = new Map<string, Record<string, unknown>>();
+                            report.forEach((s: Record<string, unknown>) => byId.set(String(s.id), s));
+                            report.forEach((s: Record<string, unknown>) => {
+                                if (s.type !== 'outbound-rtp' || s.kind !== 'audio') return;
+                                const src = s.mediaSourceId ? byId.get(String(s.mediaSourceId)) : undefined;
+                                const codec = s.codecId ? byId.get(String(s.codecId)) : undefined;
+                                // The far end's view arrives as a remote-inbound-rtp
+                                // whose localId points back at this sender.
+                                let remote: Record<string, unknown> | undefined;
+                                byId.forEach((cand) => {
+                                    if (cand.type === 'remote-inbound-rtp' && String(cand.localId) === String(s.id)) {
+                                        remote = cand;
+                                    }
                                 });
-                            } catch {
-                                /* ignore a dead pc */
-                            }
+                                out.push({
+                                    id: String(s.id),
+                                    packets: Number(s.packetsSent ?? 0),
+                                    bytes: Number(s.bytesSent ?? 0),
+                                    delay: Number(s.totalPacketSendDelay ?? 0),
+                                    ts: Number(s.timestamp ?? 0),
+                                    samplesDuration: src ? Number(src.totalSamplesDuration ?? NaN) : undefined,
+                                    energy: src ? Number(src.totalAudioEnergy ?? NaN) : undefined,
+                                    remoteLost: remote ? Number(remote.packetsLost ?? NaN) : undefined,
+                                    jitterMs: remote ? Number(remote.jitter ?? NaN) * 1000 : undefined,
+                                    targetBitrate: Number(s.targetBitrate ?? NaN),
+                                    codec: codec
+                                        ? `${codec.mimeType} ${codec.clockRate}Hz/${codec.channels ?? 1}ch ` +
+                                          `fmtp=${codec.sdpFmtpLine ?? '-'}`
+                                        : undefined,
+                                });
+                            });
+                        } catch {
+                            /* ignore a dead pc */
                         }
-                        return out;
-                    });
+                    }
+                    return out;
+                });
 
-                for (const s of samples) {
+                for (const s of snaps) {
+                    // What Teams negotiated is a prime suspect and is static, so log
+                    // it once rather than every second.
+                    if (s.codec && !reportedCodecs.has(s.codec)) {
+                        reportedCodecs.add(s.codec);
+                        console.log(`[LMA-Audio] negotiated ${s.codec}`);
+                    }
+
                     const last = prev.get(s.id);
-                    prev.set(s.id, { packets: s.packets, delay: s.delay, ts: s.ts });
+                    prev.set(s.id, s);
                     if (!last || s.ts <= last.ts) continue;
-                    const secs = (s.ts - last.ts) / 1000;
+                    const seconds = (s.ts - last.ts) / 1000;
                     const dPackets = s.packets - last.packets;
-                    const pps = dPackets / secs;
-                    const perPacketMs = dPackets > 0 ? ((s.delay - last.delay) / dPackets) * 1000 : 0;
-                    const verdict = classifyOutboundAudio({
-                        packetsPerSecond: pps,
-                        sendDelayPerPacketMs: perPacketMs,
-                    });
-                    console.log(
-                        `[LMA-Audio] outbound pps=${pps.toFixed(1)} ` +
-                            `sendDelayPerPacketMs=${perPacketMs.toFixed(2)} ` +
-                            `${verdict.healthy ? 'OK' : 'PROBLEM'}: ${verdict.reason}`,
-                    );
+                    const finite = (n?: number) => (n !== undefined && Number.isFinite(n) ? n : undefined);
+                    const dSamples =
+                        finite(s.samplesDuration) !== undefined && finite(last.samplesDuration) !== undefined
+                            ? s.samplesDuration! - last.samplesDuration!
+                            : undefined;
+                    const window: AudioWindow = {
+                        seconds,
+                        packets: dPackets,
+                        captureRatio: dSamples !== undefined ? dSamples / seconds : undefined,
+                        energyDelta:
+                            finite(s.energy) !== undefined && finite(last.energy) !== undefined
+                                ? s.energy! - last.energy!
+                                : undefined,
+                        sendDelayPerPacketMs:
+                            dPackets > 0 ? ((s.delay - last.delay) / dPackets) * 1000 : 0,
+                        remotePacketsLost:
+                            finite(s.remoteLost) !== undefined && finite(last.remoteLost) !== undefined
+                                ? s.remoteLost! - last.remoteLost!
+                                : undefined,
+                    };
+                    const verdict = classifyAudioWindow(window);
+
+                    // Log every problem and every speech window; summarise idle
+                    // periodically so the log shows liveness without a line a second
+                    // for the whole meeting.
+                    const run = verdict.state === 'problem' ? (problemRun.get(s.id) ?? 0) + 1 : 0;
+                    problemRun.set(s.id, run);
+                    const idleHeartbeat = verdict.state === 'idle' && ticks % 30 === 0;
+                    // A sustained problem prints for the first 5s then every 10s.
+                    const problemThrottled = verdict.state === 'problem' && run > 5 && run % 10 !== 0;
+                    if (verdict.state === 'ok' || idleHeartbeat || (verdict.state === 'problem' && !problemThrottled)) {
+                        const kbps = ((s.bytes - last.bytes) * 8) / 1000 / seconds;
+                        console.log(
+                            `[LMA-Audio] ${verdict.state.toUpperCase()} ${verdict.reason} | ` +
+                                `captureRatio=${window.captureRatio?.toFixed(3) ?? 'n/a'} ` +
+                                `energyDelta=${window.energyDelta?.toExponential(2) ?? 'n/a'} ` +
+                                `kbps=${kbps.toFixed(1)} ` +
+                                `targetKbps=${Number.isFinite(s.targetBitrate!) ? (s.targetBitrate! / 1000).toFixed(1) : 'n/a'} ` +
+                                `remoteLost=${window.remotePacketsLost ?? 'n/a'} ` +
+                                `jitterMs=${Number.isFinite(s.jitterMs!) ? s.jitterMs!.toFixed(1) : 'n/a'}` +
+                                (run > 5 ? ` (x${run} consecutive)` : ''),
+                        );
+                    }
                 }
             } catch {
                 // Page closed / navigated / CDP hiccup. Diagnostics must never

--- a/lma-virtual-participant-stack/backend/src/audio-diagnostics.ts
+++ b/lma-virtual-participant-stack/backend/src/audio-diagnostics.ts
@@ -72,6 +72,7 @@
  * and Node drains it with its own console.log, which demonstrably reaches
  * CloudWatch.
  */
+import { exec } from 'node:child_process';
 import type { Page } from 'playwright-core';
 
 /**
@@ -203,6 +204,85 @@ export function classifyAudioWindow(w: AudioWindow): { state: AudioState; reason
     }
     return { state: 'ok', reason: `speaking, ${pps.toFixed(1)} pkt/s` };
 }
+
+/** How often the PulseAudio device formats are sampled. */
+export const DEVICE_SPEC_INTERVAL_MS = 5000;
+
+/**
+ * Parse `pactl list short <sinks|sources|source-outputs>` into name/format pairs.
+ *
+ * WHY THIS IS WORTH MEASURING
+ * ---------------------------
+ * The regression window for #543 contains exactly two changes, landed the same
+ * day: MicroVM/ARM64 became the host, and #538 pinned all three null sinks to
+ * 16 kHz mono and added a daemon.conf containing `avoid-resampling = yes`. That
+ * setting makes PulseAudio RECONFIGURE a device to match a client instead of
+ * resampling for it — and the live capture shows Teams opening the SAME virtual
+ * mic twice with conflicting formats (mono vs stereo). Two clients demanding
+ * incompatible formats from one monitor source is a recipe for repeated device
+ * re-negotiation, and each re-negotiation glitches audio without dropping a
+ * single RTP packet, which is precisely the signature measured: container-side
+ * recording clean, packet counters clean, listener hears garble.
+ *
+ * That is still only a hypothesis. Logging the formats, and every client
+ * recording from the mic, either shows the flapping or kills the idea outright —
+ * which is the point, given three fixes have already been shipped on mechanism
+ * alone.
+ *
+ * `pactl list short` is tab-separated; the sample-spec column is the one that
+ * matters and its position differs per object type, so match it by shape rather
+ * than by index.
+ */
+export function parsePactlShort(stdout: string): Array<{ name: string; spec: string }> {
+    const out: Array<{ name: string; spec: string }> = [];
+    for (const line of stdout.split('\n')) {
+        if (!line.trim()) continue;
+        const cols = line.split('\t');
+        // e.g. "s16le 1ch 16000Hz" / "float32le 2ch 48000Hz"
+        const spec = cols.find((c) => /^[a-z0-9]+le? \d+ch \d+Hz$/.test(c.trim()));
+        if (!spec) continue;
+        // Sinks/sources put the name second; source-outputs put a numeric device
+        // id there, so fall back to the module column for a usable label.
+        const name = cols[1] && !/^\d+$/.test(cols[1]) ? cols[1] : `${cols[0]}@${cols[1]}`;
+        out.push({ name, spec: spec.trim() });
+    }
+    return out;
+}
+
+/** Render a parsed listing as a single stable line, for change detection. */
+export function formatDeviceSpecs(entries: Array<{ name: string; spec: string }>): string {
+    return entries.map((e) => `${e.name}=[${e.spec}]`).join(' ');
+}
+
+/* c8 ignore start - needs a live PulseAudio; the parser above is what is tested */
+
+/**
+ * Poll the PulseAudio device formats and log ONLY when they change. A stable
+ * pipeline therefore costs three lines for the whole meeting, while format
+ * flapping is unmissable.
+ */
+export function startAudioDeviceSpecPolling(intervalMs = DEVICE_SPEC_INTERVAL_MS): () => void {
+    const last = new Map<string, string>();
+    const kinds = ['sinks', 'sources', 'source-outputs'];
+
+    const sample = () => {
+        for (const kind of kinds) {
+            exec(`pactl list short ${kind}`, { timeout: 4000 }, (err, stdout) => {
+                if (err) return; // pulse not up yet, or tearing down
+                const line = formatDeviceSpecs(parsePactlShort(stdout));
+                if (last.get(kind) === line) return;
+                last.set(kind, line);
+                console.log(`[LMA-Audio] pulse ${kind}: ${line || '(none)'}`);
+            });
+        }
+    };
+
+    sample();
+    const timer = setInterval(sample, intervalMs);
+    return () => clearInterval(timer);
+}
+
+/* c8 ignore stop */
 
 /**
  * Install the page-side collectors. Must run BEFORE navigation: addInitScript only

--- a/lma-virtual-participant-stack/backend/src/audio-diagnostics.ts
+++ b/lma-virtual-participant-stack/backend/src/audio-diagnostics.ts
@@ -91,8 +91,24 @@ export const EXPECTED_PACKETS_PER_SECOND = 50;
  */
 export const SPEECH_ENERGY_THRESHOLD = 1e-4;
 
-/** Seconds of captured audio per second of wall clock below which capture is losing frames. */
+/**
+ * Seconds of captured audio per second of wall clock below which capture is losing
+ * frames.
+ *
+ * Judged on the CUMULATIVE ratio, never a single window. The live capture showed
+ * the per-window value alternating 0.954-0.971 / 1.049-1.061 with a mean of ~1.008
+ * — quantisation between the stats timestamp and the samples-duration counter, not
+ * lost audio. A per-window threshold anywhere near 1.0 therefore fires on every
+ * other window, which is how this metric produced four bogus "capture starving"
+ * lines in its first session. Cumulatively the same quantisation averages out.
+ */
 export const MIN_CAPTURE_RATIO = 0.95;
+
+/**
+ * Cumulative capture is only judged after this long. Below it the ratio is still
+ * dominated by the same quantisation as a single window.
+ */
+export const MIN_MEASURE_SECONDS = 10;
 
 /**
  * Longest window over which packet cadence still means anything. Beyond this, a
@@ -108,8 +124,18 @@ export interface AudioWindow {
     seconds: number;
     /** Packets sent during the window. */
     packets: number;
-    /** ΔtotalSamplesDuration / seconds, if the media-source stat was available. */
+    /**
+     * ΔtotalSamplesDuration / seconds for THIS window. Reported for context only —
+     * too quantised to judge on its own (see MIN_CAPTURE_RATIO).
+     */
     captureRatio?: number;
+    /**
+     * Captured audio / wall clock since the first sample. This is what capture
+     * continuity is judged on.
+     */
+    cumulativeCaptureRatio?: number;
+    /** Wall-clock seconds since the first sample, for MIN_MEASURE_SECONDS. */
+    elapsedSeconds?: number;
     /** ΔtotalAudioEnergy, used to detect whether the agent was speaking. */
     energyDelta?: number;
     /** Mean added latency per packet, milliseconds. */
@@ -129,13 +155,20 @@ export function classifyAudioWindow(w: AudioWindow): { state: AudioState; reason
     const pps = w.seconds > 0 ? w.packets / w.seconds : 0;
 
     // Capture continuity first: it is independent of speech, of DTX and of the
-    // sampling window, so it is the only metric here that can stand alone.
-    if (w.captureRatio !== undefined && w.captureRatio < MIN_CAPTURE_RATIO) {
+    // sampling window, so it is the only metric here that can stand alone. Judged
+    // cumulatively -- a single window is too quantised to mean anything.
+    if (
+        w.cumulativeCaptureRatio !== undefined &&
+        (w.elapsedSeconds ?? 0) >= MIN_MEASURE_SECONDS &&
+        w.cumulativeCaptureRatio < MIN_CAPTURE_RATIO
+    ) {
+        const deficitMs = (1 - w.cumulativeCaptureRatio) * (w.elapsedSeconds ?? 0) * 1000;
         return {
             state: 'problem',
             reason:
-                `capture starving: ${w.captureRatio.toFixed(3)}s of audio captured per second of wall clock ` +
-                `(need >= ${MIN_CAPTURE_RATIO}) — frames lost before the encoder`,
+                `capture starving: ${w.cumulativeCaptureRatio.toFixed(3)}s of audio captured per second of ` +
+                `wall clock over ${(w.elapsedSeconds ?? 0).toFixed(0)}s (${deficitMs.toFixed(0)}ms of audio ` +
+                `never captured) — frames lost before the encoder`,
         };
     }
     if ((w.remotePacketsLost ?? 0) > 0) {
@@ -203,7 +236,17 @@ export async function installAudioDiagnostics(page: Page): Promise<void> {
                 const stream = await original(constraints);
                 try {
                     for (const t of stream.getAudioTracks()) {
-                        push(`track settings ${JSON.stringify(t.getSettings ? t.getSettings() : {})}`);
+                        // The track ID matters as much as the settings: Teams opens
+                        // the SAME device twice with CONFLICTING processing (one mono
+                        // with echoCancellation/AGC/noiseSuppression ON, one stereo
+                        // with all three OFF). Only the sender's media-source
+                        // trackIdentifier says which of the two it actually
+                        // transmits, and Chromium's APM damages samples without
+                        // touching any packet counter — so this is the one
+                        // difference from Zoom that the stats alone cannot resolve.
+                        push(
+                            `track id=${t.id} settings=${JSON.stringify(t.getSettings ? t.getSettings() : {})}`,
+                        );
                     }
                 } catch {
                     /* ignore */
@@ -246,6 +289,14 @@ interface SenderSnapshot {
     jitterMs?: number;
     targetBitrate?: number;
     codec?: string;
+    /** Which captured track this sender transmits — matched against the gUM log. */
+    trackId?: string;
+    /**
+     * Present on the media-source ONLY while Chromium's echo canceller is running
+     * on it. Its presence is therefore a direct test of whether the transmitted
+     * track goes through the audio processing module.
+     */
+    echoReturnLoss?: number;
 }
 
 /**
@@ -256,6 +307,8 @@ interface SenderSnapshot {
  */
 export function startAudioDiagnosticsPolling(page: Page): () => void {
     const prev = new Map<string, SenderSnapshot>();
+    /** First snapshot per sender, so capture continuity can be judged cumulatively. */
+    const first = new Map<string, SenderSnapshot>();
     /** Codecs already reported, so the negotiated parameters are logged once each. */
     const reportedCodecs = new Set<string>();
     /** Consecutive problem windows per sender, so a burst collapses into one line. */
@@ -311,6 +364,11 @@ export function startAudioDiagnosticsPolling(page: Page): () => void {
                                     remoteLost: remote ? Number(remote.packetsLost ?? NaN) : undefined,
                                     jitterMs: remote ? Number(remote.jitter ?? NaN) * 1000 : undefined,
                                     targetBitrate: Number(s.targetBitrate ?? NaN),
+                                    trackId: src ? String(src.trackIdentifier ?? '') : undefined,
+                                    echoReturnLoss:
+                                        src && src.echoReturnLoss !== undefined
+                                            ? Number(src.echoReturnLoss)
+                                            : undefined,
                                     codec: codec
                                         ? `${codec.mimeType} ${codec.clockRate}Hz/${codec.channels ?? 1}ch ` +
                                           `fmtp=${codec.sdpFmtpLine ?? '-'}`
@@ -331,9 +389,20 @@ export function startAudioDiagnosticsPolling(page: Page): () => void {
                         reportedCodecs.add(s.codec);
                         console.log(`[LMA-Audio] negotiated ${s.codec}`);
                     }
+                    // Which of the two capture streams is on the wire, and whether
+                    // Chromium's APM is running on it. Static per sender, so once.
+                    const sourceKey = `src:${s.id}:${s.trackId}`;
+                    if (s.trackId && !reportedCodecs.has(sourceKey)) {
+                        reportedCodecs.add(sourceKey);
+                        console.log(
+                            `[LMA-Audio] sending trackId=${s.trackId} ` +
+                                `echoCanceller=${s.echoReturnLoss !== undefined ? `ACTIVE (erl=${s.echoReturnLoss})` : 'not running'}`,
+                        );
+                    }
 
                     const last = prev.get(s.id);
                     prev.set(s.id, s);
+                    if (!first.has(s.id) && Number.isFinite(s.samplesDuration!)) first.set(s.id, s);
                     if (!last || s.ts <= last.ts) continue;
                     const seconds = (s.ts - last.ts) / 1000;
                     const dPackets = s.packets - last.packets;
@@ -342,10 +411,22 @@ export function startAudioDiagnosticsPolling(page: Page): () => void {
                         finite(s.samplesDuration) !== undefined && finite(last.samplesDuration) !== undefined
                             ? s.samplesDuration! - last.samplesDuration!
                             : undefined;
+                    // Cumulative capture, measured from the sender's first sample:
+                    // immune to the per-window quantisation that made the raw ratio
+                    // unusable as a verdict.
+                    const base = first.get(s.id);
+                    const elapsedSeconds =
+                        base && s.ts > base.ts ? (s.ts - base.ts) / 1000 : undefined;
+                    const cumulativeCaptureRatio =
+                        base && elapsedSeconds && Number.isFinite(s.samplesDuration!)
+                            ? (s.samplesDuration! - base.samplesDuration!) / elapsedSeconds
+                            : undefined;
                     const window: AudioWindow = {
                         seconds,
                         packets: dPackets,
                         captureRatio: dSamples !== undefined ? dSamples / seconds : undefined,
+                        cumulativeCaptureRatio,
+                        elapsedSeconds,
                         energyDelta:
                             finite(s.energy) !== undefined && finite(last.energy) !== undefined
                                 ? s.energy! - last.energy!
@@ -372,6 +453,7 @@ export function startAudioDiagnosticsPolling(page: Page): () => void {
                         console.log(
                             `[LMA-Audio] ${verdict.state.toUpperCase()} ${verdict.reason} | ` +
                                 `captureRatio=${window.captureRatio?.toFixed(3) ?? 'n/a'} ` +
+                                `cumCaptureRatio=${window.cumulativeCaptureRatio?.toFixed(4) ?? 'n/a'} ` +
                                 `energyDelta=${window.energyDelta?.toExponential(2) ?? 'n/a'} ` +
                                 `kbps=${kbps.toFixed(1)} ` +
                                 `targetKbps=${Number.isFinite(s.targetBitrate!) ? (s.targetBitrate! / 1000).toFixed(1) : 'n/a'} ` +

--- a/lma-virtual-participant-stack/backend/src/audio-diagnostics.ts
+++ b/lma-virtual-participant-stack/backend/src/audio-diagnostics.ts
@@ -8,44 +8,48 @@
  * READ-ONLY diagnostics for the voice assistant audio path (GitHub #543).
  *
  * The assistant's audio crackles on Teams but not Zoom. Three fixes have failed,
- * each reasoned from a plausible mechanism rather than a measurement:
+ * each reasoned from a mechanism rather than a measurement:
  *
- *   1. #538 pinned the PulseAudio sinks to 16 kHz mono. Real inefficiency, but
- *      Zoom sounded fine on identical sinks, so resampling was never the cause.
- *   2. #544 cut the avatar's per-frame canvas work and widened the audio buffers.
- *      Simli reconnects went 2 -> 0, but the rescale path was not even active in
- *      the failing session and it still crackled.
- *   3. #545 forced echoCancellation/noiseSuppression/autoGainControl off. That
- *      BROKE Teams transcription outright and was reverted.
+ *   #538 pinned the PulseAudio sinks to 16 kHz mono — real inefficiency, but Zoom
+ *        sounded fine on identical sinks, so resampling was never the cause.
+ *   #544 cut the avatar's per-frame canvas work and widened the audio buffers —
+ *        Simli reconnects went 2 -> 0, but the rescale path was not even active in
+ *        the failing session and it still crackled.
+ *   #545 forced echoCancellation/noiseSuppression/autoGainControl off — this BROKE
+ *        Teams transcription outright and was reverted.
  *
- * What is actually known, from measuring the container's own recording of
- * `agent_output`: the signal leaving the container is pristine on BOTH platforms
+ * What IS established, by measuring the container's own recording of
+ * `agent_output`: the signal leaving the container is pristine on both platforms
  * (0 sample-level discontinuities above the click threshold, 0 clipped samples,
- * peak 18245/32767, 16 kHz mono). So the damage happens after the audio leaves
- * PulseAudio — somewhere in Chromium's capture, processing or Opus encode — and
- * that segment has never been instrumented.
+ * peak 18245/32767). So the damage happens after the audio leaves PulseAudio, in
+ * Chromium's capture / processing / Opus encode — a segment never instrumented.
+ *
+ * WHY THIS DOES NOT LOG FROM THE PAGE
+ * -----------------------------------
+ * A first version of this file logged from inside the page with console.log and
+ * produced NOTHING across three live sessions. Counting the captured console lines
+ * by type explains why:
+ *
+ *     Browser log:       0
+ *     Browser warning:   6
+ *     Browser error:     4
+ *
+ * `page.on('console')` in index.ts is working, but plain `console.log` from the
+ * page never arrives under cloakbrowser — only warnings and errors do. The Simli
+ * override's own init-script logs were silent for the same reason, which is why
+ * the audio processing module went unsuspected for so long.
+ *
+ * So the page side only ACCUMULATES observations onto `window.__lmaAudio`, and
+ * Node drains and prints them on an interval with its own console.log, which
+ * demonstrably reaches CloudWatch. No dependency on console forwarding.
  *
  * EVERYTHING HERE IS OBSERVATIONAL. Nothing mutates constraints, tracks or
- * streams. #545 proved that touching this path can silently kill transcription,
- * so the next change to it must be driven by numbers rather than by another
- * hypothesis.
- *
- * What to look for in the logs:
- *
- *   - `[LMA-Audio] gUM requested` — what the meeting client asks for. Never seen
- *     before; the Simli override that would have logged it is injected too late
- *     to run on Teams at all (zero browser-side lines in a live session).
- *   - `[LMA-Audio] track settings` — what processing is ACTUALLY in effect, which
- *     can differ from what was requested.
- *   - `[LMA-Audio] outbound` — the decisive one. Opus at 20 ms should send ~50
- *     packets/s at a steady cadence. Irregular `pps`, or growth in
- *     `sendDelayPerPacketMs`, localises the fault to Chromium's encode/send on
- *     this host. A clean, steady ~50 pps means the audio leaves correctly and our
- *     code is not the problem.
+ * streams; getUserMedia returns the original stream object unchanged. #545 proved
+ * that touching this path can silently kill transcription.
  */
 import type { Page } from 'playwright-core';
 
-/** How often to sample outbound audio stats. */
+/** How often Node drains the page-side buffer and samples sender stats. */
 export const STATS_INTERVAL_MS = 5000;
 
 /** Opus at the standard 20 ms frame duration. */
@@ -54,41 +58,30 @@ export const EXPECTED_PACKETS_PER_SECOND = 50;
 /** One sampled window of outbound audio sender stats. */
 export interface OutboundAudioSample {
     packetsPerSecond: number;
-    audioLevel?: number;
-    totalAudioEnergy?: number;
-    /** Mean send delay added per packet in this window, in milliseconds. */
     sendDelayPerPacketMs?: number;
-    bytesPerSecond?: number;
 }
 
 /**
- * Classify a sample against the expected Opus cadence.
- *
- * Pure so the thresholds are unit-testable without a browser. Deliberately
- * conservative: this only reports, and a wrong label here costs nothing, whereas
- * a wrong "fix" cost us transcription.
+ * Classify a sample against the expected Opus cadence. Pure, so the thresholds
+ * are testable without a browser.
  */
 export function classifyOutboundAudio(sample: OutboundAudioSample): {
     healthy: boolean;
     reason: string;
 } {
     const pps = sample.packetsPerSecond;
-    // Nothing being sent at all is a different failure from an irregular cadence.
     if (pps <= 0) return { healthy: false, reason: 'no audio packets being sent' };
-    // Allow +/-20%: the sampling window is not frame-aligned, so a little drift is
-    // expected even on a perfectly healthy sender.
-    const low = EXPECTED_PACKETS_PER_SECOND * 0.8;
-    const high = EXPECTED_PACKETS_PER_SECOND * 1.2;
-    if (pps < low) {
+    // +/-20%: the sampling window is not frame-aligned, so a healthy sender drifts.
+    if (pps < EXPECTED_PACKETS_PER_SECOND * 0.8) {
         return {
             healthy: false,
-            reason: `packet cadence ${pps.toFixed(1)}/s is below the expected ~${EXPECTED_PACKETS_PER_SECOND}/s — encoder or capture is starving`,
+            reason: `cadence ${pps.toFixed(1)}/s is below the expected ~${EXPECTED_PACKETS_PER_SECOND}/s — encoder or capture starving`,
         };
     }
-    if (pps > high) {
+    if (pps > EXPECTED_PACKETS_PER_SECOND * 1.2) {
         return {
             healthy: false,
-            reason: `packet cadence ${pps.toFixed(1)}/s exceeds the expected ~${EXPECTED_PACKETS_PER_SECOND}/s — bursting after a stall`,
+            reason: `cadence ${pps.toFixed(1)}/s exceeds the expected ~${EXPECTED_PACKETS_PER_SECOND}/s — bursting after a stall`,
         };
     }
     if ((sample.sendDelayPerPacketMs ?? 0) > 20) {
@@ -101,103 +94,141 @@ export function classifyOutboundAudio(sample: OutboundAudioSample): {
 }
 
 /**
- * Install the observers. Must be called BEFORE navigation: `addInitScript` only
- * runs in documents created after it is registered, which is precisely why the
- * Simli override never ran on Teams.
+ * Install the page-side collectors. Must run BEFORE navigation: addInitScript only
+ * applies to documents created afterwards — the reason the Simli override never
+ * took effect on Teams.
  */
 export async function installAudioDiagnostics(page: Page): Promise<void> {
-    await page.addInitScript(
-        ({ intervalMs, expectedPps }: { intervalMs: number; expectedPps: number }) => {
-            const md = navigator.mediaDevices;
+    await page.addInitScript(() => {
+        const w = window as unknown as Record<string, unknown>;
+        // Buffer of observations for Node to drain. Never logged from here: page
+        // console.log does not reach CloudWatch under cloakbrowser.
+        if (!w.__lmaAudio) w.__lmaAudio = [];
+        const push = (msg: string) => {
+            const buf = w.__lmaAudio as string[];
+            // Bounded, so a long meeting cannot grow this without limit.
+            if (buf.length < 500) buf.push(msg);
+        };
 
-            // ---- 1. Observe getUserMedia, without changing anything ----------
-            if (md && md.getUserMedia) {
-                const original = md.getUserMedia.bind(md);
-                md.getUserMedia = async function (constraints?: MediaStreamConstraints) {
-                    if (constraints && constraints.audio) {
-                        try {
-                            console.log(
-                                `[LMA-Audio] gUM requested audio=${JSON.stringify(constraints.audio)}`,
-                            );
-                        } catch {
-                            /* logging must never affect capture */
-                        }
-                    }
-                    const stream = await original(constraints);
-                    // Report what the browser actually applied — this can differ
-                    // from the request, and it is the ground truth for whether
-                    // echo cancellation / noise suppression / AGC are running.
+        // ---- observe getUserMedia (no mutation) ----
+        const md = navigator.mediaDevices;
+        if (md && md.getUserMedia) {
+            const original = md.getUserMedia.bind(md);
+            md.getUserMedia = async function (constraints?: MediaStreamConstraints) {
+                if (constraints && constraints.audio) {
                     try {
-                        for (const track of stream.getAudioTracks()) {
-                            const s = track.getSettings ? track.getSettings() : {};
-                            console.log(`[LMA-Audio] track settings ${JSON.stringify(s)}`);
-                        }
+                        push(`gUM requested audio=${JSON.stringify(constraints.audio)}`);
                     } catch {
-                        /* ignore */
+                        /* never affect capture */
                     }
-                    return stream;
-                };
-            }
+                }
+                const stream = await original(constraints);
+                try {
+                    for (const t of stream.getAudioTracks()) {
+                        push(`track settings ${JSON.stringify(t.getSettings ? t.getSettings() : {})}`);
+                    }
+                } catch {
+                    /* ignore */
+                }
+                return stream;
+            };
+        }
 
-            // ---- 2. Sample outbound audio sender stats -----------------------
-            // Wrap RTCPeerConnection so every connection the meeting client makes
-            // is sampled, without needing to know how it builds them.
-            const NativePC = window.RTCPeerConnection;
-            if (!NativePC) return;
-            const pcs = new Set<RTCPeerConnection>();
+        // ---- collect outbound audio senders for Node to poll ----
+        const NativePC = window.RTCPeerConnection;
+        if (NativePC) {
+            const pcs: RTCPeerConnection[] = [];
+            w.__lmaPCs = pcs;
             const Wrapped = function (this: unknown, ...args: unknown[]) {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 const pc = new (NativePC as any)(...args);
-                pcs.add(pc);
+                if (pcs.length < 32) pcs.push(pc);
                 return pc;
             } as unknown as typeof RTCPeerConnection;
             Wrapped.prototype = NativePC.prototype;
             window.RTCPeerConnection = Wrapped;
-
-            const prev = new Map<string, { packets: number; bytes: number; delay: number; ts: number }>();
-            setInterval(() => {
-                pcs.forEach((pc) => {
-                    if (pc.connectionState === 'closed') {
-                        pcs.delete(pc);
-                        return;
-                    }
-                    pc.getStats()
-                        .then((report) => {
-                            report.forEach((s: Record<string, unknown>) => {
-                                if (s.type !== 'outbound-rtp' || s.kind !== 'audio') return;
-                                const id = String(s.id);
-                                const packets = Number(s.packetsSent ?? 0);
-                                const bytes = Number(s.bytesSent ?? 0);
-                                const delay = Number(s.totalPacketSendDelay ?? 0);
-                                const ts = Number(s.timestamp ?? Date.now());
-                                const last = prev.get(id);
-                                prev.set(id, { packets, bytes, delay, ts });
-                                if (!last || ts <= last.ts) return;
-                                const secs = (ts - last.ts) / 1000;
-                                const dPackets = packets - last.packets;
-                                const pps = dPackets / secs;
-                                const bps = (bytes - last.bytes) / secs;
-                                const perPacketMs =
-                                    dPackets > 0 ? ((delay - last.delay) / dPackets) * 1000 : 0;
-                                const verdict =
-                                    pps <= 0
-                                        ? 'NO AUDIO SENT'
-                                        : pps < expectedPps * 0.8 || pps > expectedPps * 1.2
-                                          ? 'IRREGULAR'
-                                          : 'steady';
-                                console.log(
-                                    `[LMA-Audio] outbound pps=${pps.toFixed(1)} (expect ~${expectedPps}) ` +
-                                        `bytes/s=${bps.toFixed(0)} sendDelayPerPacketMs=${perPacketMs.toFixed(2)} ` +
-                                        `verdict=${verdict}`,
-                                );
-                            });
-                        })
-                        .catch(() => undefined);
-                });
-            }, intervalMs);
-
-            console.log('[LMA-Audio] diagnostics installed (observational only)');
-        },
-        { intervalMs: STATS_INTERVAL_MS, expectedPps: EXPECTED_PACKETS_PER_SECOND },
-    );
+            push('RTCPeerConnection instrumented');
+        }
+        push(`diagnostics installed in frame ${location.href.slice(0, 120)}`);
+    });
 }
+
+/* c8 ignore start - needs a live page; exercised by the container e2e test */
+
+/**
+ * Start Node-side draining. Logs with Node's console.log, which reaches
+ * CloudWatch — unlike page console.log (see the module docstring).
+ *
+ * Returns a stop function so the caller can clear the timer on teardown.
+ */
+export function startAudioDiagnosticsPolling(page: Page): () => void {
+    const prev = new Map<string, { packets: number; delay: number; ts: number }>();
+
+    const timer = setInterval(() => {
+        void (async () => {
+            try {
+                // 1. Drain page-side observations.
+                const lines: string[] = await page.evaluate(() => {
+                    const w = window as unknown as Record<string, unknown>;
+                    const buf = (w.__lmaAudio as string[]) || [];
+                    w.__lmaAudio = [];
+                    return buf;
+                });
+                for (const line of lines) console.log(`[LMA-Audio] ${line}`);
+
+                // 2. Sample outbound audio sender stats from every peer connection.
+                const samples: Array<{ id: string; packets: number; bytes: number; delay: number; ts: number }> =
+                    await page.evaluate(async () => {
+                        const w = window as unknown as Record<string, unknown>;
+                        const pcs = (w.__lmaPCs as RTCPeerConnection[]) || [];
+                        const out: Array<{ id: string; packets: number; bytes: number; delay: number; ts: number }> = [];
+                        for (const pc of pcs) {
+                            if (pc.connectionState === 'closed') continue;
+                            try {
+                                const report = await pc.getStats();
+                                report.forEach((s: Record<string, unknown>) => {
+                                    if (s.type !== 'outbound-rtp' || s.kind !== 'audio') return;
+                                    out.push({
+                                        id: String(s.id),
+                                        packets: Number(s.packetsSent ?? 0),
+                                        bytes: Number(s.bytesSent ?? 0),
+                                        delay: Number(s.totalPacketSendDelay ?? 0),
+                                        ts: Number(s.timestamp ?? 0),
+                                    });
+                                });
+                            } catch {
+                                /* ignore a dead pc */
+                            }
+                        }
+                        return out;
+                    });
+
+                for (const s of samples) {
+                    const last = prev.get(s.id);
+                    prev.set(s.id, { packets: s.packets, delay: s.delay, ts: s.ts });
+                    if (!last || s.ts <= last.ts) continue;
+                    const secs = (s.ts - last.ts) / 1000;
+                    const dPackets = s.packets - last.packets;
+                    const pps = dPackets / secs;
+                    const perPacketMs = dPackets > 0 ? ((s.delay - last.delay) / dPackets) * 1000 : 0;
+                    const verdict = classifyOutboundAudio({
+                        packetsPerSecond: pps,
+                        sendDelayPerPacketMs: perPacketMs,
+                    });
+                    console.log(
+                        `[LMA-Audio] outbound pps=${pps.toFixed(1)} ` +
+                            `sendDelayPerPacketMs=${perPacketMs.toFixed(2)} ` +
+                            `${verdict.healthy ? 'OK' : 'PROBLEM'}: ${verdict.reason}`,
+                    );
+                }
+            } catch {
+                // Page closed / navigated / CDP hiccup. Diagnostics must never
+                // affect the meeting, so swallow and try again next tick.
+            }
+        })();
+    }, STATS_INTERVAL_MS);
+
+    return () => clearInterval(timer);
+}
+
+/* c8 ignore stop */

--- a/lma-virtual-participant-stack/backend/src/audio-diagnostics.ts
+++ b/lma-virtual-participant-stack/backend/src/audio-diagnostics.ts
@@ -254,6 +254,25 @@ export function formatDeviceSpecs(entries: Array<{ name: string; spec: string }>
     return entries.map((e) => `${e.name}=[${e.spec}]`).join(' ');
 }
 
+/**
+ * Pull the default sink and source out of `pactl info`.
+ *
+ * Worth logging because a live Teams call was seen capturing with
+ * `deviceId: "default"` — so the meeting's microphone was whatever PulseAudio
+ * ranked first, not a device we chose. With a duplicated graph present
+ * (agent_mic AND agent_mic.2) that is genuinely ambiguous, and if it ever
+ * resolved to combined_audio.monitor the meeting would be fed its own mixed
+ * audio back. entrypoint.sh now pins it, and this is how we confirm the pin held.
+ */
+export function parsePactlDefaults(stdout: string): { sink?: string; source?: string } {
+    const sink = /^Default Sink:\s*(.+)$/m.exec(stdout);
+    const source = /^Default Source:\s*(.+)$/m.exec(stdout);
+    return {
+        sink: sink ? sink[1].trim() : undefined,
+        source: source ? source[1].trim() : undefined,
+    };
+}
+
 /* c8 ignore start - needs a live PulseAudio; the parser above is what is tested */
 
 /**
@@ -266,6 +285,14 @@ export function startAudioDeviceSpecPolling(intervalMs = DEVICE_SPEC_INTERVAL_MS
     const kinds = ['sinks', 'sources', 'source-outputs'];
 
     const sample = () => {
+        exec('pactl info', { timeout: 4000 }, (err, stdout) => {
+            if (err) return;
+            const d = parsePactlDefaults(stdout);
+            const line = `sink=${d.sink ?? '?'} source=${d.source ?? '?'}`;
+            if (last.get('defaults') === line) return;
+            last.set('defaults', line);
+            console.log(`[LMA-Audio] pulse defaults: ${line}`);
+        });
         for (const kind of kinds) {
             exec(`pactl list short ${kind}`, { timeout: 4000 }, (err, stdout) => {
                 if (err) return; // pulse not up yet, or tearing down

--- a/lma-virtual-participant-stack/backend/src/index.ts
+++ b/lma-virtual-participant-stack/backend/src/index.ts
@@ -11,7 +11,7 @@ import { transcriptionService } from './scribe.js';
 import { VirtualParticipantStatusManager } from './status-manager.js';
 import { recordingService } from './recording.js';
 import { videoRecorder } from './video-recorder.js';
-import { installAudioDiagnostics } from './audio-diagnostics.js';
+import { installAudioDiagnostics, startAudioDiagnosticsPolling } from './audio-diagnostics.js';
 import { sendEndMeeting, sendStartMeeting } from './kinesis-stream.js';
 import { MCPCommandHandler } from './mcp-command-handler.js';
 import { LambdaClient, InvokeCommand } from '@aws-sdk/client-lambda';
@@ -442,6 +442,10 @@ const main = async (): Promise<void> => {
     // never ran on Teams at all. Read-only by design — the previous attempt at
     // this path mutated constraints and silently killed transcription (#545).
     await installAudioDiagnostics(page);
+    // Node-side draining: page console.log does NOT reach CloudWatch under
+    // cloakbrowser (only warnings/errors do), which is why the first version of
+    // these diagnostics produced nothing across three live sessions.
+    const stopAudioDiagnostics = startAudioDiagnosticsPolling(page);
 
     // Renderer-crash latch. A renderer OOM crash leaves every page.evaluate
     // hanging on "Target crashed", so meeting.initialize() never returns and
@@ -719,7 +723,13 @@ const main = async (): Promise<void> => {
         // Cleanup - set flag to prevent uncaughtException from killing process mid-cleanup
         cleanupInProgress = true;
         console.log('Cleaning up...');
-        
+
+        // Stop the diagnostics timer first: an un-cleared interval holding a page
+        // reference would keep the Node process alive past teardown.
+        try {
+            stopAudioDiagnostics();
+        } catch { /* never block cleanup */ }
+
         try {
             // Stop transcription service
             await transcriptionService.stopTranscription();

--- a/lma-virtual-participant-stack/backend/src/index.ts
+++ b/lma-virtual-participant-stack/backend/src/index.ts
@@ -11,7 +11,11 @@ import { transcriptionService } from './scribe.js';
 import { VirtualParticipantStatusManager } from './status-manager.js';
 import { recordingService } from './recording.js';
 import { videoRecorder } from './video-recorder.js';
-import { installAudioDiagnostics, startAudioDiagnosticsPolling } from './audio-diagnostics.js';
+import {
+    installAudioDiagnostics,
+    startAudioDeviceSpecPolling,
+    startAudioDiagnosticsPolling,
+} from './audio-diagnostics.js';
 import { sendEndMeeting, sendStartMeeting } from './kinesis-stream.js';
 import { MCPCommandHandler } from './mcp-command-handler.js';
 import { LambdaClient, InvokeCommand } from '@aws-sdk/client-lambda';
@@ -446,6 +450,11 @@ const main = async (): Promise<void> => {
     // cloakbrowser (only warnings/errors do), which is why the first version of
     // these diagnostics produced nothing across three live sessions.
     const stopAudioDiagnostics = startAudioDiagnosticsPolling(page);
+    // PulseAudio device formats, logged only when they change. Teams opens the
+    // virtual mic twice with conflicting formats (mono vs stereo); with
+    // avoid-resampling that can make PulseAudio re-negotiate the device
+    // repeatedly, which glitches audio without dropping any RTP packet (#543).
+    const stopDeviceSpecs = startAudioDeviceSpecPolling();
 
     // Renderer-crash latch. A renderer OOM crash leaves every page.evaluate
     // hanging on "Target crashed", so meeting.initialize() never returns and
@@ -728,6 +737,7 @@ const main = async (): Promise<void> => {
         // reference would keep the Node process alive past teardown.
         try {
             stopAudioDiagnostics();
+            stopDeviceSpecs();
         } catch { /* never block cleanup */ }
 
         try {

--- a/lma-virtual-participant-stack/backend/src/scribe-recording-source.test.ts
+++ b/lma-virtual-participant-stack/backend/src/scribe-recording-source.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2025 Amazon.com
+ * This file is licensed under the MIT License.
+ * See the LICENSE file in the project root for full license information.
+ */
+
+/**
+ * Regression tests for the S3 audio recording missing the voice assistant.
+ *
+ * Reported from a live meeting: "the audio recording did not contain the voice
+ * assistant spoken responses, but the video recording does. Same thing with
+ * Teams." Both were true, and the cause was which PulseAudio source each one is
+ * fed from:
+ *
+ *   video recording   ffmpeg on combined_audio.monitor  -> meeting + agent  ✓
+ *   audio recording   ffmpeg on meeting_audio.monitor   -> meeting only     ✗
+ *
+ * meeting_audio is deliberately agent-free so Nova never hears itself, so the
+ * assistant's replies were structurally absent from every audio recording ever
+ * produced — not intermittently lost. It went unnoticed because the assistant's
+ * transcript comes from Nova's own text output, not from Transcribe, so the
+ * transcript looked complete while the audio it supposedly came from was not.
+ *
+ * The recording is now teed inside audioStream(), from the same chunks that go to
+ * Transcribe. These tests assert the wiring at the source level because the
+ * alternative is spawning ffmpeg and PulseAudio.
+ */
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { readFileSync } from 'node:fs';
+
+const src = readFileSync(
+    new URL('./scribe.ts', import.meta.url).pathname.replace('/dist/', '/src/'),
+    'utf8',
+);
+
+/** Body of the named method, up to the start of the next method at the same depth. */
+function methodBody(name: string): string {
+    const start = src.indexOf(name);
+    assert.notEqual(start, -1, `${name} not found in scribe.ts`);
+    const rest = src.slice(start);
+    // Methods in this class are declared at four-space indentation.
+    const end = rest.slice(1).search(/\n {4}(private|public|async|\/\*\*)/);
+    return end === -1 ? rest : rest.slice(0, end + 1);
+}
+
+test('the recording is written from the combined-audio stream', () => {
+    // combined_audio.monitor is the only source carrying BOTH the meeting and the
+    // agent, which is what a meeting recording has to contain.
+    const body = methodBody('private async *audioStream');
+    assert.match(body, /combined_audio\.monitor/);
+    assert.match(body, /recordingStream\.write\(chunk\)/);
+});
+
+test('the recording is NOT written from the meeting-only stream', () => {
+    // The defect itself. meeting_audio.monitor exists precisely to exclude the
+    // agent, so anything recorded from it can never contain the assistant.
+    const body = methodBody('private async writeAudio');
+    assert.match(body, /meeting_audio\.monitor/, 'writeAudio should still feed Nova from meeting-only audio');
+    assert.doesNotMatch(
+        body,
+        /recordingStream\.write/,
+        'writeAudio must not write the recording — meeting_audio.monitor has no agent audio',
+    );
+});
+
+test('writeAudio no longer takes a recording stream at all', () => {
+    // Leaving the parameter in place would invite the bug straight back; removing
+    // it makes reintroducing the write a compile error rather than a silent
+    // regression that only shows up in a recording nobody plays back.
+    assert.match(src, /private async writeAudio\(transcribeResponse: any\): Promise<void>/);
+    assert.doesNotMatch(src, /this\.writeAudio\(response, recordingStream\)/);
+});
+
+test('the recording only captures audio once the meeting has started', () => {
+    // audioStream runs before details.start to keep the Transcribe stream alive
+    // with silence; recording that would prepend the pre-join period to every file.
+    const body = methodBody('private async *audioStream');
+    const guard = body.slice(0, body.indexOf('recordingStream.write(chunk)'));
+    assert.match(guard.split('\n').slice(-4).join('\n'), /details\.start && recordingStream/);
+});
+
+test('the recording tees the pre-framing chunk, not each frame', () => {
+    // frameAudioChunk returns subarrays of the same buffer, so writing frames
+    // would produce an identical file with more syscalls — and if the split ever
+    // changed, a subtly different one.
+    const body = methodBody('private async *audioStream');
+    const writeIdx = body.indexOf('recordingStream.write(chunk)');
+    const frameIdx = body.indexOf('frameAudioChunk(chunk)');
+    assert.ok(writeIdx > 0 && frameIdx > 0);
+    assert.ok(writeIdx < frameIdx, 'the recording write should precede framing');
+});
+
+test('the audio recording and the transcript come from the same samples', () => {
+    // The user-visible promise of a recording: it is what was transcribed. Both
+    // now derive from the single ffmpeg on combined_audio.monitor in audioStream.
+    const body = methodBody('private async *audioStream');
+    assert.match(body, /yield \{ AudioEvent: \{ AudioChunk: frame \} \}/);
+    assert.equal((src.match(/recordingStream\.write/g) || []).length, 1, 'exactly one writer');
+});

--- a/lma-virtual-participant-stack/backend/src/scribe.ts
+++ b/lma-virtual-participant-stack/backend/src/scribe.ts
@@ -89,6 +89,12 @@ const isStaleSessionError = (error: any): boolean => {
 export class TranscriptionService {
     private process: ChildProcess | null = null;           // FFmpeg: combined_audio.monitor → Transcribe
     private novaAudioProcess: ChildProcess | null = null;  // FFmpeg: meeting_audio.monitor → Nova/recording
+    // pacat: meeting audio → combined_audio. This is the SOLE route for meeting
+    // audio into the sink Transcribe reads, and it must stay an ACTIVE stream:
+    // a module-loopback alone let the null sink idle/suspend and combined_audio
+    // went digitally silent (peak amplitude 0 over 50s) while meeting_audio still
+    // had audio (GitHub #569).
+    private meetingToCombinedPipe: ChildProcess | null = null;
     private startTime: number | null = null;
     // Cumulative timeline offset (seconds) applied to Transcribe timestamps.
     // Amazon Transcribe resets Item.StartTime/EndTime to 0 on every new
@@ -624,6 +630,15 @@ export class TranscriptionService {
             try { this.novaAudioProcess.kill(); } catch (_) { /* ignore */ }
             this.novaAudioProcess = null;
         }
+        if (this.meetingToCombinedPipe) {
+            try {
+                if (this.meetingToCombinedPipe.stdin && !this.meetingToCombinedPipe.stdin.destroyed) {
+                    this.meetingToCombinedPipe.stdin.end();
+                }
+                this.meetingToCombinedPipe.kill();
+            } catch (_) { /* ignore */ }
+            this.meetingToCombinedPipe = null;
+        }
     }
 
     async stopTranscription(): Promise<void> {
@@ -722,8 +737,29 @@ export class TranscriptionService {
     // Channel separation (meeting vs combined) prevents Nova from hearing its own voice.
     private async writeAudio(transcribeResponse: any, recordingStream: any): Promise<void> {
         try {
-            // (Meeting audio reaches combined_audio via the module-loopback set up
-            // in entrypoint.sh — see the note in the stdout handler below.)
+            // Pipe meeting audio into combined_audio for Transcribe. This is the
+            // ONLY writer for meeting audio on that sink (entrypoint.sh
+            // deliberately has no loopback for it), so there is no duplication —
+            // and unlike a loopback, an active pacat stream keeps the null sink
+            // from suspending (#542, #569).
+            this.meetingToCombinedPipe = spawn('pacat', [
+                '--playback',
+                '--device=combined_audio',
+                '--format=s16le',
+                '--rate=16000',
+                '--channels=1',
+                '--raw',
+                '--latency-msec=80',
+            ]);
+
+            this.meetingToCombinedPipe.on('error', (error: any) => {
+                console.error(`pacat (meeting→combined) error: ${error.message}`);
+            });
+
+            this.meetingToCombinedPipe.stderr?.on('data', (data: any) => {
+                const msg = data.toString().trim();
+                if (msg) console.log(`pacat (meeting→combined): ${msg}`);
+            });
 
             // Capture meeting-only audio for Nova and recording
             this.novaAudioProcess = spawn('ffmpeg', [
@@ -761,15 +797,12 @@ export class TranscriptionService {
                     try {
                         recordingStream.write(chunk);
 
-                        // NOTE: meeting audio is deliberately NOT forwarded to
-                        // combined_audio here. entrypoint.sh already routes
-                        // meeting_audio.monitor -> combined_audio with a
-                        // module-loopback, so writing it again from this process
-                        // delivered every utterance to Transcribe TWICE, at two
-                        // different latencies. Transcribe duly transcribed both:
-                        // "Jack and Jill, Jack and Jill went up ..." (GitHub #542).
-                        // This process still feeds the recording and the voice
-                        // assistant, which have no other source.
+                        // Sole route for meeting audio into combined_audio (see
+                        // the pacat spawn above). entrypoint.sh has no loopback
+                        // for it, so this does not duplicate (#542).
+                        if (this.meetingToCombinedPipe?.stdin && !this.meetingToCombinedPipe.stdin.destroyed) {
+                            this.meetingToCombinedPipe.stdin.write(chunk);
+                        }
 
                         if (voiceAssistant.isEnabled() && voiceAssistant.isActive() && voiceAssistant.isActivated()) {
                             voiceAssistant.sendAudioChunk(chunk);

--- a/lma-virtual-participant-stack/backend/src/scribe.ts
+++ b/lma-virtual-participant-stack/backend/src/scribe.ts
@@ -88,7 +88,7 @@ const isStaleSessionError = (error: any): boolean => {
 
 export class TranscriptionService {
     private process: ChildProcess | null = null;           // FFmpeg: combined_audio.monitor → Transcribe
-    private novaAudioProcess: ChildProcess | null = null;  // FFmpeg: meeting_audio.monitor → Nova/recording
+    private novaAudioProcess: ChildProcess | null = null;  // FFmpeg: meeting_audio.monitor → Nova (NOT the recording)
     // pacat: meeting audio → combined_audio. This is the SOLE route for meeting
     // audio into the sink Transcribe reads, and it must stay an ACTIVE stream:
     // a module-loopback alone let the null sink idle/suspend and combined_audio
@@ -150,7 +150,15 @@ export class TranscriptionService {
         console.log('Wake phrases configured:', this.wakePhrases);
     }
 
-    private async *audioStream() {
+    /**
+     * @param recordingStream tee of the audio that goes to Transcribe, which is
+     *   what the meeting's S3 audio recording must contain. It used to be fed from
+     *   the meeting-ONLY ffmpeg in writeAudio, so the voice assistant's spoken
+     *   replies were structurally absent from every recording — while the video
+     *   recording, which captures combined_audio.monitor, had them. Teeing here
+     *   makes the audio recording match both the transcript and the video.
+     */
+    private async *audioStream(recordingStream?: NodeJS.WritableStream) {
 
         // Capture from combined_audio.monitor to get both meeting and agent audio for transcription
         this.process = spawn('ffmpeg', [
@@ -190,6 +198,14 @@ export class TranscriptionService {
 
         try {
             for await (const chunk of this.process.stdout!) {
+                // Record exactly what Transcribe hears, before framing: the frames
+                // below are subarrays of this chunk, so writing them instead would
+                // duplicate nothing but cost an extra write per frame. Gated on
+                // details.start for the same reason the silence branch below is —
+                // nothing before the meeting starts belongs in the recording.
+                if (details.start && recordingStream) {
+                    recordingStream.write(chunk);
+                }
                 // Cap the frame size (see MAX_AUDIO_CHUNK_BYTES). ffmpeg can hand
                 // over a buffer larger than Transcribe accepts, which used to
                 // abort transcription for the rest of the meeting (GitHub #536).
@@ -296,7 +312,7 @@ export class TranscriptionService {
             const sessionStartMs = Date.now();
             try {
                 const transcriptionParams: any = {
-                    AudioStream: this.audioStream(),
+                    AudioStream: this.audioStream(recordingStream),
                     MediaSampleRateHertz: this.sampleRate,
                     MediaEncoding: 'pcm',
                     ShowSpeakerLabel: true,
@@ -377,7 +393,7 @@ export class TranscriptionService {
                 if (isLocalTest) {
                     try {
                         await Promise.all([
-                            this.writeAudio(response, recordingStream).catch(err => {
+                            this.writeAudio(response).catch(err => {
                                 console.error('Audio write error (non-fatal in local test):', err.message);
                                 return Promise.resolve();
                             }),
@@ -392,7 +408,7 @@ export class TranscriptionService {
                 } else {
                     // Production mode - let errors crash the task
                     await Promise.all([
-                        this.writeAudio(response, recordingStream),
+                        this.writeAudio(response),
                         this.handleTranscriptEvents(response)
                     ]);
                 }
@@ -732,10 +748,11 @@ export class TranscriptionService {
     }
 
     // Captures meeting-only audio (meeting_audio.monitor) via a separate FFmpeg process.
-    // Feeds audio to: (1) recording file, (2) combined_audio sink for Transcribe, (3) voice assistant.
+    // Feeds audio to: (1) combined_audio sink for Transcribe, (2) voice assistant.
+    // NOT the recording — see audioStream(), which tees it from combined_audio.
     // Uses separate process variables to avoid overwriting the transcription FFmpeg in audioStream().
     // Channel separation (meeting vs combined) prevents Nova from hearing its own voice.
-    private async writeAudio(transcribeResponse: any, recordingStream: any): Promise<void> {
+    private async writeAudio(transcribeResponse: any): Promise<void> {
         try {
             // Pipe meeting audio into combined_audio for Transcribe. This is the
             // ONLY writer for meeting audio on that sink (entrypoint.sh
@@ -795,8 +812,11 @@ export class TranscriptionService {
             this.novaAudioProcess.stdout?.on('data', async (chunk: Buffer) => {
                 if (details.start && this.isTranscribing) {
                     try {
-                        recordingStream.write(chunk);
-
+                        // NOT written to the recording: this stream is meeting-only
+                        // by design (Nova must not hear itself), so recording it
+                        // silently dropped the assistant's replies. The recording is
+                        // teed from combined_audio.monitor in audioStream() instead.
+                        //
                         // Sole route for meeting audio into combined_audio (see
                         // the pacat spawn above). entrypoint.sh has no loopback
                         // for it, so this does not duplicate (#542).

--- a/lma-virtual-participant-stack/test/test_audio_graph_idempotency.py
+++ b/lma-virtual-participant-stack/test/test_audio_graph_idempotency.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2025 Amazon.com
+# This file is licensed under the MIT License.
+# See the LICENSE file in the project root for full license information.
+"""The PulseAudio graph in entrypoint.sh must be safe to build more than once.
+
+A live MicroVM was observed with the ENTIRE audio graph duplicated::
+
+    sinks:   meeting_audio  agent_output  combined_audio
+             meeting_audio.2 agent_output.2 combined_audio.2
+    sources: meeting_audio.monitor agent_output.monitor combined_audio.monitor
+             agent_mic
+             meeting_audio.2.monitor agent_output.2.monitor
+             combined_audio.2.monitor agent_mic.2
+
+``pactl`` renames a colliding sink instead of failing, so nothing complained.
+
+The cause is the MicroVM lifecycle: ``bootStack()`` runs this script from the
+``/ready`` hook, and Lambda RETRIES ``/ready`` whenever it answers 503 -- roughly
+three times on a cold ARM boot, and ``bootStack`` reports failure if the VNC
+ports come up slower than its timeout. Every ``load-module`` ran again on each
+retry.
+
+The spare sinks are inert (nothing writes to them). The damage is the second
+``module-loopback`` from ``agent_output.monitor`` into ``combined_audio``: it
+mixes the agent's voice in TWICE at two independent latencies, which is exactly
+the double-writer entrypoint.sh warns about for meeting audio in GitHub #542 --
+there, it made Transcribe emit every utterance twice ("Jack and Jill, Jack and
+Jill went up ..."). And since ``/ready`` runs at IMAGE BUILD time, the duplicate
+graph lands in the snapshot, so every launch inherits it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ENTRYPOINT = (
+    Path(__file__).resolve().parents[1] / "backend" / "entrypoint.sh"
+)
+
+
+@pytest.fixture(name="entrypoint")
+def entrypoint_fixture() -> str:
+    return ENTRYPOINT.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("sink", ["meeting_audio", "agent_output", "combined_audio"])
+def test_each_null_sink_is_guarded_by_an_existence_check(entrypoint: str, sink: str) -> None:
+    """Creating a sink that already exists yields a renamed `.2` duplicate."""
+    assert f"pa_sink_exists {sink}" in entrypoint, (
+        f"module-null-sink {sink} must be skipped when it already exists"
+    )
+
+
+def test_the_agent_loopback_is_guarded(entrypoint: str) -> None:
+    """The one duplicate that actually corrupts audio.
+
+    Two loopbacks from the same monitor into the same sink sum the agent's voice
+    twice, at two independent latencies -- the #542 double-writer, applied to the
+    agent leg instead of the meeting leg.
+    """
+    assert "pa_loopback_exists agent_output.monitor combined_audio" in entrypoint
+
+
+def test_the_agent_mic_remap_source_is_guarded(entrypoint: str) -> None:
+    """A second agent_mic makes the meeting's microphone ambiguous.
+
+    Chromium was seen requesting `deviceId: "default"`, so with both agent_mic and
+    agent_mic.2 present, which one becomes the meeting's mic is PulseAudio's
+    choice rather than ours.
+    """
+    assert "pa_source_exists agent_mic" in entrypoint
+
+
+def test_the_guard_helpers_match_names_exactly(entrypoint: str) -> None:
+    """`grep -qx` on the name column, not a substring match.
+
+    A substring match would make `agent_output` satisfy a check for `agent_out`,
+    and -- worse -- would let `agent_output.2` satisfy the check for
+    `agent_output`, so a graph that was ALREADY duplicated would look correct.
+    """
+    for helper in ("pa_sink_exists", "pa_source_exists"):
+        match = re.search(rf"{helper}\(\) \{{(.+?)\}}", entrypoint, re.S)
+        assert match, f"{helper} should be defined"
+        body = match.group(1)
+        assert "cut -f2" in body, f"{helper} must look at the name column only"
+        assert "grep -qx" in body, f"{helper} must match the whole name"
+
+
+def test_the_default_source_is_pinned(entrypoint: str) -> None:
+    """Otherwise the meeting's microphone is whatever PulseAudio ranks first.
+
+    Every other reader names its device explicitly (the ffmpegs, the pacat
+    streams, the speaking detector), so nothing depended on the previous
+    behaviour -- but Chromium asked for "default" and got an unspecified source.
+    """
+    assert "pactl set-default-source agent_mic" in entrypoint
+
+
+def test_the_default_sink_is_still_pinned(entrypoint: str) -> None:
+    """Chromium's meeting audio has to land in meeting_audio, not a spare sink."""
+    assert "pactl set-default-sink meeting_audio" in entrypoint
+
+
+def test_meeting_audio_still_has_no_loopback_into_combined(entrypoint: str) -> None:
+    """Guard the #542/#569 invariant while adding guards around it.
+
+    meeting audio reaches combined_audio through the app's ACTIVE pacat stream
+    only: a module-loopback there went digitally silent because it does not keep a
+    null sink out of suspend (#569), and a second writer duplicated every
+    utterance to Transcribe (#542).
+    """
+    loopbacks: list[str] = re.findall(r"module-loopback[^\n]*", entrypoint)
+    for line in loopbacks:
+        assert "source=meeting_audio.monitor" not in line, (
+            f"meeting_audio must not be loopback-routed into combined_audio: {line}"
+        )

--- a/lma-virtual-participant-stack/test/test_audio_sample_rates.py
+++ b/lma-virtual-participant-stack/test/test_audio_sample_rates.py
@@ -106,9 +106,30 @@ def test_resampler_favours_quality_over_speed(dockerfile: str) -> None:
     assert int(method.rsplit("-", 1)[1]) >= 3, "quality level should be >= 3"
 
 
-def test_avoid_resampling_is_enabled(dockerfile: str) -> None:
-    """Makes PulseAudio follow the stream's rate instead of converting."""
-    assert "avoid-resampling = yes" in dockerfile
+def test_avoid_resampling_is_not_enabled(dockerfile: str) -> None:
+    """avoid-resampling must stay OFF; the explicit sink pinning replaces it.
+
+    It tells PulseAudio to RECONFIGURE a device to a client's rate rather than
+    resample for it. That buys nothing here -- every null sink already carries an
+    explicit ``rate=16000 channels=1 format=s16le`` (see the tests above), and
+    that pinning is what removed the triple resample of GitHub #538.
+
+    It can, however, do harm. Teams opens the agent_mic remap source TWICE with
+    conflicting formats (one mono capture with echoCancellation/AGC on, one stereo
+    capture with them off -- both observed on a live call via the audio
+    diagnostics), so two clients demand incompatible formats from a single monitor
+    source. Zoom opens it once, and Zoom is the platform that sounds fine. Device
+    re-negotiation glitches audio without dropping an RTP packet, which matches
+    every measurement taken for #543: the container-side recording is clean, the
+    packet counters are clean, and only the meeting listener hears garble.
+    """
+    # Match the printf form the config lines are actually written in, not any
+    # mention of the word -- the Dockerfile comment explains why it is absent, and
+    # a bare substring check would fail on that explanation.
+    setting = [
+        line for line in dockerfile.splitlines() if re.match(r"\s*'avoid-resampling", line)
+    ]
+    assert not setting, f"avoid-resampling must not be set: {setting}"
 
 
 def test_daemon_config_is_owned_by_the_running_user(dockerfile: str) -> None:

--- a/lma-virtual-participant-stack/test/test_audio_single_writer.py
+++ b/lma-virtual-participant-stack/test/test_audio_single_writer.py
@@ -159,7 +159,11 @@ def test_only_nova_writes_into_agent_output() -> None:
 
 def test_pulse_loopback_latency_tolerates_cpu_jitter(entrypoint_lines: list[str]) -> None:
     for line in entrypoint_lines:
-        if "module-loopback" not in line:
+        # Only lines that CREATE a loopback. entrypoint.sh also greps the module
+        # list for an existing loopback to stay idempotent under /ready retries
+        # (see test_audio_graph_idempotency.py), and that detection pattern
+        # naturally mentions module-loopback without setting a latency.
+        if "load-module module-loopback" not in line:
             continue
         match = re.search(r"latency_msec=(\d+)", line)
         assert match, f"loopback should set latency_msec explicitly: {line.strip()}"

--- a/lma-virtual-participant-stack/test/test_audio_single_writer.py
+++ b/lma-virtual-participant-stack/test/test_audio_single_writer.py
@@ -66,9 +66,19 @@ def entrypoint_lines() -> list[str]:
     return _uncommented(ENTRYPOINT)
 
 
-def test_exactly_one_loopback_writes_meeting_audio_into_combined(
+def test_no_loopback_writes_meeting_audio_into_combined(
     entrypoint_lines: list[str],
 ) -> None:
+    """A module-loopback is NOT a reliable route into a null sink.
+
+    It does not keep the sink out of PulseAudio's idle/suspend state, so this
+    route went digitally silent: a live Zoom session recorded 50s of
+    combined_audio with peak amplitude 0 while meeting_audio itself had audio
+    (GitHub #569). The app's pacat stream is the route instead -- it delivers the
+    audio AND keeps the sink running.
+
+    This is the inverse of the original #542 fix, which removed the wrong writer.
+    """
     writers = [
         line
         for line in entrypoint_lines
@@ -76,26 +86,44 @@ def test_exactly_one_loopback_writes_meeting_audio_into_combined(
         and "source=meeting_audio.monitor" in line
         and "sink=combined_audio" in line
     ]
-    assert len(writers) == 1, (
-        f"expected exactly 1 loopback meeting_audio -> combined_audio, found "
-        f"{len(writers)}: {writers}"
+    assert not writers, (
+        "entrypoint.sh must NOT loopback meeting_audio into combined_audio; the "
+        f"pacat stream in scribe.ts is the sole route. Found: {writers}"
     )
 
 
-def test_the_app_does_not_also_write_meeting_audio_into_combined() -> None:
-    """This is the specific regression: a SECOND writer from the app.
+def test_the_app_is_the_sole_writer_of_meeting_audio_into_combined() -> None:
+    """scribe.ts holds exactly one ACTIVE pacat stream on combined_audio.
 
-    scribe.ts spawned `pacat --playback --device=combined_audio` and fed it the
-    same meeting audio the entrypoint loopback already routes.
+    "Active" is the load-bearing word: it is what keeps the null sink from
+    suspending. Exactly one, because two writers made Transcribe hear every
+    utterance twice ("Jack and Jill, Jack and Jill went up...", #542).
     """
     scribe = "\n".join(_uncommented(SCRIBE))
-    assert "--device=combined_audio" not in scribe, (
-        "scribe.ts must not write into combined_audio; entrypoint.sh's "
-        "module-loopback is the sole route for meeting audio"
+    assert scribe.count("--device=combined_audio") == 1, (
+        "expected exactly one pacat writer into combined_audio in scribe.ts"
     )
-    assert "meetingToCombinedPipe" not in scribe, (
-        "the duplicate pacat pipe should be fully removed, not just unused"
+    assert "meetingToCombinedPipe.stdin.write(chunk)" in scribe, (
+        "the pipe must actually be fed, not merely spawned"
     )
+
+
+def test_the_pacat_writer_uses_an_active_stream_not_a_oneshot() -> None:
+    """The stream must be long-lived, since keeping the sink awake is its job.
+
+    A short-lived writer would deliver its chunk and let combined_audio suspend
+    again, reproducing #569 intermittently — which is the worst version of this
+    bug, because it looks like it works.
+    """
+    scribe = SCRIBE.read_text()
+    spawn_idx = scribe.index("--device=combined_audio")
+    # The handle is retained on the instance and fed from the ffmpeg data handler,
+    # rather than spawned per chunk.
+    assert "this.meetingToCombinedPipe = spawn('pacat'" in scribe
+    assert scribe.count("spawn('pacat'") >= 1
+    # ...and torn down with the session, not leaked.
+    assert "this.meetingToCombinedPipe.kill()" in scribe
+    assert spawn_idx > 0
 
 
 def test_agent_audio_also_has_exactly_one_route_into_combined(


### PR DESCRIPTION
Started as the #569 one-liner and grew as live testing on LMA-Bob surfaced more. Eight commits, three of them real fixes and the rest measurement.

## Fixes

**#569 — `combined_audio` went digitally silent.** Restores the `pacat` writer as the SOLE route for meeting audio into `combined_audio`. A `module-loopback` does not keep a null sink out of PulseAudio's idle/suspend state, so a live Zoom session recorded 50s of `combined_audio` at peak amplitude 0 while `meeting_audio` itself had audio. Verified live: transcription, assistant audio and video-recording audio all working on Zoom.

**The S3 audio recording never contained the voice assistant.** It was fed from `meeting_audio.monitor`, which is deliberately agent-free so Nova never hears itself — so the assistant's replies were structurally absent from *every* audio recording ever produced, while the video recording (which reads `combined_audio.monitor`) had them. It hid for so long because the assistant's transcript comes from Nova's own text output rather than from Transcribe: the transcript looked complete while the audio it supposedly came from was not. Now teed from the same chunks that go to Transcribe, so the recording is by construction what was transcribed.

**MicroVM `/ready` retries built the PulseAudio graph twice.** `bootStack()` runs `entrypoint.sh` from the `/ready` hook and Lambda retries `/ready` on 503 (~3 times on a cold ARM boot). No `load-module` was idempotent and `pactl` silently renames a colliding sink, so a live MicroVM was running with 6 sinks and 8 sources instead of 3 and 4. Because `/ready` runs at *image build* time, the duplicate graph was captured in the snapshot and every launch inherited it. The damaging duplicate is the second `module-loopback agent_output.monitor → combined_audio`, which mixes the agent's voice in twice at two independent latencies — the same double-writer defect as #542. Also pins `set-default-source agent_mic`, which had never been set (a live Teams call was seen capturing `deviceId: "default"`).

Additionally drops `avoid-resampling = yes`: redundant now that every sink carries an explicit `rate=16000 channels=1 format=s16le`, and it makes PulseAudio reconfigure devices to match clients.

## Diagnostics for #543

Read-only. `#545` proved that mutating this path can silently kill transcription, so nothing here touches constraints, tracks or streams.

Measures capture continuity (`totalSamplesDuration` vs wall clock), the negotiated codec and bitrate, far-end RTCP loss/jitter, which captured track is transmitted, whether Chromium's echo canceller is running on it, and which PulseAudio device each process is capturing. Drains from Node, because page `console.log` does not reach CloudWatch under cloakbrowser.

Two earlier versions of these diagnostics produced false alarms and were rewritten: DTX comfort noise read as "capture starving", and a 2.5s utterance averaged over a 5s window read as 50% frame loss. Both false-alarm classes are pinned by tests using the values from the live captures.

## #543 is NOT fixed

The garble on Teams remains unresolved and is documented rather than guessed at. What the diagnostics establish:

- The container-side signal is clean (0 discontinuities, 0 clipped, peak 18245/32767; the video recording is clean to the ear on Teams).
- The sender is clean during speech: 48 pkt/s, ~24 kbps Opus, `remoteLost=0`, cumulative capture continuity 1.008.
- So the damage is to the **samples**, not the stream — nothing in packet-land will show it.

Refuted and recorded in the code comments so they are not retried: triple resampling (#538), avatar CPU (#544), Chromium audio processing (#545 — `echoCanceller=not running` on the transmitted track), `avoid-resampling` re-negotiation (device formats never changed across a whole call), and the duplicated graph (fixed; still garbled).

## Testing

132 container tests, 112 python tests. New coverage for the recording source, audio-graph idempotency (including exact-name matching so an already-duplicated graph cannot look correct), and the capture/format probes.