### PR TITLE
chore(deps): consolidate the 2nd Dependabot wave that needed code changes

### DIFF
--- a/lma-asr-microvm-stack/source/asr_server/lifecycle_hooks.py
+++ b/lma-asr-microvm-stack/source/asr_server/lifecycle_hooks.py
@@ -48,7 +48,7 @@ import logging
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from uuid import uuid4
 
 from asr_server.recognizer import (
@@ -121,7 +121,7 @@ def _default_recognizer_factory() -> Recognizer:
 # --- State ------------------------------------------------------------------
 
 
-class Phase(str, Enum):
+class Phase(StrEnum):
     """The MicroVM lifecycle phase this process is in.
 
     ``CREATED`` is the pre-``/run`` state a fresh snapshot resumes into — note

--- a/lma-asr-microvm-stack/source/requirements-dev.txt
+++ b/lma-asr-microvm-stack/source/requirements-dev.txt
@@ -8,7 +8,7 @@
 # a numpy-only wrapper that the tests construct directly.
 pytest==9.1.1
 pytest-asyncio==1.4.0
-pydantic==2.9.2
+pydantic==2.13.5
 websockets==13.1
 numpy==1.26.4
-ruff==0.6.9
+ruff==0.16.5

--- a/lma-browser-extension-stack/package-lock.json
+++ b/lma-browser-extension-stack/package-lock.json
@@ -8,28 +8,28 @@
       "name": "lma-extension",
       "version": "<VERSION_TOKEN>",
       "dependencies": {
-        "@cloudscape-design/components": "^3.0.1347",
-        "@cloudscape-design/global-styles": "^1.0.66",
+        "@cloudscape-design/components": "^3.0.1356",
+        "@cloudscape-design/global-styles": "^1.0.67",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-use-websocket": "^4.13.0",
-        "web-vitals": "^6.1.1"
+        "web-vitals": "^6.2.1"
       },
       "devDependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^7.0.1",
-        "@testing-library/react": "^16.1.0",
-        "@testing-library/user-event": "^14.6.4",
-        "@types/chrome": "^0.2.6",
+        "@testing-library/react": "^16.3.3",
+        "@testing-library/user-event": "^14.6.6",
+        "@types/chrome": "^0.2.7",
         "@types/jest": "^30.0.0",
-        "@types/node": "^26.2.0",
+        "@types/node": "^26.4.0",
         "@types/react": "^19.2.18",
-        "@types/react-dom": "^19.2.4",
+        "@types/react-dom": "^19.2.5",
         "eslint": "^8.57.0",
         "eslint-plugin-react": "^7.37.5",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
-        "typescript-eslint": "^8.67.0"
+        "typescript-eslint": "^8.68.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2245,9 +2245,9 @@
       "license": "MIT"
     },
     "node_modules/@cloudscape-design/components": {
-      "version": "3.0.1347",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.1347.tgz",
-      "integrity": "sha512-UHVlv/lAuqP0Gj7T3iD6E5rhivzk8fJfKiO3UbFDUoWkEsJJ+KZvbMSiHYLBcgjgaeWgpIS3oF0uR3zMoCUKcg==",
+      "version": "3.0.1356",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.1356.tgz",
+      "integrity": "sha512-iTzpJQ5axu10LGg8FLZ8ZsLdJGJ+BsSEyzpE0IUk+dS2dFierpRuASKDP0CoTnZjdwrGHxqOKLoUON4wMgzC5A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cloudscape-design/collection-hooks": "^1.0.0",
@@ -2273,9 +2273,9 @@
       }
     },
     "node_modules/@cloudscape-design/global-styles": {
-      "version": "1.0.66",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/global-styles/-/global-styles-1.0.66.tgz",
-      "integrity": "sha512-2bK2F7B0JUZg0ciRraMuI5bKAwqJ4RRqgfWR5lDZNxT9czPUYG40fUkTuT5yHp/bZVAKFuTms9UPJ+II3AGr0w==",
+      "version": "1.0.67",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/global-styles/-/global-styles-1.0.67.tgz",
+      "integrity": "sha512-W3rYWDc9dgo/nOrmaxWb9oSFeECeFuYDUwgkhPd4NbrzP1aqNnlQsUiA3s1L2VQQm82tsuDsAyYh/lqQWEDRpw==",
       "license": "Apache-2.0"
     },
     "node_modules/@cloudscape-design/test-utils-core": {
@@ -4573,9 +4573,9 @@
       "license": "MIT"
     },
     "node_modules/@testing-library/react": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
-      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.3.tgz",
+      "integrity": "sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4601,9 +4601,9 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "14.6.4",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.4.tgz",
-      "integrity": "sha512-QCGwP6QrjypBLwyj5cuyfVamkaIEy/XGY+1VDehbtbQqOggYmTFpFOdWR5mPz14vX8vXLMVjDHlRNBcClyO9ew==",
+      "version": "14.6.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.6.tgz",
+      "integrity": "sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4698,9 +4698,9 @@
       }
     },
     "node_modules/@types/chrome": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.2.6.tgz",
-      "integrity": "sha512-8OgXtL+OcR2IpY2ul5itg0R3xmdceAM4ldcHxh4BFL20p5z7fjhpyP5KuXAp1LIxA7oQgyViKTS9d+W8Sn8jdQ==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.2.7.tgz",
+      "integrity": "sha512-9kjBozQ+jyDVt1eai3VZqjHDTN95JCuRmbRHOryOltBJmzrTmUw/9r/DznmjRaQ8WlyIfeCA4WNzoj0IvormJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4933,9 +4933,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
-      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4998,9 +4998,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -5222,14 +5222,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
-      "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.68.0.tgz",
+      "integrity": "sha512-5GQtWZCXFcFYux955pvoS02WLc49pXNlvIxocKjS0clvwo3in1RdlzVKyiqQH9vE5AKWFLTaUgeQkOrTS+0Qxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.67.0",
-        "@typescript-eslint/types": "^8.67.0",
+        "@typescript-eslint/tsconfig-utils": "^8.68.0",
+        "@typescript-eslint/types": "^8.68.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -5244,9 +5244,9 @@
       }
     },
     "node_modules/@typescript-eslint/project-service/node_modules/@typescript-eslint/types": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
-      "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.68.0.tgz",
+      "integrity": "sha512-9RnpsGJjrAllCMefGVVsImJM24YurhC0Q1h4UbvivtvOqXmR/vEJge2OoE++z9m6hyg8T1Q8t5SNT6tHSbrxcg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5276,9 +5276,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
-      "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.68.0.tgz",
+      "integrity": "sha512-F7zrGQfiJHojPwi8vhxZQC1tWtJzvL74cK/nqri2lk8YUXvYaYwl263xOJ69jDWPUk1hmcdoayFwk9lX09npVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20321,16 +20321,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.67.0.tgz",
-      "integrity": "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.68.0.tgz",
+      "integrity": "sha512-MHy0Y0ynqeEbx/S45+i/bBssdy3X6KNBfmJAP35GrgtNxu2TQ5K5xsFDhAnmsq1jvpdoZOPG1LGtJo0HWqYCrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.67.0",
-        "@typescript-eslint/parser": "8.67.0",
-        "@typescript-eslint/typescript-estree": "8.67.0",
-        "@typescript-eslint/utils": "8.67.0"
+        "@typescript-eslint/eslint-plugin": "8.68.0",
+        "@typescript-eslint/parser": "8.68.0",
+        "@typescript-eslint/typescript-estree": "8.68.0",
+        "@typescript-eslint/utils": "8.68.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -20345,17 +20345,17 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
-      "integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.68.0.tgz",
+      "integrity": "sha512-WASHDpCm6qO5jj9g1a+8NiW5+GCkAyLReR56/4VruYmNgfUmqpxOfZ2Yfb8xGfJPWv5Qi6LSD8sXdces3vbp/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.67.0",
-        "@typescript-eslint/type-utils": "8.67.0",
-        "@typescript-eslint/utils": "8.67.0",
-        "@typescript-eslint/visitor-keys": "8.67.0",
+        "@typescript-eslint/scope-manager": "8.68.0",
+        "@typescript-eslint/type-utils": "8.68.0",
+        "@typescript-eslint/utils": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -20368,22 +20368,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.67.0",
+        "@typescript-eslint/parser": "^8.68.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
-      "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.68.0.tgz",
+      "integrity": "sha512-fHq2VC1kpyYfvEcbiMjOpySY4WS7voEp89yAThrHRX5sm9j2lzYppCb2umFMEed4fWcyeLjHxrz0mpjNBaBxMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.67.0",
-        "@typescript-eslint/types": "8.67.0",
-        "@typescript-eslint/typescript-estree": "8.67.0",
-        "@typescript-eslint/visitor-keys": "8.67.0",
+        "@typescript-eslint/scope-manager": "8.68.0",
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/typescript-estree": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -20399,14 +20399,14 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
-      "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.68.0.tgz",
+      "integrity": "sha512-T5eXpcaJNg8bhjHJ8Rjp68Vq/QBteYtTKY8TZqVNPaUbuz0f6jI9t6aDkylwvalpAB9XTTFeFOjrjXAZ3YvmVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.67.0",
-        "@typescript-eslint/visitor-keys": "8.67.0"
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -20417,15 +20417,15 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/type-utils": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
-      "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.68.0.tgz",
+      "integrity": "sha512-X77zqoY1EjeWGs/0JNxeaMfp5C5lIz4Tw8y66F1Ne8Faq6g424sBNYM6xBAqElfGZPLpWS+CZAp0DXyKDzWiHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.67.0",
-        "@typescript-eslint/typescript-estree": "8.67.0",
-        "@typescript-eslint/utils": "8.67.0",
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/typescript-estree": "8.68.0",
+        "@typescript-eslint/utils": "8.68.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -20442,9 +20442,9 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/types": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
-      "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.68.0.tgz",
+      "integrity": "sha512-9RnpsGJjrAllCMefGVVsImJM24YurhC0Q1h4UbvivtvOqXmR/vEJge2OoE++z9m6hyg8T1Q8t5SNT6tHSbrxcg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20456,16 +20456,16 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
-      "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.68.0.tgz",
+      "integrity": "sha512-OKKsD0tYmoNiU5PW2zehO1yO56jYOm1ShYlxon/Z0SJNidAkdVg86eg9ruRuoXf8xfnuWZGbwDsStkoXbZtIIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.67.0",
-        "@typescript-eslint/tsconfig-utils": "8.67.0",
-        "@typescript-eslint/types": "8.67.0",
-        "@typescript-eslint/visitor-keys": "8.67.0",
+        "@typescript-eslint/project-service": "8.68.0",
+        "@typescript-eslint/tsconfig-utils": "8.68.0",
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -20484,16 +20484,16 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
-      "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.68.0.tgz",
+      "integrity": "sha512-PB5gJMMOg0Q5P1tsgWtEAqQacJXq0qEqRHDX/YJ4FaTMLfZPpHB3gjl2EJuiZyPABxmj4ZQYiY9m1bdAJ5y7tQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.67.0",
-        "@typescript-eslint/types": "8.67.0",
-        "@typescript-eslint/typescript-estree": "8.67.0"
+        "@typescript-eslint/scope-manager": "8.68.0",
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/typescript-estree": "8.68.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -20508,13 +20508,13 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
-      "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.68.0.tgz",
+      "integrity": "sha512-YR65gGdGvTUAWLldC3xLOvOzamdGzB4A5/N8rehEaHs3Zvoe39BhgY+u0SPch1OvrVTfLcc55wsSgK2NcnTS/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/types": "8.68.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -20562,9 +20562,9 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/ignore": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.7.tgz",
+      "integrity": "sha512-dML0wP6oak21rsNYCJpJB6O1BJIEwNpGrTw0URPfAk4hm0e3pRfCtzkfB6olBcXcVlU2rouCyz7lCyRB0OMVCA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20925,9 +20925,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.1.1.tgz",
-      "integrity": "sha512-r93gKnR6ZC2O8F3JrS0AAGIQ0v0OhXuyg4DAj2oG7K+GPkwXfUSc3ZcWeu50AsV5yIc6xxnTjERipJ6EvSw2vg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.2.1.tgz",
+      "integrity": "sha512-rLcLXA2sx6+9dE88NHFubwTtGxpK4yYBLj6qHPdFoCaLr0cXGb4efOqtKLlm4loGA4OEKHIQKMKzZkKyOh5ctw==",
       "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {

--- a/lma-browser-extension-stack/package.json
+++ b/lma-browser-extension-stack/package.json
@@ -3,12 +3,12 @@
   "version": "<VERSION_TOKEN>",
   "private": true,
   "dependencies": {
-    "@cloudscape-design/components": "^3.0.1347",
-    "@cloudscape-design/global-styles": "^1.0.66",
+    "@cloudscape-design/components": "^3.0.1356",
+    "@cloudscape-design/global-styles": "^1.0.67",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-use-websocket": "^4.13.0",
-    "web-vitals": "^6.1.1"
+    "web-vitals": "^6.2.1"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -37,18 +37,18 @@
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^7.0.1",
-    "@testing-library/react": "^16.1.0",
-    "@testing-library/user-event": "^14.6.4",
-    "@types/chrome": "^0.2.6",
+    "@testing-library/react": "^16.3.3",
+    "@testing-library/user-event": "^14.6.6",
+    "@types/chrome": "^0.2.7",
     "@types/jest": "^30.0.0",
-    "@types/node": "^26.2.0",
+    "@types/node": "^26.4.0",
     "@types/react": "^19.2.18",
-    "@types/react-dom": "^19.2.4",
+    "@types/react-dom": "^19.2.5",
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.37.5",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
-    "typescript-eslint": "^8.67.0"
+    "typescript-eslint": "^8.68.0"
   },
   "overrides": {
     "ajv@8": "^8.17.1",


### PR DESCRIPTION
Of the five PRs in this wave, #620 (tooling) and #621 (ui) were clean and merged as-is, and #622 closed itself ("updatable in another way") once #627 landed. The remaining two **could not be merged as opened** — both would have broken something. Their bumps are taken here and both are closed.

## #619 browser-ext (9 updates) — its lockfile regressed #625

Bumps: `@cloudscape-design/components` 3.0.1347→3.0.1356, `global-styles` 1.0.66→1.0.67, `web-vitals` 6.1.1→6.2.1, `@testing-library/react` 16.1.0→16.3.3, `user-event` 14.6.4→14.6.6, `@types/chrome` 0.2.6→0.2.7, `@types/node` 26.2.0→26.4.0, `@types/react-dom` 19.2.4→19.2.5, `typescript-eslint` 8.67.0→8.68.0.

Good news first: the rebase **correctly preserved the runtime/dev split from #625** — every bump landed in the section it belongs to.

But the lockfile it generated is missing `node_modules/tailwindcss/node_modules/yaml` — the single entry #625 added to make `npm ci` work. Merging it would have reintroduced the exact failure that PR fixed:

```
npm error code EUSAGE
npm error Missing: yaml@2.9.0 from lock file
```

Dependabot's npm resolves that nested entry differently from npm 11.x, and the CodeBuild buildspec runs `npm install`, which papers over it — **so this regression would not have surfaced anywhere except a local `npm ci`.** Same package.json bumps here, with a lockfile regenerated by `npm install`.

Worth knowing: expect this to recur on every browser-ext Dependabot PR until CRA goes (#624). The alternative is pinning the npm version used to generate the lockfile.

## #623 asr microvm (2 updates) — ruff 0.16.5 fails the lint gate

Bumps: `pydantic` 2.9.2→2.13.5, `ruff` 0.6.9→**0.16.5**.

Ten minor versions of ruff brings a new rule the code trips over, so #623 as opened turns `ruff check .` — the documented gate for this stack — red:

```
UP042 Class Phase inherits from both `str` and `enum.Enum`
   --> asr_server/lifecycle_hooks.py:124:7
    help: Inherit from `enum.StrEnum`
```

Fixed rather than suppressed: `Phase(str, Enum)` → `Phase(StrEnum)`. I checked first that this is behaviour-neutral **here**, because it isn't universally — `StrEnum` changes what `str(member)` returns:

- `requires-python = ">=3.11"` and ruff `target-version = "py311"`, so `StrEnum` is available
- every use is an identity comparison (`is Phase.X`) or an explicit `.value`; nothing formats a bare member
- `phase` is never serialised to JSON
- confirmed empirically: `== "created"` → True, `.value` → `created`, f-string → `created`, `json.dumps` → `"running"` — identical to `(str, Enum)`

## Verification

| Check | Result |
|---|---|
| browser-ext `npm ci` | clean (**was** `EUSAGE`) |
| browser-ext `npm run build` | clean, via the real buildspec path |
| browser-ext `npm audit --omit=dev` | still **0** |
| nested `yaml` lockfile entry | present |
| asr microvm tests | **418 passed** |
| `ruff check` | passes on **both** 0.16.5 and 0.6.9 — the fix isn't version-locked |

**Not done:** `ruff format` would restyle 18 files, but that's pre-existing — 0.6.9 reports the same 18 — and `ruff format` isn't part of this stack's gate (CLAUDE.md documents `ruff check`). Left alone rather than bundling a 34-file reformat into a dependency batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)