### PR TITLE
chore(asr): mark the MicroVM ASR engine EXPERIMENTAL, withdraw its tuning params

### DIFF
--- a/docs/cloudformation-parameters.md
+++ b/docs/cloudformation-parameters.md
@@ -11,6 +11,7 @@ title: "CloudFormation Parameters Reference"
 - [Meeting Assistant](#meeting-assistant)
 - [Knowledge Base](#knowledge-base)
 - [Transcription](#transcription)
+- [On-demand ASR and Diarization (MicroVM) — EXPERIMENTAL](#on-demand-asr-and-diarization-microvm--experimental)
 - [End-of-Call Summary](#end-of-call-summary)
 - [Virtual Participant](#virtual-participant)
 - [Voice Assistant](#voice-assistant)
@@ -66,7 +67,12 @@ This is a complete reference of all LMA CloudFormation stack parameters. These v
 | ContentRedactionLanguages | Languages that support content redaction | en-US | en-US, en-AU, en-GB, es-US |
 | ShowSpeakerLabel | Default for per-channel speaker partitioning (diarization) on WebSocket streaming sessions -- the Stream Audio tab and the Desktop Capture App. Applies to both channels when used. Clients that send their own per-channel choice take precedence, so leave this false unless you want it on for clients that do not. See [Transcription & Translation](transcription-and-translation.md#speaker-identification-within-a-channel). | false | true, false |
 
-## On-demand ASR and Diarization (MicroVM)
+## On-demand ASR and Diarization (MicroVM) — EXPERIMENTAL
+
+> **EXPERIMENTAL — not production ready.** Transcript quality is below Amazon
+> Transcribe's, speaker labels depend on a calibrated operating point, and defaults
+> may change between releases. Amazon Transcribe remains the recommended engine for
+> production meetings.
 
 Alternative streaming engine to Amazon Transcribe, giving per-voice speaker labels.
 Off by default. A meeting transcribed by this engine does not go through Amazon
@@ -77,9 +83,21 @@ Lambda MicroVMs is available. See [On-demand ASR & Speaker Diarization](microvm-
 | Parameter | Description | Default | Allowed Values |
 |-----------|-------------|---------|----------------|
 | TranscriptionEngine | Deploys the on-demand ASR + diarization stack. Meetings still use Amazon Transcribe unless a client opts in | AmazonTranscribe | AmazonTranscribe, MicrovmAsr |
-| AsrModelBundle | A pre-vetted pairing of ASR model, speaker embedder and turn-detection model, **together with the diarization operating point measured for that combination** | nemotron-titanet-small | nemotron-titanet-small, permissive-zipformer-campplus, transcription-only |
-| AsrMaxMeetingSeconds | Hard lifetime ceiling per MicroVM and the cost backstop if a transcriber task dies without releasing it | 14400 | 600–28800 |
-| AsrMaxSpeakers | Cap on distinct speakers per audio channel (0 discovers as many as appear) | 0 | 0–30 |
+
+`TranscriptionEngine` is the only deploy-time question for this engine. Its tuning
+knobs — the model bundle, MicroVM lifetime ceiling, speaker cap, turn-cut behaviour
+and maximum open row duration — used to be parameters (`AsrModelBundle`,
+`AsrMaxMeetingSeconds`, `AsrMaxSpeakers`, `AsrLiveTurnCut`, `AsrMaxOpenSegmentMs`) and
+are now fixed in the `AsrDefaults` mapping in `lma-main.yaml`, at the same values the
+parameters defaulted to. They were withdrawn because the engine is experimental and
+its defaults are still moving, so asking five unanswerable questions at deploy time
+was worse than picking known-good values.
+
+Most of them were never deploy-time decisions anyway: **maximum speakers per
+channel**, **live turn cut** and **maximum open row duration** are all overridable at
+runtime from the ASR Config page in the LMA UI, taking effect on the next meeting with
+no stack update. Only the model bundle and the lifetime ceiling need a redeploy — edit
+the mapping. Changing the bundle rebuilds the MicroVM image (~20 minutes).
 
 ### Why a bundle instead of three model parameters
 

--- a/docs/microvm-asr.md
+++ b/docs/microvm-asr.md
@@ -7,10 +7,18 @@ title: "On-demand ASR & Speaker Diarization (MicroVM)"
 
 # On-demand ASR & Speaker Diarization (MicroVM)
 
-> **Status:** Experimental, opt-in, and off by default. Deploying it changes nothing
-> on its own: meetings still use Amazon Transcribe unless a client asks for
-> diarization. Accuracy (WER) and diarization error rate have not yet been
-> benchmarked — see [What is not yet measured](#what-is-not-yet-measured).
+> **Status: EXPERIMENTAL — not production ready.** Opt-in and off by default.
+> **Amazon Transcribe remains the recommended engine for production meetings**;
+> transcript quality here is below it, speaker labels depend on a calibrated operating
+> point, and defaults may change between releases. Deploying it changes nothing on its
+> own: meetings still use Amazon Transcribe unless a client asks for diarization.
+> Accuracy (WER) and diarization error rate have not yet been benchmarked — see
+> [What is not yet measured](#what-is-not-yet-measured).
+>
+> Because it is experimental, its tuning knobs are deliberately **not** exposed as
+> CloudFormation parameters. `TranscriptionEngine` is the only deploy-time question;
+> everything else is either fixed in the `AsrDefaults` mapping in `lma-main.yaml` or
+> adjustable at runtime from the ASR Config page.
 
 ## Table of Contents
 
@@ -95,14 +103,28 @@ default) and warms it. Expect several extra minutes on the first create and on a
 later change to a model parameter. Build logs land in
 `/aws/lambda-microvms/<stack-name>-asr`.
 
-Relevant parameters (all under *On-demand ASR and Diarization* in the console):
+There is one CloudFormation parameter, under *EXPERIMENTAL - On-demand ASR and
+Diarization* in the console:
 
 | Parameter | Default | Purpose |
 |---|---|---|
 | `TranscriptionEngine` | `AmazonTranscribe` | `MicrovmAsr` deploys this engine |
-| `AsrModelBundle` | `nemotron-titanet-small` | A pre-vetted pairing of all three models plus its calibrated operating point |
-| `AsrMaxMeetingSeconds` | `14400` | Hard lifetime ceiling per MicroVM, and the cost backstop |
-| `AsrMaxSpeakers` | `0` | Optional cap per channel; 0 discovers as many as appear |
+
+Everything else lives in the `AsrDefaults` mapping in `lma-main.yaml`, at the values
+the former parameters defaulted to:
+
+| Mapping key | Value | Purpose | Also settable at runtime? |
+|---|---|---|---|
+| `ModelBundle` | `nemotron-titanet-small` | A pre-vetted pairing of all three models plus its calibrated operating point | No — rebuilds the image (~20 min) |
+| `MaxMeetingSeconds` | `14400` | Hard lifetime ceiling per MicroVM, and the cost backstop | No |
+| `MaxSpeakers` | `0` | Optional cap per channel; 0 discovers as many as appear | Yes — ASR Config page |
+| `LiveTurnCut` | `true` | Close a row on a confirmed speaker change, not just a pause | Yes — ASR Config page |
+| `MaxOpenSegmentMs` | `20000` | Close a row after this much unbroken speech regardless | Yes — ASR Config page |
+
+To change one of the first two, edit the mapping and update the stack. The rest are
+better changed on the ASR Config page, which takes effect on the next meeting with no
+stack update. `scripts/sync_bundles.py --check` verifies that `ModelBundle` names a
+bundle the catalog actually ships.
 
 ### Model bundles
 
@@ -150,8 +172,11 @@ Edit `source/catalog.json`, then run:
 python3 lma-asr-microvm-stack/scripts/sync_bundles.py
 ```
 
-That regenerates the `AsrModelBundle` allowed values in **both** `lma-main.yaml` and this
-stack's `template.yaml`, plus the `BundleMemory` mapping. The memory duplication cannot be
+That regenerates the `AsrModelBundle` allowed values in this stack's `template.yaml`,
+plus the `BundleMemory` mapping, and validates that the `ModelBundle` value in
+`lma-main.yaml`'s `AsrDefaults` mapping names a bundle the catalog ships. (`lma-main.yaml`
+used to be rewritten here too, when it had its own `AsrModelBundle` parameter; it now holds
+a single value, so it is checked rather than generated.) The memory duplication cannot be
 removed — `MinimumMemoryInMiB` needs a CloudFormation-typed number and a Mapping cannot be
 keyed on a value a custom resource resolved — so it is generated instead. `--check` reports
 drift without writing, and unit tests assert the same thing, so a hand-edit that updates one
@@ -238,11 +263,12 @@ transcript.
 ## Tuning it without a redeploy
 
 The diarization operating point is empirical and specific to the speaker model, so
-it lives in runtime configuration rather than only in stack parameters. **Configuration
+it lives in runtime configuration rather than in stack parameters. **Configuration
 ▸ ASR Config** (admin only) edits it, and the next meeting to start picks it up — no
 stack update, no image rebuild.
 
-Every field is an override: leave it blank and the CloudFormation parameter applies.
+Every field is an override: leave it blank and the deployment default applies — the
+bundle's own calibrated value, or the `AsrDefaults` mapping entry where there is one.
 There is no default record to keep in sync.
 
 | Field | Effect |
@@ -426,7 +452,8 @@ takes effect on the next meeting, with no rebuild.
 
 The split above is retroactive: it happens when the utterance closes, so until then a
 live row holds both speakers. With **Close a row on a confirmed speaker change**
-(`AsrLiveTurnCut`, on by default) the speaker change becomes the *primary* boundary and
+(`LiveTurnCut` in the `AsrDefaults` mapping, on by default, and `liveTurnCut` on the ASR
+Config page) the speaker change becomes the *primary* boundary and
 endpointing silence is only a backstop — which is the right way round, because a pause
 is not what separates people, taking turns is.
 
@@ -567,7 +594,8 @@ a local measurement rather than trusting the catalog for an unknown embedder.
   with video recording): inference happens in the MicroVM, not in the task.
 - One MicroVM serves both audio channels of a meeting. The default 8 GiB baseline
   gives 4 vCPU, which both channels share.
-- `AsrMaxMeetingSeconds` (default 4 h, service maximum 8 h) bounds what a single
+- `MaxMeetingSeconds` in the `AsrDefaults` mapping (default 4 h, service maximum 8 h)
+  bounds what a single
   MicroVM can cost. The transcriber terminates the MicroVM on meeting end and on
   SIGTERM (deploys, scale-in); the ceiling is the backstop if the task dies
   without doing either.
@@ -741,7 +769,8 @@ If a single person still fragments: run
 [Calibrate](#calibrating-the-operating-point) against one of your own recorded
 meetings — it performs exactly the measurement above, automatically. Failing that,
 lower the threshold on the ASR Config page, raise the minimum utterance length, and only then
-consider `AsrMaxSpeakers` — a cap bounds the symptom but cannot fix a mis-set
+consider the maximum speakers per channel on the ASR Config page — a cap bounds the
+symptom but cannot fix a mis-set
 operating point. Sample sizes behind the numbers above are small (11 utterances, one
 voice pair), which is the reason calibration exists rather than a bigger table of
 defaults.
@@ -764,7 +793,8 @@ channel separation on its own — the two channels have to have come from two se
 sources.
 
 **Too many speakers detected on genuinely multi-speaker audio.** Lower
-`AsrSpeakerThreshold`, or set `AsrMaxSpeakers` to the room size.
+the speaker similarity threshold, or set the maximum speakers per channel to the room
+size — both on the ASR Config page.
 
 ## Licences
 

--- a/lma-ai-stack/source/ui/src/components/asr-config/AsrConfigPage.jsx
+++ b/lma-ai-stack/source/ui/src/components/asr-config/AsrConfigPage.jsx
@@ -22,6 +22,7 @@ import {
   StatusIndicator,
   KeyValuePairs,
   FileUpload,
+  Badge,
 } from '@cloudscape-design/components';
 
 import useSettingsContext from '../../contexts/settings';
@@ -220,10 +221,17 @@ const AsrConfigPage = () => {
 
   if (!engineDeployed) {
     return (
-      <Container header={<Header variant="h1">ASR Configuration</Header>}>
+      <Container
+        header={
+          <Header variant="h1" info={<Badge color="severity-medium">Experimental</Badge>}>
+            ASR Configuration
+          </Header>
+        }
+      >
         <Alert type="info" header="On-demand ASR engine is not deployed">
-          These settings apply to the on-demand ASR &amp; diarization engine. Deploy it by setting{' '}
-          <b>TranscriptionEngine</b> to <b>MicrovmAsr</b> on the main stack.
+          These settings apply to the on-demand ASR &amp; diarization engine, which is{' '}
+          <b>experimental and not production ready</b> — Amazon Transcribe remains the recommended engine. To evaluate
+          it, set <b>TranscriptionEngine</b> to <b>MicrovmAsr</b> on the main stack.
         </Alert>
       </Container>
     );
@@ -254,9 +262,10 @@ const AsrConfigPage = () => {
         header={
           <Header
             variant="h1"
+            info={<Badge color="severity-medium">Experimental</Badge>}
             description={
               'Runtime settings for the on-demand ASR & speaker diarization engine. Every field is ' +
-              'optional: leave it blank to use the CloudFormation parameter. Changes take effect on ' +
+              'optional: leave it blank to use the deployment default. Changes take effect on ' +
               'the next meeting that starts — no stack update and no image rebuild.'
             }
             actions={
@@ -278,6 +287,12 @@ const AsrConfigPage = () => {
           <Spinner />
         ) : (
           <SpaceBetween size="l">
+            <Alert type="warning" header="Experimental — not production ready">
+              The on-demand ASR &amp; diarization engine is still under development. Transcript quality is below Amazon
+              Transcribe&apos;s, speaker labels depend on a calibrated operating point, and defaults may change between
+              releases. Amazon Transcribe remains the recommended engine for production meetings.
+            </Alert>
+
             {!diarizationAvailable && (
               <Alert type="info" header="This deployment transcribes but does not diarize">
                 The deployed bundle carries no speaker-embedding model, so the speaker settings below have no effect and

--- a/lma-ai-stack/source/ui/src/components/asr-config/tools-panel.jsx
+++ b/lma-ai-stack/source/ui/src/components/asr-config/tools-panel.jsx
@@ -4,16 +4,25 @@
  * See the LICENSE file in the project root for full license information.
  */
 import React from 'react';
-import { HelpPanel, Icon } from '@cloudscape-design/components';
+import { Badge, HelpPanel, Icon } from '@cloudscape-design/components';
 
 const DOCS_BASE = 'https://aws-samples.github.io/amazon-transcribe-live-meeting-assistant';
 
-const header = <h2>ASR Configuration</h2>;
+const header = (
+  <h2>
+    ASR Configuration <Badge color="severity-medium">Experimental</Badge>
+  </h2>
+);
 const content = (
   <>
     <p>
+      <b>This engine is experimental and not production ready.</b> Its transcript quality is below Amazon
+      Transcribe&apos;s, speaker labels require a calibrated operating point, and defaults may change between releases.
+      Amazon Transcribe remains the recommended engine for production meetings.
+    </p>
+    <p>
       Tune the on-demand ASR &amp; speaker diarization engine without redeploying. Every field is an optional override
-      on the CloudFormation parameters, read at the start of each meeting.
+      on the deployment defaults, read at the start of each meeting.
     </p>
     <h3>Tuning order when one person appears as several speakers</h3>
     <ol>

--- a/lma-ai-stack/source/ui/src/components/common/navigation-items.js
+++ b/lma-ai-stack/source/ui/src/components/common/navigation-items.js
@@ -3,6 +3,9 @@
  * This file is licensed under the MIT License.
  * See the LICENSE file in the project root for full license information.
  */
+import React from 'react';
+import { Badge } from '@cloudscape-design/components';
+
 import {
   CALLS_PATH,
   MEETINGS_QUERY_PATH,
@@ -87,6 +90,13 @@ export const generateNavigationItems = (settings, isAdmin) => {
           type: 'link',
           text: 'ASR Config',
           href: `#${ASR_CONFIG_PATH}`,
+          // The on-demand MicroVM ASR engine is not production ready. Flagged here
+          // as well as on the page itself so the label is visible before anyone
+          // navigates in. JSX inside this .js file is handled by the jsxInJsPlugin
+          // in vite.config.js; the React import above is for eslint's
+          // react/react-in-jsx-scope, which this config still enforces even though
+          // the build uses the automatic runtime.
+          info: <Badge color="severity-medium">Experimental</Badge>,
         },
         {
           type: 'link',

--- a/lma-asr-microvm-stack/scripts/sync_bundles.py
+++ b/lma-asr-microvm-stack/scripts/sync_bundles.py
@@ -4,12 +4,22 @@
 # See the LICENSE file in the project root for full license information.
 """Regenerate the CloudFormation bundle lists from ``source/catalog.json``.
 
-Adding a bundle otherwise means hand-editing the same two facts into two templates:
-the ``AsrModelBundle`` allowed values (in both ``lma-main.yaml`` and this stack's
-``template.yaml``) and the ``BundleMemory`` mapping. Both duplications are already
-guarded by tests, but a guard that fails after the fact is worse than not having to
-edit by hand at all -- an earlier character-offset edit to these blocks silently
-deleted four unrelated parameters, and only cfn-lint caught it.
+Adding a bundle otherwise means hand-editing the same two facts into this stack's
+``template.yaml``: the ``AsrModelBundle`` allowed values and the ``BundleMemory``
+mapping. Both duplications are already guarded by tests, but a guard that fails
+after the fact is worse than not having to edit by hand at all -- an earlier
+character-offset edit to these blocks silently deleted four unrelated parameters,
+and only cfn-lint caught it.
+
+``lma-main.yaml`` used to be rewritten here too, because it declared its own
+``AsrModelBundle`` parameter. It no longer does: the MicroVM ASR tuning parameters
+were withdrawn from the deploy-time surface while the engine is experimental, and
+the chosen bundle now lives in that template's ``AsrDefaults`` mapping. There is no
+list to generate there any more -- one value -- but it is still a hand-edited copy
+of a catalog id, so it is *validated* instead (see ``check_main_template``). Dropping
+the file from ``TEMPLATES`` without that check would have quietly lost the only
+thing stopping ``lma-main.yaml`` from naming a bundle that does not exist, which
+fails 20 minutes into a deploy rather than at commit time.
 
 The memory duplication cannot be removed: ``MinimumMemoryInMiB`` needs a
 CloudFormation-typed number and a Mapping cannot be keyed on a value a custom
@@ -35,10 +45,15 @@ from pathlib import Path
 STACK_DIR = Path(__file__).resolve().parent.parent
 REPO_ROOT = STACK_DIR.parent
 CATALOG = STACK_DIR / "source" / "catalog.json"
-TEMPLATES = (REPO_ROOT / "lma-main.yaml", STACK_DIR / "template.yaml")
+TEMPLATES = (STACK_DIR / "template.yaml",)
+MAIN_TEMPLATE = REPO_ROOT / "lma-main.yaml"
 
 PARAM = "AsrModelBundle"
 MAPPING = "BundleMemory"
+
+# The single bundle id in lma-main.yaml's AsrDefaults mapping, e.g.
+#       ModelBundle: nemotron-titanet-small
+MAIN_BUNDLE_RE = re.compile(r"^ {6}ModelBundle: *(\S+) *$", re.MULTILINE)
 
 
 class SyncError(RuntimeError):
@@ -117,8 +132,33 @@ def rewrite_mapping(lines: list[str], memory: dict[str, int], ids: list[str]) ->
     return out
 
 
+def check_main_template(ids: list[str]) -> None:
+    """Assert lma-main.yaml's AsrDefaults mapping names a bundle the catalog ships.
+
+    Nothing is generated there -- the mapping holds one id, not a list -- but it is
+    still a hand-maintained copy of a catalog value, and a typo or a renamed bundle
+    would only surface when the ASR stack rejected the parameter partway through a
+    deploy.
+    """
+    text = MAIN_TEMPLATE.read_text()
+    found = MAIN_BUNDLE_RE.findall(text)
+    if not found:
+        raise SyncError(
+            f"{MAIN_TEMPLATE.name}: no 'ModelBundle:' entry found in the AsrDefaults "
+            "mapping (was the mapping renamed or reindented?)"
+        )
+    if len(found) > 1:
+        raise SyncError(f"{MAIN_TEMPLATE.name}: expected one ModelBundle entry, found {found}")
+    if found[0] not in ids:
+        raise SyncError(
+            f"{MAIN_TEMPLATE.name}: AsrDefaults ModelBundle is {found[0]!r}, which is not "
+            f"a bundle in catalog.json ({', '.join(ids)})"
+        )
+
+
 def sync(check: bool) -> int:
     ids, memory = bundles()
+    check_main_template(ids)
     stale: list[Path] = []
 
     for path in TEMPLATES:

--- a/lma-main.yaml
+++ b/lma-main.yaml
@@ -347,100 +347,13 @@ Parameters:
       - AmazonTranscribe
       - MicrovmAsr
     Description: >-
-      Streaming transcription engine for Stream Audio and the Audio Capture apps.
-      AmazonTranscribe is the default. MicrovmAsr deploys an on-demand ASR +
-      speaker-diarization engine on AWS Lambda MicroVMs and makes per-voice
-      speaker labels available; meetings that opt in are then NOT transcribed by
-      Amazon Transcribe, so content redaction, custom vocabularies, custom
-      language models and language identification do not apply to them, and the
-      default model is English only. REQUIRES a region where AWS Lambda MicroVMs
-      is available (it is not available in GovCloud). Deploying it does not change
-      existing behaviour on its own: every meeting still uses Amazon Transcribe until
-      an admin makes this engine the default on the ASR Config page. Both engines can
-      produce speaker labels, so requesting them does not select an engine.
-
-  AsrModelBundle:
-    Type: String
-    Default: nemotron-titanet-small
-    AllowedValues:
-      - nemotron-titanet-small
-      - permissive-zipformer-campplus
-      - transcription-only
-      - permissive-fastconformer-titanet-large
-      - nemotron-titanet-large
-      - apache-only-zipformer-3dspeaker
-      - accurate-parakeet-titanet-large
-      - parakeet-streaming-titanet-small
-      - parakeet-streaming-low-latency
-    Description: >-
-      Which pre-vetted model pairing the MicroVM ASR engine uses. Each bundle names an
-      ASR model, a speaker-embedding model and a turn-detection model TOGETHER WITH the
-      diarization operating point measured for that combination, so a deployment gets a
-      working configuration without tuning anything. Picking the models separately is
-      deliberately not offered: the similarity threshold is not a property of the
-      embedder alone (utterance length moves it as much as the model does), so it is
-      only meaningful for a stated pairing.
-      CALIBRATED, so speaker labels work immediately - nemotron-titanet-small is the
-      default and validated on real meetings, but its ASR weights are under the NVIDIA
-      Open Model License and are NOT redistributable; permissive-zipformer-campplus is
-      Apache-2.0 and MIT throughout and measurably worse, its ASR model being trained on
-      read speech; transcription-only has no diarization and labels by audio channel.
-      NOT YET CALIBRATED, so they produce NO speaker labels until this deployment runs a
-      calibration from the ASR Config page, because a threshold borrowed from another
-      pairing fragments or merges speakers - permissive-fastconformer-titanet-large is
-      CC-BY-4.0 and MIT throughout and so redistributable, its ASR model sharing the
-      default's architecture but trained on conversational speech at a quarter the size,
-      which makes it the one to try if you need to redistribute the image;
-      nemotron-titanet-large is the validated default with a larger embedder, aimed at
-      under-splitting on a channel dominated by one talker;
-      apache-only-zipformer-3dspeaker is for a deployment that cannot accept CC-BY-4.0
-      attribution, both halves being the weaker choice; accurate-parakeet-titanet-large
-      has the highest expected accuracy and is redistributable but is OFFLINE, meaning
-      audio is segmented by VAD and decoded per utterance so there is NO interim text
-      while somebody is still speaking, and it needs 16 GiB.
-      Changing the bundle rebuilds the MicroVM image (~20 minutes).
-
-  AsrMaxMeetingSeconds:
-    Type: Number
-    Default: 14400
-    MinValue: 600
-    MaxValue: 28800
-    Description: >-
-      Hard ceiling on one ASR MicroVM's lifetime, and the cost backstop if a
-      transcriber task dies without releasing it. Service maximum is 8 hours.
-
-  AsrLiveTurnCut:
-    Type: String
-    Default: "true"
-    AllowedValues: ["true", "false"]
-    Description: >-
-      Whether the MicroVM ASR engine closes a transcript row as soon as a speaker
-      change is confirmed, instead of waiting for a pause. Endpointing silence is what
-      previously separated speakers, so two people talking over each other shared one
-      row and one label until somebody stopped talking. Requires a bundle with a
-      turn-detection model.
-
-  AsrMaxOpenSegmentMs:
-    Type: Number
-    Default: 20000
-    MinValue: 0
-    MaxValue: 60000
-    Description: >-
-      Close a row after this much unbroken speech even when no speaker change is
-      found, so a monologue does not sit in the live transcript as one unlabelled
-      block. 0 follows the engine's own utterance boundaries.
-
-  AsrMaxSpeakers:
-    Type: Number
-    Default: 0
-    MinValue: 0
-    MaxValue: 30
-    Description: >-
-      Optional cap on distinct speakers per audio channel. 0 (the default)
-      discovers as many as appear, which is the honest setting: how many people
-      share a microphone or a browser tab is not knowable in advance. A cap is a
-      safety net, not a fix for over-splitting — set it only when the meeting size
-      is genuinely known, the way the Upload Audio page asks for it.
+      Transcription engine for Stream Audio and the Audio Capture apps. Keep
+      AmazonTranscribe unless you are evaluating the EXPERIMENTAL MicrovmAsr engine,
+      which is not production ready. MicrovmAsr is English only, needs a region with
+      AWS Lambda MicroVMs (not GovCloud), and meetings using it get no content
+      redaction, custom vocabulary, custom language model or language ID. Deploying
+      it changes nothing on its own - an admin must enable it per meeting or make it
+      the default on the ASR Config page. See docs/microvm-asr.md.
 
   ModelValidation:
     Type: String
@@ -940,14 +853,9 @@ Metadata:
           - CustomVocabularyName
           - CustomLanguageModelName
       - Label:
-          default: On-demand ASR and Diarization (MicroVM, alternative to Amazon Transcribe)
+          default: EXPERIMENTAL - On-demand ASR and Diarization (MicroVM, alternative to Amazon Transcribe)
         Parameters:
           - TranscriptionEngine
-          - AsrModelBundle
-          - AsrMaxMeetingSeconds
-          - AsrMaxSpeakers
-          - AsrLiveTurnCut
-          - AsrMaxOpenSegmentMs
       - Label:
           default: Transcript Event Processing Configuration
         Parameters:
@@ -1073,17 +981,7 @@ Metadata:
       CustomLanguageModelName:
         default: Transcription Custom Language Model Name
       TranscriptionEngine:
-        default: Streaming Transcription Engine
-      AsrModelBundle:
-        default: ASR Model Bundle (pre-vetted pairing)
-      AsrMaxMeetingSeconds:
-        default: ASR MicroVM Maximum Lifetime (seconds)
-      AsrMaxSpeakers:
-        default: ASR Maximum Speakers Per Channel
-      AsrLiveTurnCut:
-        default: ASR Split Rows On Speaker Change (not just on pauses)
-      AsrMaxOpenSegmentMs:
-        default: ASR Maximum Open Row Duration (ms)
+        default: Streaming Transcription Engine (EXPERIMENTAL if not AmazonTranscribe)
       ModelValidation:
         default: Amazon Bedrock Model Validation
       TranscriptLambdaHookFunctionArn:
@@ -1157,6 +1055,40 @@ Rules:
           BedrockKnowledgeBaseId is required when MeetingAssistService
           is 'STRANDS_BEDROCK_WITH_KB (Use Existing)'
 
+Mappings:
+  # Tuning defaults for the EXPERIMENTAL MicroVM ASR engine.
+  #
+  # These were five top-level CloudFormation parameters (AsrModelBundle,
+  # AsrMaxMeetingSeconds, AsrMaxSpeakers, AsrLiveTurnCut, AsrMaxOpenSegmentMs).
+  # They are fixed here instead of asked at deploy time because the engine is not
+  # production ready: exposing its operating point invites tuning a feature whose
+  # defaults are still moving, and it crowded the Parameters page with five
+  # questions almost nobody deploying LMA can answer.
+  #
+  # The values below are exactly what those parameters defaulted to, so a stack
+  # that accepted the defaults is unchanged. A stack that had OVERRIDDEN one is
+  # not: the override disappears with the parameter and this value takes over. In
+  # particular an existing stack on a non-default ModelBundle reverts to
+  # nemotron-titanet-small on the next update and rebuilds the image (~20 min).
+  # Edit the mapping before updating if you need to keep a different bundle.
+  #
+  # Nothing is lost by fixing them. MaxSpeakers, LiveTurnCut and MaxOpenSegmentMs
+  # are all overridable at runtime from the ASR Config page (maxSpeakers,
+  # liveTurnCut, maxOpenSegmentMs), which takes effect on the next meeting with no
+  # stack update. The other two genuinely need a deploy either way: ModelBundle
+  # rebuilds the MicroVM image (~20 min) and MaxMeetingSeconds is a MicroVM
+  # lifetime ceiling.
+  #
+  # ModelBundle must name a bundle in lma-asr-microvm-stack/source/catalog.json;
+  # scripts/sync_bundles.py --check enforces that.
+  AsrDefaults:
+    Engine:
+      ModelBundle: nemotron-titanet-small
+      MaxMeetingSeconds: "14400"
+      MaxSpeakers: "0"
+      LiveTurnCut: "true"
+      MaxOpenSegmentMs: "20000"
+
 Conditions:
   ShouldRetainDataOnDelete: !Equals [!Ref EnableDataRetentionOnDelete, "true"]
   ShouldDeleteDataOnDelete: !Equals [!Ref EnableDataRetentionOnDelete, "false"]
@@ -1190,7 +1122,10 @@ Conditions:
   ShouldDeployMicrovmAsr: !Equals [!Ref TranscriptionEngine, "MicrovmAsr"]
   ShouldEnableAsrDiarization: !And
     - !Condition ShouldDeployMicrovmAsr
-    - !Not [!Equals [!Ref AsrModelBundle, "transcription-only"]]
+    - !Not
+      - !Equals
+        - !FindInMap [AsrDefaults, Engine, ModelBundle]
+        - "transcription-only"
 
 Resources:
   ##########################################################################
@@ -2712,9 +2647,9 @@ Resources:
         LambdaArtifactBucket: <ARTIFACT_BUCKET_NAME_TOKEN>
         AsrLauncherS3Key: <ASR_MICROVM_LAUNCHER_S3_KEY_TOKEN>
         AsrImageSourceS3Key: <ASR_MICROVM_IMAGE_SOURCE_S3_KEY_TOKEN>
-        AsrModelBundle: !Ref AsrModelBundle
-        AsrMaxMeetingSeconds: !Ref AsrMaxMeetingSeconds
-        AsrMaxSpeakers: !Ref AsrMaxSpeakers
+        AsrModelBundle: !FindInMap [AsrDefaults, Engine, ModelBundle]
+        AsrMaxMeetingSeconds: !FindInMap [AsrDefaults, Engine, MaxMeetingSeconds]
+        AsrMaxSpeakers: !FindInMap [AsrDefaults, Engine, MaxSpeakers]
         CloudWatchLogsExpirationInDays: !Ref CloudWatchLogsExpirationInDays
         CustomerManagedEncryptionKeyArn: !GetAtt CustomerManagedEncryptionKey.Arn
         LoggingBucketName: !Ref LoggingBucket
@@ -2774,9 +2709,9 @@ Resources:
           - ShouldDeployMicrovmAsr
           - !GetAtt ASRMICROVMSTACK.Outputs.AsrConfigTableName
           - ""
-        AsrMaxSpeakers: !Ref AsrMaxSpeakers
-        AsrLiveTurnCut: !Ref AsrLiveTurnCut
-        AsrMaxOpenSegmentMs: !Ref AsrMaxOpenSegmentMs
+        AsrMaxSpeakers: !FindInMap [AsrDefaults, Engine, MaxSpeakers]
+        AsrLiveTurnCut: !FindInMap [AsrDefaults, Engine, LiveTurnCut]
+        AsrMaxOpenSegmentMs: !FindInMap [AsrDefaults, Engine, MaxOpenSegmentMs]
         # The calibrated operating point for the deployed bundle, resolved from
         # catalog.json by the ASR stack. Previously a top-level parameter defaulting
         # to 0.2 while the catalog's measured value for the default embedder was


### PR DESCRIPTION
The on-demand MicroVM ASR & diarization feature is not fully baked. This keeps it in place but discourages use, and stops asking users to configure it at deploy time.

## 1. EXPERIMENTAL labelling

**CloudFormation**
- Parameter group → `EXPERIMENTAL - On-demand ASR and Diarization (MicroVM, alternative to Amazon Transcribe)`
- `TranscriptionEngine` label → `Streaming Transcription Engine (EXPERIMENTAL if not AmazonTranscribe)`, so the warning sits on the field itself, not only on the section header

**UI** — all three surfaces, so the label is visible before *and* after navigating in:
- Side nav "ASR Config" gains an `info` Badge
- Page header gains the same Badge, plus a warning `Alert` in the body
- Help panel header gains the Badge and now leads with the caveat

**Docs** — EXPERIMENTAL banners on the ASR section of `cloudformation-parameters.md` and at the top of `microvm-asr.md`, both naming Amazon Transcribe as the recommended engine.

## 2. Shortened the `TranscriptionEngine` description

It was 12 lines of prose, which the console renders as a wall of text under the field. Now 7 short lines: keep AmazonTranscribe unless evaluating; what MicrovmAsr costs you (English only, no redaction / custom vocab / CLM / language ID, needs a MicroVM region); that deploying changes nothing on its own; and a pointer to `docs/microvm-asr.md` for the detail that used to be inline.

## 3. Removed five parameters in favour of a mapping

`AsrModelBundle`, `AsrMaxMeetingSeconds`, `AsrMaxSpeakers`, `AsrLiveTurnCut` and `AsrMaxOpenSegmentMs` are gone from the deploy-time surface. Their values now live in a new `AsrDefaults` mapping in `lma-main.yaml` — **at exactly what the parameters defaulted to** (verified programmatically) — and the nested stacks read them via `!FindInMap`.

Worth noting: three of the five were never deploy-time decisions anyway. `MaxSpeakers`, `LiveTurnCut` and `MaxOpenSegmentMs` are all overridable at runtime from the ASR Config page, taking effect on the next meeting with no stack update. Only `ModelBundle` and `MaxMeetingSeconds` need a redeploy either way.

`Fn::FindInMap` is now used inside the `ShouldEnableAsrDiarization` condition. That's supported in the `Conditions` section, but rather than trust the docs I confirmed it against the real service with a minimal template — `aws cloudformation validate-template` accepts it.

### ⚠️ Upgrade note

A stack that accepted the old defaults is unaffected. A stack that had **overridden** one of these loses the override, because it disappears along with the parameter. In particular, a stack on a non-default `ModelBundle` reverts to `nemotron-titanet-small` on the next update and rebuilds the MicroVM image (~20 min). This is called out in the mapping comment — edit the mapping before updating if you need to keep a different bundle.

## Knock-on fix: `sync_bundles.py` would have broken

The bundle generator rewrote the `AsrModelBundle` `AllowedValues` in **both** templates and raises `SyncError("AsrModelBundle not found")` when the parameter is absent — so removing it from `lma-main.yaml` would have broken `--check` outright.

It now generates only the ASR stack's `template.yaml`, and *validates* `lma-main.yaml` instead: the mapping's `ModelBundle` must name a bundle `catalog.json` actually ships. Dropping the file from `TEMPLATES` without adding that check would have quietly lost the only thing stopping `lma-main.yaml` from naming a nonexistent bundle — which fails 20 minutes into a deploy rather than at commit time. I verified the guard fires:

```
$ python3 lma-asr-microvm-stack/scripts/sync_bundles.py --check
ERROR: lma-main.yaml: AsrDefaults ModelBundle is 'not-a-real-bundle', which is not
a bundle in catalog.json (nemotron-titanet-small, permissive-zipformer-campplus, ...)
```

Docs were updated for every reference to the removed parameters — including the ASR Config page and help-panel text that told users a blank field "uses the CloudFormation parameter", which would have been a dangling reference.

## Verification

| Check | Result |
|---|---|
| cfn-lint 1.56 on `lma-main.yaml` | findings **identical to develop**, zero errors |
| `aws cloudformation validate-template` | accepts `FindInMap` in `Conditions` |
| Mapping values vs former parameter defaults | equal (checked programmatically) |
| `sync_bundles.py --check` | passes; guard fires on a bogus bundle id |
| ASR MicroVM tests | 418 passed |
| `asr_image_source` tests | 38 passed |
| UI | eslint clean, prettier clean, 39 tests pass, production build succeeds |
| `sync_bundles.py` | black / flake8 / ruff clean, pylint 9.67/10 |

Note `lma-main.yaml` is not yamllint-gated (the Makefile lints `lma-ai-stack.yaml` only) and already carries ~340 line-length findings, so the long lines here are consistent with the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)