### PR TITLE
fix(ai-stack): drop inert SnapStart from StrandsChatInterfaceFunction

### DIFF
--- a/lma-ai-stack/deployment/lma-ai-stack.yaml
+++ b/lma-ai-stack/deployment/lma-ai-stack.yaml
@@ -1823,8 +1823,13 @@ Resources:
     Properties:
       Role: !GetAtt StrandsChatInterfaceFunctionExecutionRole.Arn
       Runtime: python3.12
-      SnapStart:
-        ApplyOn: PublishedVersions
+      # No SnapStart here: `ApplyOn: PublishedVersions` only takes effect for a
+      # published version, and this function is reached through an unqualified
+      # $LATEST ARN (the StrandsChatDataSource AppSync data source uses
+      # `!GetAtt StrandsChatInterfaceFunction.Arn`), so no version is ever
+      # published and the setting was inert. Measured before removing it: init
+      # 440 ms, exec 297 ms — SnapStart targets multi-second inits, and paying
+      # for a version cache plus alias-qualified wiring buys nothing at 440 ms.
       Environment:
         Variables:
           ASYNC_AGENT_ASSIST_ORCHESTRATOR_ARN: !GetAtt AsyncAgentAssistOrchestrator.Arn


### PR DESCRIPTION
`StrandsChatInterfaceFunction` sets `SnapStart: ApplyOn: PublishedVersions`, which only takes effect for a **published version**. The function has no `AutoPublishAlias` and is reached exclusively through an unqualified `$LATEST` ARN — the StrandsChat AppSync data source wires it with `!GetAtt StrandsChatInterfaceFunction.Arn` — so no version is ever published and the setting has never done anything.

It's the only `SnapStart` in the repo, so it also reads as though cold starts are handled somewhere when they aren't.

Surfaced by the cfn-lint 1.54 → 1.56 bump in #618, which added `W2530` for exactly this case: `'SnapStart' is enabled but 'AutoPublishAlias' is not configured`.

## Measured before deciding

Rather than guess, I measured on LMA-Bob (`us-west-2`, log group `/LMA-Bob-AISTACK-VFZYS5M8GCDD/lambda/StrandsChatInterfaceFunction`, 90-day window):

| invocations | cold starts | init | exec |
|---|---|---|---|
| 1 | 1 | **440 ms** | 297 ms |

SnapStart targets multi-second init times from heavy imports. At 440 ms it would buy no perceptible latency, and making it *real* would mean adding `AutoPublishAlias` plus re-pointing both the AppSync data source and its IAM resource at an alias-qualified ARN — versioned-function storage and extra deploy machinery for nothing.

So: removed, with a comment recording the measurement and the `$LATEST` wiring so nobody re-adds it on the assumption it was doing something.

## Verification

- cfn-lint 1.56.0 findings identical to `develop` **except** `W2530`, which is gone (diffed rule-by-rule)
- yamllint error count unchanged — 547 pre-existing, none added, and every added comment line is ≤80 chars
- `sam validate` → "is a valid SAM Template"

🤖 Generated with [Claude Code](https://claude.com/claude-code)