### PR TITLE
fix(vp): scheduled VPs never launch under VPLaunchType=MICROVM

### DIFF
--- a/lma-virtual-participant-stack/lambda_functions/microvm_launcher/index.py
+++ b/lma-virtual-participant-stack/lambda_functions/microvm_launcher/index.py
@@ -278,11 +278,21 @@ def lambda_handler(event, context):
     # Wait for RUNNING so a failure to start is reported now, while the
     # state machine can still mark the VP failed, rather than leaving
     # the UI waiting on a VP that never boots.
+    #
+    # Nothing below here may raise: RunMicrovm has already succeeded, and
+    # EventBridge Scheduler invokes this function ASYNCHRONOUSLY for scheduled
+    # meetings, so an unhandled exception hands the event back to Lambda's
+    # default async retry (2 more attempts, minutes apart) and can put a second
+    # and third bot in the same meeting. A transient GetMicrovm throttle or 5xx
+    # is therefore swallowed and simply retried until the deadline.
     state = response.get("state", "PENDING")
     deadline = time.time() + 120
     while state in ("PENDING", "STARTING") and time.time() < deadline:
         time.sleep(2)
-        state = microvms.get_microvm(microvm_id).get("state", state)
+        try:
+            state = microvms.get_microvm(microvm_id).get("state", state)
+        except Exception:  # noqa: BLE001 - see above; keep polling
+            logger.warning("GetMicrovm %s failed; retrying", microvm_id, exc_info=True)
 
     if state != "RUNNING":
         logger.error("MicroVM %s did not reach RUNNING (state=%s)", microvm_id, state)

--- a/lma-virtual-participant-stack/template.yaml
+++ b/lma-virtual-participant-stack/template.yaml
@@ -2139,6 +2139,24 @@ Resources:
         S3Bucket: !Ref ArtifactBucket
         S3Key: !Ref MicrovmLauncherS3Key
 
+  # EventBridge Scheduler invokes this function ASYNCHRONOUSLY for scheduled
+  # meetings, so Lambda's default async policy would retry a failed invocation
+  # twice more, minutes apart -- putting a second and third bot in the same
+  # meeting if the failure happened after RunMicrovm had already succeeded.
+  # Retrying a meeting join minutes late is not useful anyway, so turn it off
+  # and let the launcher report the failure instead.
+  #
+  # This affects ONLY asynchronous invocations. The "start now" state machine
+  # calls the same function through states:::lambda:invoke (synchronous), which
+  # keeps its own Retry/Catch and is unaffected.
+  VPMicrovmLauncherAsyncConfig:
+    Type: AWS::Lambda::EventInvokeConfig
+    Condition: UseMicrovmLaunchType
+    Properties:
+      FunctionName: !Ref VPMicrovmLauncherFunction
+      Qualifier: $LATEST
+      MaximumRetryAttempts: 0
+
   TaskDefinition:
     Type: "AWS::ECS::TaskDefinition"
     Metadata:
@@ -3181,7 +3199,6 @@ Resources:
           logger.setLevel(getattr(logging, os.environ.get('LOG_LEVEL', 'INFO')))
           
           scheduler_client = boto3.client('scheduler')
-          ecs_client = boto3.client('ecs')
 
 
           def _ecs_params(vp_id, new_image, launch_type, meeting_time_int,

--- a/lma-virtual-participant-stack/template.yaml
+++ b/lma-virtual-participant-stack/template.yaml
@@ -3127,10 +3127,17 @@ Resources:
                 Resource: 
                   - !Ref TaskDefinition
                   - !Sub "${TaskDefinition}:*"
+              # CreateSchedule passes the role EventBridge Scheduler assumes at
+              # fire time: the ECS runTask role for EC2/FARGATE, and additionally
+              # the launcher-invoke role under MICROVM.
               - Effect: Allow
                 Action:
                   - iam:PassRole
-                Resource: !GetAtt VPSchedulerExecutionRole.Arn
+                Resource: !If
+                  - UseMicrovmLaunchType
+                  - - !GetAtt VPSchedulerExecutionRole.Arn
+                    - !GetAtt VPScheduleInvokeLauncherRole.Arn
+                  - - !GetAtt VPSchedulerExecutionRole.Arn
               - Effect: Allow
                 Action:
                   - dynamodb:DescribeStream
@@ -3175,7 +3182,48 @@ Resources:
           
           scheduler_client = boto3.client('scheduler')
           ecs_client = boto3.client('ecs')
-          
+
+
+          def _ecs_params(vp_id, new_image, launch_type, meeting_time_int,
+                          user_sub, zoom_secret_name, enable_video_recording_str):
+              """RunTask parameters for the EC2/FARGATE scheduled launch path."""
+              return {
+                  'ClientToken': vp_id,
+                  'TaskDefinition': os.environ['TASK_DEFINITION_ARN'],
+                  'Cluster': os.environ['CLUSTER_ARN'],
+                  'LaunchType': launch_type,
+                  'NetworkConfiguration': {
+                      'AwsvpcConfiguration': {
+                          'AssignPublicIp': 'DISABLED',
+                          'SecurityGroups': json.loads(os.environ['SECURITY_GROUPS']),
+                          'Subnets': json.loads(os.environ['SUBNETS']),
+                      }
+                  },
+                  'Overrides': {
+                      'ContainerOverrides': [{
+                          'Name': os.environ['CONTAINER_NAME'],
+                          'Environment': [
+                              {'Name': 'VIRTUAL_PARTICIPANT_ID', 'Value': vp_id},
+                              {'Name': 'MEETING_PLATFORM', 'Value': new_image.get('meetingPlatform', {}).get('S', '')},
+                              {'Name': 'MEETING_ID', 'Value': new_image.get('meetingId', {}).get('S', '')},
+                              {'Name': 'MEETING_PASSWORD', 'Value': new_image.get('meetingPassword', {}).get('S', '')},
+                              {'Name': 'MEETING_NAME', 'Value': new_image.get('meetingName', {}).get('S', '')},
+                              {'Name': 'MEETING_TIME', 'Value': str(meeting_time_int)},
+                              {'Name': 'LMA_USER', 'Value': new_image.get('owner', {}).get('S', '')},
+                              {'Name': 'LMA_USER_SUB', 'Value': user_sub},
+                              {'Name': 'ZOOM_CREDENTIALS_SECRET_NAME', 'Value': zoom_secret_name},
+                              {'Name': 'GRAPHQL_ENDPOINT', 'Value': os.environ.get('GRAPHQL_ENDPOINT', '')},
+                              {'Name': 'CALL_DATA_STREAM_NAME', 'Value': os.environ.get('CALL_DATA_STREAM_NAME', '')},
+                              {'Name': 'RECORDINGS_BUCKET_NAME', 'Value': os.environ.get('RECORDINGS_BUCKET_NAME', '')},
+                              {'Name': 'VP_TASK_REGISTRY_TABLE_NAME', 'Value': os.environ.get('VP_TASK_REGISTRY_TABLE_NAME', '')},
+                              {'Name': 'ENABLE_VIDEO_RECORDING', 'Value': enable_video_recording_str},
+                          ]
+                      }]
+                  },
+                  'EnableExecuteCommand': False
+              }
+
+
           def lambda_handler(event, context):
               logger.info("Processing VP scheduler request")
               logger.info(f"Event: {json.dumps(event, default=str)}")
@@ -3201,7 +3249,6 @@ Resources:
                           
                           if is_scheduled and meeting_time:
                               meeting_time_int = int(meeting_time)
-                              current_time = int(datetime.now().timestamp())
 
                               # Schedule for future execution
                               delay_seconds = 120  # 2 minutes before meeting
@@ -3221,44 +3268,53 @@ Resources:
                                   if user_zoom_sub and stack_name else ''
                               )
 
-                              ecs_params = {
-                                  'ClientToken': vp_id,
-                                  'TaskDefinition': os.environ['TASK_DEFINITION_ARN'],
-                                  'Cluster': os.environ['CLUSTER_ARN'],
-                                  'LaunchType': os.environ.get('VP_LAUNCH_TYPE', 'FARGATE'),
-                                  'NetworkConfiguration': {
-                                      'AwsvpcConfiguration': {
-                                          'AssignPublicIp': 'DISABLED',
-                                          'SecurityGroups': json.loads(os.environ['SECURITY_GROUPS']),
-                                          'Subnets': json.loads(os.environ['SUBNETS']),
-                                      }
-                                  },
-                                  'Overrides': {
-                                      'ContainerOverrides': [{
-                                          'Name': os.environ['CONTAINER_NAME'],
-                                          'Environment': [
-                                              {'Name': 'VIRTUAL_PARTICIPANT_ID', 'Value': vp_id},
-                                              {'Name': 'MEETING_PLATFORM', 'Value': new_image.get('meetingPlatform', {}).get('S', '')},
-                                              {'Name': 'MEETING_ID', 'Value': new_image.get('meetingId', {}).get('S', '')},
-                                              {'Name': 'MEETING_PASSWORD', 'Value': new_image.get('meetingPassword', {}).get('S', '')},
-                                              {'Name': 'MEETING_NAME', 'Value': new_image.get('meetingName', {}).get('S', '')},
-                                              {'Name': 'MEETING_TIME', 'Value': str(meeting_time_int)},
-                                              {'Name': 'LMA_USER', 'Value': new_image.get('owner', {}).get('S', '')},
-                                              {'Name': 'LMA_USER_SUB', 'Value': user_sub},
-                                              {'Name': 'ZOOM_CREDENTIALS_SECRET_NAME', 'Value': zoom_secret_name},
-                                              {'Name': 'GRAPHQL_ENDPOINT', 'Value': os.environ.get('GRAPHQL_ENDPOINT', '')},
-                                              {'Name': 'CALL_DATA_STREAM_NAME', 'Value': os.environ.get('CALL_DATA_STREAM_NAME', '')},
-                                              {'Name': 'RECORDINGS_BUCKET_NAME', 'Value': os.environ.get('RECORDINGS_BUCKET_NAME', '')},
-                                              {'Name': 'VP_TASK_REGISTRY_TABLE_NAME', 'Value': os.environ.get('VP_TASK_REGISTRY_TABLE_NAME', '')},
-                                              {'Name': 'ENABLE_VIDEO_RECORDING', 'Value': enable_video_recording_str},
-                                          ]
-                                      }]
-                                  },
-                                  'EnableExecuteCommand': False
-                              }
-                              
+                              launch_type = os.environ.get('VP_LAUNCH_TYPE', 'FARGATE')
+
+                              if launch_type == 'MICROVM':
+                                  # EventBridge Scheduler has a native ECS runTask target but
+                                  # none for lambda-microvms, so a MICROVM schedule invokes the
+                                  # launcher Lambda instead -- the same target the "start now"
+                                  # state machine uses (see ScheduledMeetingTarget). Forwarding
+                                  # VP_LAUNCH_TYPE into an ecs:runTask LaunchType instead makes
+                                  # ECS reject the fire with "launch type should be one of
+                                  # [EC2,FARGATE,EXTERNAL]", and because the schedule is
+                                  # ActionAfterCompletion=DELETE it then vanishes, leaving the
+                                  # VP stuck at SCHEDULED with no visible error (issue #613).
+                                  #
+                                  # The launcher accepts this flat payload as well as the state
+                                  # machine's {"data": {...}} shape; the key names below are the
+                                  # ones its FIELD_MAP looks for. Cognito tokens are absent by
+                                  # design -- they are minted per session and would have expired
+                                  # by the meeting time -- which matches what the ECS scheduled
+                                  # path passes today.
+                                  target = {
+                                      'Arn': os.environ['MICROVM_LAUNCHER_ARN'],
+                                      'RoleArn': os.environ['SCHEDULE_INVOKE_LAUNCHER_ROLE_ARN'],
+                                      'Input': json.dumps({
+                                          'virtualParticipantId': vp_id,
+                                          'meetingPlatform': new_image.get('meetingPlatform', {}).get('S', ''),
+                                          'meetingId': new_image.get('meetingId', {}).get('S', ''),
+                                          'meetingPassword': new_image.get('meetingPassword', {}).get('S', ''),
+                                          'meetingName': new_image.get('meetingName', {}).get('S', ''),
+                                          'meetingTime': str(meeting_time_int),
+                                          'owner': new_image.get('owner', {}).get('S', ''),
+                                          'userSub': user_sub,
+                                          'zoomCredentialsSecretName': zoom_secret_name,
+                                          'enableVideoRecording': enable_video_recording_str,
+                                      })
+                                  }
+                              else:
+                                  target = {
+                                      'Arn': 'arn:aws:scheduler:::aws-sdk:ecs:runTask',
+                                      'RoleArn': os.environ['SCHEDULER_ROLE_ARN'],
+                                      'Input': json.dumps(_ecs_params(
+                                          vp_id, new_image, launch_type, meeting_time_int,
+                                          user_sub, zoom_secret_name, enable_video_recording_str,
+                                      ))
+                                  }
+
                               schedule_expression = f"at({scheduled_time.strftime('%Y-%m-%dT%H:%M:%S')})"
-                              
+
                               response = scheduler_client.create_schedule(
                                   ActionAfterCompletion='DELETE',
                                   FlexibleTimeWindow={'Mode': 'OFF'},
@@ -3267,17 +3323,16 @@ Resources:
                                   ScheduleExpression=schedule_expression,
                                   ScheduleExpressionTimezone='UTC',
                                   State='ENABLED',
-                                  Target={
-                                      'Arn': 'arn:aws:scheduler:::aws-sdk:ecs:runTask',
-                                      'RoleArn': os.environ['SCHEDULER_ROLE_ARN'],
-                                      'Input': json.dumps(ecs_params)
-                                  }
+                                  Target=target
                               )
-                              
-                              logger.info(f"Successfully scheduled VP {vp_id} with schedule ARN: {response.get('ScheduleArn')}")
+
+                              logger.info(
+                                  f"Successfully scheduled VP {vp_id} ({launch_type}) "
+                                  f"with schedule ARN: {response.get('ScheduleArn')}"
+                              )
                           else:
                               logger.info(f"VP {vp_id} is not scheduled, skipping")
-                              
+
                       elif event_name == 'REMOVE':
                           try:
                               scheduler_client.delete_schedule(
@@ -3313,6 +3368,18 @@ Resources:
           SCHEDULE_GROUP_NAME: !Ref VPScheduleGroup
           SCHEDULER_ROLE_ARN: !GetAtt VPSchedulerExecutionRole.Arn
           VP_LAUNCH_TYPE: !Ref VPLaunchType
+          # MICROVM only: the schedule target is the launcher Lambda rather than
+          # ecs:runTask, so it needs the function ARN and the role EventBridge
+          # Scheduler assumes to invoke it. Both resources are conditional on
+          # UseMicrovmLaunchType, so these are omitted for EC2/FARGATE.
+          MICROVM_LAUNCHER_ARN: !If
+            - UseMicrovmLaunchType
+            - !GetAtt VPMicrovmLauncherFunction.Arn
+            - !Ref AWS::NoValue
+          SCHEDULE_INVOKE_LAUNCHER_ROLE_ARN: !If
+            - UseMicrovmLaunchType
+            - !GetAtt VPScheduleInvokeLauncherRole.Arn
+            - !Ref AWS::NoValue
           LMA_STACK_NAME: !Ref LMAStackName
           LOG_LEVEL: !Ref LogLevel
   # DynamoDB Event Source Mapping for Scheduler Lambda

--- a/lma-virtual-participant-stack/test/test_vp_template.py
+++ b/lma-virtual-participant-stack/test/test_vp_template.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import re
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -1059,3 +1060,199 @@ def test_launcher_field_names_match_the_state_machine(raw: str, launcher: str) -
             f"{env_key} maps to {candidates}, none of which the template sends; "
             f"available: {sorted(authoritative)}"
         )
+
+
+# ----------------------------------------------------------------------
+# VPScheduler Lambda: the DynamoDB-stream scheduled-launch path
+# ----------------------------------------------------------------------
+# This is a SECOND scheduling path, separate from the state machine's
+# ScheduledMeetingTarget above: the UI writes an isScheduled row and the
+# DynamoDB stream drives this Lambda. It was missed when MICROVM was added,
+# so it forwarded VP_LAUNCH_TYPE straight into an ecs:runTask LaunchType and
+# every scheduled MICROVM meeting silently failed to launch (issue #613).
+# These tests run the inline code for real rather than grepping it.
+
+
+def _scheduler_source(raw: str) -> str:
+    """The VPScheduler Lambda's inline `Code: ZipFile` body, dedented."""
+    lines = raw.split("\n")
+    for i, line in enumerate(lines):
+        if "ZipFile: |" not in line:
+            continue
+        # Several inline functions exist in this template; pick the scheduler by
+        # the API only it calls.
+        if not any("create_schedule" in nxt for nxt in lines[i : i + 200]):
+            continue
+        indent = len(line) - len(line.lstrip()) + 2
+        body = []
+        for candidate in lines[i + 1 :]:
+            if not candidate.strip():
+                body.append("")
+                continue
+            if len(candidate) - len(candidate.lstrip()) < indent:
+                break
+            body.append(candidate[indent:])
+        return "\n".join(body)
+    raise AssertionError("could not find the VPScheduler inline code")
+
+
+class _FakeScheduler:
+    """Captures create_schedule kwargs instead of calling EventBridge."""
+
+    def __init__(self) -> None:
+        self.created: list[dict] = []
+
+    def create_schedule(self, **kwargs):  # noqa: ANN003
+        self.created.append(kwargs)
+        return {"ScheduleArn": "arn:aws:scheduler:::schedule/g/n"}
+
+
+SCHEDULER_ENV = {
+    "TASK_DEFINITION_ARN": "arn:aws:ecs:us-west-2:1:task-definition/vp:1",
+    "CLUSTER_ARN": "arn:aws:ecs:us-west-2:1:cluster/vp",
+    "SECURITY_GROUPS": '["sg-1"]',
+    "SUBNETS": '["subnet-1", "subnet-2"]',
+    "CONTAINER_NAME": "scribe",
+    "SCHEDULE_GROUP_NAME": "stack-vp-schedules",
+    "SCHEDULER_ROLE_ARN": "arn:aws:iam::1:role/EcsTarget",
+    "MICROVM_LAUNCHER_ARN": "arn:aws:lambda:us-west-2:1:function:Launcher",
+    "SCHEDULE_INVOKE_LAUNCHER_ROLE_ARN": "arn:aws:iam::1:role/InvokeLauncher",
+    "VP_TASK_REGISTRY_TABLE_NAME": "registry",
+    "LMA_STACK_NAME": "stack",
+}
+
+# A realistic isScheduled row, matching what the UI writes (captured from a
+# live stream event).
+SCHEDULED_ROW = {
+    "id": {"S": "vp-1"},
+    "isScheduled": {"BOOL": True},
+    "meetingTime": {"N": "1788299100"},
+    "meetingPlatform": {"S": "TEAMS"},
+    "meetingId": {"S": "25582977335241"},
+    "meetingPassword": {"S": "secret"},
+    "meetingName": {"S": "Teams Schedule"},
+    "owner": {"S": "user@example.com"},
+    "userSub": {"S": "sub-1"},
+    "enableVideoRecording": {"BOOL": True},
+}
+
+
+def _run_scheduler(raw: str, launch_type: str) -> dict:
+    """Execute the inline scheduler on one INSERT event; return the schedule."""
+    import types
+    from unittest import mock
+
+    fake = _FakeScheduler()
+    module = types.ModuleType("vpscheduler")
+    module.__dict__["__name__"] = "vpscheduler"
+    env = {**SCHEDULER_ENV, "VP_LAUNCH_TYPE": launch_type}
+    with mock.patch.dict("os.environ", env, clear=False), mock.patch(
+        "boto3.client",
+        side_effect=lambda service, *a, **k: fake if service == "scheduler" else mock.Mock(),
+    ):
+        exec(compile(_scheduler_source(raw), "vpscheduler", "exec"), module.__dict__)
+        event = {
+            "Records": [
+                {
+                    "eventName": "INSERT",
+                    "dynamodb": {"Keys": {"id": {"S": "vp-1"}}, "NewImage": SCHEDULED_ROW},
+                }
+            ]
+        }
+        result = module.lambda_handler(event, None)
+
+    assert result["statusCode"] == 200, result
+    assert len(fake.created) == 1, f"expected one schedule, got {fake.created}"
+    return fake.created[0]
+
+
+@pytest.mark.parametrize("launch_type", ["FARGATE", "EC2"])
+def test_scheduled_ecs_launch_types_still_use_run_task(raw: str, launch_type: str) -> None:
+    schedule = _run_scheduler(raw, launch_type)
+    target = schedule["Target"]
+
+    assert target["Arn"] == "arn:aws:scheduler:::aws-sdk:ecs:runTask"
+    assert target["RoleArn"] == SCHEDULER_ENV["SCHEDULER_ROLE_ARN"]
+    params = json.loads(target["Input"])
+    # The valid launch type must still reach ECS verbatim.
+    assert params["LaunchType"] == launch_type
+    assert params["ClientToken"] == "vp-1"
+    env = {e["Name"]: e["Value"] for e in params["Overrides"]["ContainerOverrides"][0]["Environment"]}
+    assert env["MEETING_ID"] == "25582977335241"
+    assert env["VIRTUAL_PARTICIPANT_ID"] == "vp-1"
+    assert env["ENABLE_VIDEO_RECORDING"] == "true"
+
+
+def test_scheduled_microvm_invokes_the_launcher_not_run_task(raw: str) -> None:
+    """The regression from issue #613.
+
+    ECS RunTask accepts only EC2/FARGATE/EXTERNAL, so a schedule carrying
+    LaunchType=MICROVM fails at fire time. Because the schedule is
+    ActionAfterCompletion=DELETE it then deletes itself, leaving the VP row at
+    SCHEDULED with nothing in the console to show why.
+    """
+    schedule = _run_scheduler(raw, "MICROVM")
+    target = schedule["Target"]
+
+    assert target["Arn"] == SCHEDULER_ENV["MICROVM_LAUNCHER_ARN"]
+    assert target["RoleArn"] == SCHEDULER_ENV["SCHEDULE_INVOKE_LAUNCHER_ROLE_ARN"]
+    assert "runTask" not in json.dumps(schedule), "MICROVM must not target ecs:runTask"
+    assert "MICROVM" not in target["Input"], "MICROVM must never appear as an ECS LaunchType"
+
+
+def test_scheduled_microvm_payload_is_readable_by_the_launcher(
+    raw: str, launcher: str
+) -> None:
+    """Every key the target sends must be one the launcher's FIELD_MAP reads.
+
+    The two sides are different files. A field the launcher does not recognise
+    is silently dropped and the meeting joins with a default instead — which is
+    how an empty meeting id previously reached Zoom.
+    """
+    payload = json.loads(_run_scheduler(raw, "MICROVM")["Target"]["Input"])
+
+    block = launcher.split("FIELD_MAP = {", 1)[1].split("\n}", 1)[0]
+    known = set(re.findall(r'"([a-zA-Z]+)"', block))
+
+    unknown = sorted(set(payload) - known)
+    assert not unknown, f"launcher FIELD_MAP does not read {unknown}"
+
+    # The values the VP cannot join without.
+    assert payload["virtualParticipantId"] == "vp-1"
+    assert payload["meetingId"] == "25582977335241"
+    assert payload["meetingPlatform"] == "TEAMS"
+    assert payload["meetingPassword"] == "secret"
+    # meetingTime is the real meeting time, not the (2-min-earlier) fire time.
+    assert payload["meetingTime"] == "1788299100"
+
+
+def test_scheduled_launch_fires_before_the_meeting_starts(raw: str) -> None:
+    # Both paths must leave boot headroom, or the VP joins late.
+    for launch_type in ("FARGATE", "MICROVM"):
+        expression = _run_scheduler(raw, launch_type)["ScheduleExpression"]
+        fires_at = datetime.strptime(
+            expression, "at(%Y-%m-%dT%H:%M:%S)"
+        ).replace(tzinfo=timezone.utc)
+        meeting = datetime.fromtimestamp(1788299100, tz=timezone.utc)
+        assert 0 < (meeting - fires_at).total_seconds() <= 300, launch_type
+
+
+def test_scheduler_lambda_can_pass_the_launcher_invoke_role(template: dict) -> None:
+    """CreateSchedule needs iam:PassRole on the role it hands to Scheduler.
+
+    Without it the create_schedule call itself fails, so no schedule is ever
+    written and the VP row again sits at SCHEDULED.
+    """
+    policies = template["Resources"]["VirtualParticipantSchedulerRole"]["Properties"][
+        "Policies"
+    ]
+    statements = policies[0]["PolicyDocument"]["Statement"]
+    pass_role = [s for s in statements if "iam:PassRole" in s["Action"]]
+    assert len(pass_role) == 1, "expected exactly one PassRole statement"
+
+    rendered = json.dumps(pass_role[0]["Resource"])
+    assert "VPSchedulerExecutionRole" in rendered
+    assert "VPScheduleInvokeLauncherRole" in rendered, (
+        "the MICROVM branch passes VPScheduleInvokeLauncherRole to EventBridge "
+        "Scheduler, so the Lambda needs PassRole on it"
+    )

--- a/lma-virtual-participant-stack/test/test_vp_template.py
+++ b/lma-virtual-participant-stack/test/test_vp_template.py
@@ -1211,11 +1211,49 @@ def test_scheduled_microvm_payload_is_readable_by_the_launcher(
     """
     payload = json.loads(_run_scheduler(raw, "MICROVM")["Target"]["Input"])
 
+    # Strip comments BEFORE parsing: the FIELD_MAP block explains the meetingID
+    # / meetingId spelling trap in prose, so a naive scan of the whole block
+    # would treat any key merely *mentioned* in a comment as supported.
     block = launcher.split("FIELD_MAP = {", 1)[1].split("\n}", 1)[0]
-    known = set(re.findall(r'"([a-zA-Z]+)"', block))
+    code_only = "\n".join(
+        line for line in block.splitlines() if not line.strip().startswith("#")
+    )
+    entries = dict(re.findall(r'"([A-Z_]+)":\s*\(([^)]*)\)', code_only))
+    assert entries, "could not parse FIELD_MAP"
+    known = {c.strip().strip("\"'") for cands in entries.values() for c in cands.split(",") if c.strip()}
 
     unknown = sorted(set(payload) - known)
     assert not unknown, f"launcher FIELD_MAP does not read {unknown}"
+
+    # The other direction, which is the one that actually matters: the MICROVM
+    # payload must carry every per-meeting value the ECS branch sets as a
+    # container env var, or a scheduled MicroVM VP silently launches with less
+    # configuration than a scheduled Fargate one.
+    ecs_env = {
+        e["Name"]
+        for e in json.loads(_run_scheduler(raw, "FARGATE")["Target"]["Input"])[
+            "Overrides"
+        ]["ContainerOverrides"][0]["Environment"]
+    }
+    # These four are per-STACK, not per-meeting: the launcher reads them from the
+    # ECS task definition via _static_config() instead of the schedule payload.
+    from_task_definition = {
+        "GRAPHQL_ENDPOINT",
+        "CALL_DATA_STREAM_NAME",
+        "RECORDINGS_BUCKET_NAME",
+        "VP_TASK_REGISTRY_TABLE_NAME",
+    }
+    # env var name -> the payload key(s) FIELD_MAP resolves it from
+    supplied = {
+        env_key
+        for env_key, cands in entries.items()
+        if any(c.strip().strip("\"'") in payload for c in cands.split(",") if c.strip())
+    }
+    missing = sorted(ecs_env - from_task_definition - supplied)
+    assert not missing, (
+        f"the MICROVM schedule payload drops {missing}, which the ECS "
+        "scheduled path passes to the container"
+    )
 
     # The values the VP cannot join without.
     assert payload["virtualParticipantId"] == "vp-1"
@@ -1250,9 +1288,54 @@ def test_scheduler_lambda_can_pass_the_launcher_invoke_role(template: dict) -> N
     pass_role = [s for s in statements if "iam:PassRole" in s["Action"]]
     assert len(pass_role) == 1, "expected exactly one PassRole statement"
 
-    rendered = json.dumps(pass_role[0]["Resource"])
-    assert "VPSchedulerExecutionRole" in rendered
-    assert "VPScheduleInvokeLauncherRole" in rendered, (
-        "the MICROVM branch passes VPScheduleInvokeLauncherRole to EventBridge "
-        "Scheduler, so the Lambda needs PassRole on it"
+    # Assert on the Fn::If STRUCTURE, not a substring of the whole thing: both
+    # role names appear either way round, so a substring check would still pass
+    # with the branches inverted -- which cfn-lint flags as W1001 and which
+    # would break every MICROVM deploy.
+    resource = pass_role[0]["Resource"]
+    assert "Fn::If" in resource, "PassRole must be conditional on the launch type"
+    condition, if_microvm, if_ecs = resource["Fn::If"]
+    assert condition == "UseMicrovmLaunchType", condition
+
+    def _roles(branch: object) -> set[str]:
+        return set(re.findall(r"(VP[A-Za-z]+Role)", json.dumps(branch)))
+
+    assert _roles(if_microvm) == {
+        "VPSchedulerExecutionRole",
+        "VPScheduleInvokeLauncherRole",
+    }, "the MICROVM branch must pass BOTH the ECS-target and launcher-invoke roles"
+    # VPScheduleInvokeLauncherRole is itself Condition: UseMicrovmLaunchType, so
+    # referencing it from the false branch is an unresolvable GetAtt.
+    assert _roles(if_ecs) == {"VPSchedulerExecutionRole"}, (
+        "the EC2/FARGATE branch must not reference the MicroVM-only role"
+    )
+
+
+def test_launcher_async_retries_are_disabled(template: dict) -> None:
+    """A scheduled launch must not be retried into duplicate bots.
+
+    EventBridge Scheduler invokes the launcher asynchronously, so Lambda's
+    default async policy would re-run it twice more, minutes apart. If the first
+    attempt failed AFTER RunMicrovm succeeded, each retry adds another VP to the
+    same meeting.
+    """
+    config = template["Resources"]["VPMicrovmLauncherAsyncConfig"]
+    assert config["Condition"] == "UseMicrovmLaunchType"
+    props = config["Properties"]
+    assert props["MaximumRetryAttempts"] == 0
+    assert "VPMicrovmLauncherFunction" in json.dumps(props["FunctionName"])
+
+
+def test_launcher_never_raises_after_starting_a_microvm(launcher: str) -> None:
+    """The wait-for-RUNNING poll must not propagate transient API errors.
+
+    An exception here escapes the handler, and on the asynchronous
+    (EventBridge Scheduler) path that means a retry with a MicroVM already
+    running -- i.e. two bots in the meeting.
+    """
+    after_run = launcher.split('logger.info("Started MicroVM', 1)[1]
+    poll = after_run.split("if state != \"RUNNING\"", 1)[0]
+    assert "get_microvm" in poll, "could not locate the wait-for-RUNNING loop"
+    assert "try:" in poll and "except" in poll, (
+        "the wait-for-RUNNING poll must swallow transient GetMicrovm failures"
     )


### PR DESCRIPTION
Fixes #613.

## Problem

On a `VPLaunchType=MICROVM` deployment (the default), "start now" VPs work but **scheduled** VPs never launch. The VP row sits at `SCHEDULED` forever, the bot never joins, and no error reaches the UI.

The `VPScheduler` Lambda — DynamoDB-stream driven, and the path the UI's "schedule a meeting" flow actually uses — had a single launch path. It always created an EventBridge schedule targeting `ecs:runTask` and forwarded `VP_LAUNCH_TYPE` straight into `LaunchType`:

```python
'LaunchType': os.environ.get('VP_LAUNCH_TYPE', 'FARGATE'),
...
Target={'Arn': 'arn:aws:scheduler:::aws-sdk:ecs:runTask', ...}
```

ECS RunTask accepts only `EC2`/`FARGATE`/`EXTERNAL`, so the fire fails validation. Because the schedule is `ActionAfterCompletion=DELETE`, it then deletes itself — leaving nothing in the console to explain the failure.

The "start now" **state machine** already forks on launch type (`ScheduledMeetingTarget`, gated on `UseMicrovmLaunchType`). This second scheduling path was missed when MICROVM was added.

### Reproduced on a live MICROVM stack, before the fix

`AWS/Scheduler` for the VP schedule group, on the fire:

```
InvocationAttemptCount = 1
TargetErrorCount       = 1
```

No ECS task created, `VPMicrovmLauncher` never invoked, schedule gone, VP row still `SCHEDULED`.

## Fix

EventBridge Scheduler has a native `ecs:runTask` target but none for `lambda-microvms`, so a MICROVM schedule now targets the **launcher Lambda** — the same target the state machine already uses:

- **Code:** fork the `INSERT` branch on `VP_LAUNCH_TYPE`. MICROVM targets `VPMicrovmLauncherFunction` via `VPScheduleInvokeLauncherRole`; EC2/FARGATE keep `ecs:runTask` unchanged (RunTask params moved verbatim into an `_ecs_params` helper).
- **Env:** add `MICROVM_LAUNCHER_ARN` and `SCHEDULE_INVOKE_LAUNCHER_ROLE_ARN`, both `!If UseMicrovmLaunchType` so nothing changes for EC2/FARGATE.
- **IAM:** `VirtualParticipantSchedulerRole` gets `iam:PassRole` on `VPScheduleInvokeLauncherRole` — `CreateSchedule` passes that role to Scheduler, and without it the create call itself fails.

The launcher needed no change to read the payload: it already accepts this flat shape alongside the state machine's `{"data": {...}}`, and its `FIELD_MAP` already reads the DynamoDB spellings (`meetingId`, `owner`). Cognito tokens are deliberately absent — they are per-session and would have expired by the meeting time — which matches what the ECS scheduled path passes today.

Reuses the existing `VPScheduleInvokeLauncherRole` rather than adding `lambda:InvokeFunction` to `VPSchedulerExecutionRole` (the ECS-target role), keeping the two schedule targets on separate least-privilege roles.

### Duplicate-launch hardening (second commit)

EventBridge Scheduler invokes a Lambda target **asynchronously** ([Lambda developer guide](https://docs.aws.amazon.com/lambda/latest/dg/with-eventbridge-scheduler.html)). That has a consequence worth guarding before this path goes live: Lambda's default async policy retries a failed invocation **twice more, minutes apart**, so a failure *after* `RunMicrovm` had already succeeded would put a second and third bot in the same meeting.

The exposed path was the launcher's wait-for-RUNNING poll, where an unguarded `GetMicrovm` turns a transient throttle or 5xx into an unhandled exception. So:

- that loop now swallows and retries transient errors instead of propagating them;
- the launcher gets `MaximumRetryAttempts: 0` for async invokes (`AWS::Lambda::EventInvokeConfig`) — retrying a meeting join minutes late is not useful anyway.

This affects only asynchronous invocations. The "start now" state machine calls the same function through `states:::lambda:invoke` (synchronous), so it keeps its own `Retry`/`Catch` and is unaffected.

Also drops a dead `current_time` local and a dead `ecs_client` in the scheduler Lambda.

## Verification

Deployed from this branch to a live `VPLaunchType=MICROVM` stack and scheduled a Teams meeting:

```
schedule created  Target.Arn     = ...:function:LMA-Bob-VPMicrovmLauncher
                  Target.RoleArn = ...:role/...VPScheduleInvokeLauncherR...
                  Input          = {"virtualParticipantId": "...", "meetingPlatform": "TEAMS",
                                    "meetingId": "255829...", "meetingTime": "1788314230", ...}

on fire           InvocationAttemptCount = 1
                  TargetErrorCount       = 0        <- was 1
                  launcher invoked, 48 config values staged
                  MicroVM microvm-d69ace9e... started, endpoint published

VP row            SCHEDULED -> LAUNCHING_BROWSER -> VNC_READY -> JOINING
                  (reached the Teams admission screen, same as the "start now" path)
```

Also deployed to a **fresh** MICROVM stack from scratch to confirm the conditional env vars and IAM render correctly on a create (not just an update).

## Tests

Eight new tests in `lma-virtual-participant-stack/test/test_vp_template.py`. They execute the inline Lambda for real (fake `scheduler` client) rather than grepping the template, and assert on the schedule it produces:

- `test_scheduled_ecs_launch_types_still_use_run_task` (FARGATE, EC2) — the launch type still reaches ECS verbatim
- `test_scheduled_microvm_invokes_the_launcher_not_run_task` — the regression itself
- `test_scheduled_microvm_payload_is_readable_by_the_launcher` — parity in **both** directions: every key sent is one `FIELD_MAP` reads, and every per-meeting env var the ECS branch sets is present in the MICROVM payload (minus the four per-stack values the launcher reads from the task definition)
- `test_scheduled_launch_fires_before_the_meeting_starts` — both paths keep boot headroom
- `test_scheduler_lambda_can_pass_the_launcher_invoke_role` — asserts the `Fn::If` **structure** per branch, since `VPScheduleInvokeLauncherRole` is itself MicroVM-conditional and referencing it from the false branch is an unresolvable `GetAtt`
- `test_launcher_async_retries_are_disabled` / `test_launcher_never_raises_after_starting_a_microvm` — the duplicate-launch guards

Each was checked by mutation — re-introducing the specific defect it describes (dropping `meetingId` from `FIELD_MAP`; deleting `userSub`/`zoomCredentialsSecretName`/`enableVideoRecording` from the payload; inverting the `Fn::If` branches) makes it fail.

Full suite: 120 passed. `cfn-lint` reports no errors (same pre-existing warnings as `develop`); `ruff` clean.

## Follow-ups for maintainers (not fixed here)

1. **A failed scheduled launch is still invisible, and a Scheduler DLQ would not fix it.** Because the invoke is asynchronous, Scheduler gets a 202 as soon as the invoke is accepted, records success, and deletes the schedule — so a DLQ or `TargetErrorCount` alarm only ever catches invoke-level failures, not the launcher returning `{"ok": False}` (quota, throttle, `state != RUNNING`). The state machine consumes that return value via `MarkVPFailed`; EventBridge Scheduler cannot. `VPMicrovmLauncherRole` already holds `dynamodb:UpdateItem` on the VP table, so the fix is a launcher-side status write-back rather than a DLQ.
2. **Top-of-the-hour throttling.** `RunMicrovm` is rate-limited to 5 TPS per account and `FlexibleTimeWindow` is `OFF`, so meetings scheduled for the same `:00` all fire in the same second. The launcher converts a throttle into `ok:False` with no retry on this path. A small flexible time window, or raising retryable errors so Scheduler's retry policy engages, would help.
3. **The state machine's own `CreateSchedule` path still diverges** — it fires *at* the meeting time with no boot headroom, sends `meetingTime` as an ISO string where the container does `parseInt(process.env.MEETING_TIME)`, and omits `userSub`/`zoomCredentialsSecretName`/`enableVideoRecording`. Unverified; probably deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)