### PR TITLE
fix(capture-app/macos): don't announce a dead session as a completed meeting

### DIFF
--- a/lma-desktop-capture-app-stack/source/macos/Sources/LMACaptureClient/CaptureController.swift
+++ b/lma-desktop-capture-app-stack/source/macos/Sources/LMACaptureClient/CaptureController.swift
@@ -19,6 +19,53 @@ final class CaptureController {
         case error(String)
     }
 
+    /// Decides, from the STREAM of state changes, when a recording session began
+    /// and whether it ended well — so the UI announces "your meeting is being
+    /// processed" only when a meeting actually got uploaded.
+    ///
+    /// Why a tracker and not a test on the new state alone: teardown always
+    /// passes through `.stopping`, for a clean Stop AND for a fatal auth, so
+    /// `.stopping` carries no information about the outcome. Judging it in
+    /// isolation is what made a dead session (token rejected, nothing sent)
+    /// announce a successful upload with a link to a meeting that was never
+    /// created. Instead `.stopping` is treated as "still in flight" and the
+    /// outcome is taken from the TERMINAL state that follows it: `.error` failed,
+    /// `.authenticated`/`.idle` succeeded.
+    ///
+    /// This also removes any dependence on the order in which the fatal-auth path
+    /// happens to set its states, which is a fragile thing to rely on. Pure and
+    /// sequence-tested in SelfTest.
+    struct SessionTracker {
+        enum Event: Equatable {
+            case none
+            case started
+            case ended(succeeded: Bool)
+        }
+
+        /// True while a recording session is in flight (including during teardown).
+        private(set) var active = false
+
+        mutating func observe(_ state: State) -> Event {
+            switch state {
+            case .streaming:
+                if active { return .none }   // repeat/no-op
+                active = true
+                return .started
+            case .stopping, .starting, .signingIn:
+                // Transient: a session may still be in flight, so decide nothing.
+                return .none
+            case .error:
+                guard active else { return .none }   // e.g. a sign-in or pre-stream failure
+                active = false
+                return .ended(succeeded: false)
+            case .authenticated, .idle:
+                guard active else { return .none }
+                active = false
+                return .ended(succeeded: true)
+            }
+        }
+    }
+
     private(set) var config: Config
     /// Keeps the access token fresh while signed in. Lives on the CONTROLLER, not
     /// the socket, so it survives Stop/Start and keeps refreshing while nothing
@@ -117,6 +164,12 @@ final class CaptureController {
     /// schedule. Refreshed tokens are mirrored back onto `config` so everything
     /// that reads it (isAuthenticated, sockets created later) stays correct.
     private func installTokenStore() {
+        // Retire any previous refresher first. Nothing reachable installs a store
+        // while another is live (the sign-in form only appears once the tokens are
+        // cleared), but an in-flight refresh on an abandoned store would write its
+        // stale token onto `config` through onRefresh and clobber the new session.
+        // One line to make that unrepresentable rather than merely unreachable.
+        tokenStore?.invalidate()
         let store = TokenStore(accessToken: config.accessToken, idToken: config.idToken,
                                refreshToken: config.refreshToken,
                                clientId: config.clientId, region: config.effectiveRegion)

--- a/lma-desktop-capture-app-stack/source/macos/Sources/LMACaptureClient/MenuBarApp.swift
+++ b/lma-desktop-capture-app-stack/source/macos/Sources/LMACaptureClient/MenuBarApp.swift
@@ -65,6 +65,9 @@ final class MenuBarAppState: ObservableObject {
     private var segmentStartedAt: Date?
     private var accumulatedSeconds = 0
     private var elapsedTimer: Timer?
+    /// Turns the state stream into begin/end recording events (see
+    /// CaptureController.SessionTracker).
+    private var sessionTracker = CaptureController.SessionTracker()
 
     /// Recently used meeting names (most recent first), for quick re-selection.
     @Published var recentMeetingNames: [String] = []
@@ -139,17 +142,19 @@ final class MenuBarAppState: ObservableObject {
         }
         controller.onStateChange = { [weak self] s in
             guard let self = self else { return }
-            let wasStreaming = self.isStreaming
             self.state = s
-            let nowStreaming = self.isStreaming
-            if nowStreaming && !wasStreaming {
+            // An error (rejected token, capture failure) means nothing was
+            // uploaded — don't tell the user a recording is on its way. The
+            // outcome is taken from the terminal state AFTER teardown, not from
+            // the `.stopping` that every teardown passes through; see
+            // CaptureController.SessionTracker for why that distinction matters.
+            switch self.sessionTracker.observe(s) {
+            case .none:
+                break
+            case .started:
                 self.beginElapsedTimer()
-            } else if !nowStreaming && wasStreaming {
-                // An error (bad token, capture failure) or sign-out means nothing
-                // was uploaded — don't tell the user a recording is on its way.
-                let failed: Bool
-                if case .error = s { failed = true } else { failed = false }
-                self.endElapsedTimer(succeeded: !failed)
+            case .ended(let succeeded):
+                self.endElapsedTimer(succeeded: succeeded)
             }
         }
         controller.onLevels = { [weak self] m, k, c, p in

--- a/lma-desktop-capture-app-stack/source/macos/Sources/LMACaptureClient/SelfTest.swift
+++ b/lma-desktop-capture-app-stack/source/macos/Sources/LMACaptureClient/SelfTest.swift
@@ -190,6 +190,64 @@ enum SelfTest {
         check("redaction is a no-op on clean text",
               TranscriberSocket.redactingTokens("plain error, no tokens"), "plain error, no tokens")
 
+        // ── Session outcome from a state SEQUENCE ────────────────────────────
+        // Whether the UI announces "your meeting is being processed" (with a link
+        // to it). Announcing that for a session which uploaded nothing is a real
+        // user-facing lie, and it is decided by a SEQUENCE of states, not one
+        // state — so it is tested as a sequence. A per-state assertion would have
+        // passed while the bug was live, because every teardown (clean stop AND
+        // fatal auth) passes through `.stopping`.
+        print("\nRecording-session outcome (state sequences):")
+
+        func replay(_ states: [CaptureController.State]) -> String {
+            var tracker = CaptureController.SessionTracker()
+            var events: [String] = []
+            for s in states {
+                switch tracker.observe(s) {
+                case .none: continue
+                case .started: events.append("start")
+                case .ended(let ok): events.append(ok ? "end:success" : "end:failed")
+                }
+            }
+            return events.isEmpty ? "(none)" : events.joined(separator: ",")
+        }
+
+        // A clean Stop: END was sent, the meeting really is being processed.
+        check("clean stop announces success",
+              replay([.authenticated, .starting, .streaming, .stopping, .authenticated]),
+              "start,end:success")
+        // Fatal auth mid-recording: the token was rejected and nothing was
+        // uploaded, so this must NOT be announced as a completed meeting. This is
+        // the case that regressed.
+        check("fatal auth does NOT announce success",
+              replay([.authenticated, .starting, .streaming, .stopping, .error("session expired")]),
+              "start,end:failed")
+        // Same, if the error is set before teardown rather than after — the
+        // outcome must not depend on that ordering, and must fire only ONCE.
+        check("fatal auth, error set first, ends once",
+              replay([.streaming, .error("session expired"), .stopping, .error("session expired")]),
+              "start,end:failed")
+        // Sign-out mid-recording still sends END, so it did complete.
+        check("logout while streaming announces success",
+              replay([.streaming, .stopping, .idle]),
+              "start,end:success")
+        // A failure BEFORE streaming started never began a session, so it must
+        // produce no end event at all (nothing to announce, nothing to retract).
+        check("capture failure before streaming: no events",
+              replay([.authenticated, .starting, .error("capture failed")]),
+              "(none)")
+        check("sign-in failure: no events",
+              replay([.idle, .signingIn, .error("bad password")]),
+              "(none)")
+        // Pause/resume and repeated `.streaming` must not restart the timer.
+        check("repeated streaming does not re-start",
+              replay([.streaming, .streaming, .stopping, .authenticated]),
+              "start,end:success")
+        // Two sessions in one app run: two clean start/end pairs.
+        check("two sessions in one run",
+              replay([.streaming, .stopping, .authenticated, .starting, .streaming, .stopping, .authenticated]),
+              "start,end:success,start,end:success")
+
         // Cognito error classification: only a REJECTED credential is terminal.
         // Retrying a rejected refresh token is pointless; giving up on a 5xx or a
         // throttle would sign the user out for no reason.


### PR DESCRIPTION
Follow-up to #572. Found while reviewing the Windows port (#574) — its `HandleFatalAuth` carries a comment about deliberately setting the error *before* `Stop()` "so the panel doesn't announce a dead meeting as being processed". Checking the macOS ordering showed macOS has exactly the bug the Windows code avoids.

## The bug

On a fatal auth mid-recording — token rejected, refresh failed, i.e. the path #572 added — `handleFatalAuth` calls `stop(then: .error(...))`, and `stop()`'s first act is `setState(.stopping)`. `MenuBarApp` judged the streaming→stopping transition with `if case .error = s`, which is false for `.stopping`, so it took the **success** branch and posted a user notification:

> **Recording stopped (12:34)** — Your meeting is being processed. Click to open it in LMA.

…with a deep link to a meeting that was never created, for a session that uploaded nothing.

The comment at `MenuBarApp.swift:148-150` already stated the opposite intent — *"An error (bad token, capture failure) or sign-out means nothing was uploaded — don't tell the user a recording is on its way"* — so the intent was documented; the implementation just didn't achieve it. The reason is structural: **every** teardown passes through `.stopping`, for a clean Stop and for a fatal auth alike, so that state carries no information about the outcome and cannot be judged in isolation.

## The fix

Take the outcome from the **terminal state after teardown** rather than from `.stopping`. New `CaptureController.SessionTracker` treats `.stopping` (and `.starting`/`.signingIn`) as "still in flight", then resolves `.error` → failed and `.authenticated`/`.idle` → succeeded.

Chosen over the Windows approach (set the error first, then stop) because it makes the result **independent of the order** in which the fatal-auth path happens to set its states — a fragile thing to depend on. Both orderings now produce exactly one `end:failed` event.

It lives on `CaptureController` rather than in `MenuBarApp` so that it is compiled for `--selftest`; `MenuBarApp` is `@available(macOS 13.0, *)`-gated.

Also in here: `installTokenStore()` now retires any previous store (`tokenStore?.invalidate()`). Nothing reachable installs one while another is live — the sign-in form only appears once the tokens are cleared — but an in-flight refresh on an abandoned store would write its stale token onto `config` via `onRefresh` and clobber the new session. The Windows client does this; one line makes it unrepresentable rather than merely unreachable.

## Testing

`--selftest` gains **9 assertions (63 total, all passing)**, deliberately covering this as a **sequence** of states rather than per-state — a per-state assertion passed the whole time the bug was live.

I verified the new tests actually catch the bug rather than just documenting the new behaviour. Replaying the *old* logic over the fatal-auth sequence:

```
OLD logic, fatal-auth sequence : start,end:success   <- new test demands start,end:failed
OLD logic, clean-stop sequence : start,end:success   <- new test demands start,end:success
```

So the fatal-auth test fails against the old code, and normal stop behaviour is unchanged (no regression). Sequences covered: clean stop, fatal auth in **both** state orderings, logout mid-recording (which does send END, so it *is* a success), failures before streaming began (no events at all), repeated `.streaming`, and two sessions in one app run.

Clean `swift build`, no warnings. GUI launches and survives.

## Not verified

The notification itself is GUI-only and I can't drive the Start button in this environment (no accessibility permission), so the *user-visible* absence of the false notification rests on the sequence tests plus the state machine — not on observing a real notification. Forcing it manually: sign in, `aws cognito-idp admin-user-global-sign-out`, start a recording; expect an error and the sign-in form, and **no** "meeting is being processed" notification.

## Note for the Windows client

`source/windows/` is untouched here. Windows avoids the false notification by ordering (error before `Stop()`), which works — but the tracker approach is more robust, and the Windows panel decides on the same `streaming→false` transition. Worth considering when the findings on #574 are addressed.
